### PR TITLE
ci: Update secret-scanner to use public action

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,5 +1,5 @@
 # Secret-scanner workflow from Arista Networks.
-on:
+on: 
   pull_request:
     types: [synchronize]
   push:
@@ -10,21 +10,6 @@ jobs:
   scan_secret:
     name: Scan incoming changes
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/aristanetworks/secret-scanner-service:main
-      options: --name sss-scanner
-    steps:
-      - name: Checkout ${{ github.ref }}
-        # Hitting https://github.com/actions/checkout/issues/334 so trying v1
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 0
+    steps: 
       - name: Run scanner
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          scanner commit . github ${{ github.repository }} \
-             --markdown-file job_summary.md \
-             ${{ github.event_name == 'pull_request' && format('--since-commit {0}', github.event.pull_request.base.sha) || ''}}
-      - name: Write result to summary
-        run: cat ./job_summary.md >> $GITHUB_STEP_SUMMARY
-        if: ${{ always() }}
+        uses: aristanetworks/secret-scanner-service-public@main

--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -1,5 +1,5 @@
 # Secret-scanner workflow from Arista Networks.
-on: 
+on:
   pull_request:
     types: [synchronize]
   push:


### PR DESCRIPTION
# Description

Use public action to run secret scanner. Pulling and running docker image directly makes it hard for the secret scanner team to make changes in the future.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
