### PR TITLE
feat(anta): Added the test case to verify NTP associations functionality

### DIFF
--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from pydantic import BaseModel, Field
 
-from anta.custom_types import PositiveInteger
+from anta.custom_types import Hostname, PositiveInteger
 from anta.models import AntaCommand, AntaTest
 from anta.tools import get_failed_logs, get_value
 
@@ -345,7 +345,7 @@ class VerifyNTPAssociations(AntaTest):
         class NTPServer(BaseModel):
             """Model for a NTP server."""
 
-            server_address: str | IPv4Address
+            server_address: Hostname | IPv4Address
             """The NTP server address as an IPv4 address or hostname. The NTP server name defined in the running configuration
             of the device may change during DNS resolution, which is not handled in ANTA. Please provide the DNS-resolved server name.
             For example, 'ntp.example.com' in the configuration might resolve to 'ntp3.example.com' in the device output."""

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -310,14 +310,17 @@ class VerifyNTPAssociations(AntaTest):
 
     Expected Results
     ----------------
-    * Success: The test will pass if the Primary NTP server should be preferred and will have condition 'sys.peer' and other servers will have condition "candidate".
-    * Failure: The test will fail if the Primary NTP server is NOT preferred.
+    * Success: The test will pass if the Primary NTP server (marked as preferred) has the condition 'sys.peer' and
+    all other NTP servers have the condition 'candidate'.
+    * Failure: The test will fail if the Primary NTP server (marked as preferred) does not have the condition 'sys.peer' or
+    if any other NTP server does not have the condition 'candidate'.
 
     Examples
     --------
     ```yaml
-    - VerifyNTPAssociations:
-        ntp_servers:
+    anta.tests.system:
+      - VerifyNTPAssociations:
+          ntp_servers:
             - server_address: 1.1.1.1
               preferred: True
             - server_address: 2.2.2.2
@@ -350,7 +353,7 @@ class VerifyNTPAssociations(AntaTest):
         failures: str = ""
 
         if not (peer_details := get_value(self.instance_commands[0].json_output, "peers")):
-            self.result.is_failure("NTP peers are not configured.")
+            self.result.is_failure("None of NTP peers are not configured.")
             return
 
         # Iterate over each NTP server

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -372,7 +372,7 @@ class VerifyNTPAssociations(AntaTest):
 
             # Check if NTP server details exists.
             if (peer_detail := get_value(peer_details, server_address, separator="..")) is None:
-                failures += f"\nNTP peer {server_address} is not configured."
+                failures += f"NTP peer {server_address} is not configured.\n"
                 continue
 
             # Collecting the expected NTP peer details.
@@ -386,7 +386,7 @@ class VerifyNTPAssociations(AntaTest):
             # Collecting failures logs if any.
             failure_logs = get_failed_logs(expected_peer_details, actual_peer_details)
             if failure_logs:
-                failures += f"\nFor NTP peer {server_address}:{failure_logs}"
+                failures += f"For NTP peer {server_address}:{failure_logs}\n"
 
         # Check if there are any failures.
         if not failures:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -449,8 +449,11 @@ anta.tests.system:
       ntp_servers:
         - server_address: 1.1.1.1
           preferred: True
+          stratum: 1
         - server_address: 2.2.2.2
+          stratum: 1
         - server_address: 3.3.3.3
+          stratum: 1
 
 anta.tests.vlan:
   - VerifyVlanInternalPolicy:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -447,10 +447,10 @@ anta.tests.system:
   - VerifyNTP:
   - VerifyNTPAssociations:
       ntp_servers:
-          - server_address: 1.1.1.1
-            preferred: True
-          - server_address: 2.2.2.2
-          - server_address: 3.3.3.3
+        - server_address: 1.1.1.1
+          preferred: True
+        - server_address: 2.2.2.2
+        - server_address: 3.3.3.3
 
 anta.tests.vlan:
   - VerifyVlanInternalPolicy:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -445,6 +445,12 @@ anta.tests.system:
   - VerifyMemoryUtilization:
   - VerifyFileSystemUtilization:
   - VerifyNTP:
+  - VerifyNTPAssociations:
+      ntp_servers:
+          - server_address: 1.1.1.1
+            preferred: True
+          - server_address: 2.2.2.2
+          - server_address: 3.3.3.3
 
 anta.tests.vlan:
   - VerifyVlanInternalPolicy:

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -387,8 +387,8 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "\nFor NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\nExpected `1` as the stratum, but found `2` instead."
-                "\nFor NTP peer 2.2.2.2:\nExpected `candidate` as the condition, but found `sys.peer` instead.\n"
+                "For NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\nExpected `1` as the stratum, but found `2` instead.\n"
+                "For NTP peer 2.2.2.2:\nExpected `candidate` as the condition, but found `sys.peer` instead.\n"
                 "For NTP peer 3.3.3.3:\nExpected `candidate` as the condition, but found `sys.peer` instead.\nExpected `2` as the stratum, but found `3` instead."
             ],
         },
@@ -406,7 +406,7 @@ poll interval unknown
         },
         "expected": {
             "result": "failure",
-            "messages": ["NTP peers are not configured."],
+            "messages": ["None of NTP peers are not configured."],
         },
     },
     {
@@ -464,7 +464,7 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "\nFor NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\n"
+                "For NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\n"
                 "NTP peer 2.2.2.2 is not configured.\nNTP peer 3.3.3.3 is not configured."
             ],
         },

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -296,41 +296,14 @@ poll interval unknown
                     "1.1.1.1 (*.pool.ntp.org)": {
                         "condition": "sys.peer",
                         "peerIpAddr": "1.1.1.1",
-                        "refid": "17.253.16.125",
-                        "stratumLevel": 2,
-                        "peerType": "unicast",
-                        "lastReceived": 1720764730.0,
-                        "pollInterval": 64,
-                        "reachabilityHistory": [True],
-                        "delay": 173.387,
-                        "offset": -0.221,
-                        "jitter": 0.709,
                     },
                     "2.2.2.2 (*.pool.ntp.org)": {
                         "condition": "candidate",
                         "peerIpAddr": "2.2.2.2",
-                        "refid": "17.253.16.125",
-                        "stratumLevel": 2,
-                        "peerType": "unicast",
-                        "lastReceived": 1720764730.0,
-                        "pollInterval": 64,
-                        "reachabilityHistory": [True],
-                        "delay": 173.387,
-                        "offset": -0.221,
-                        "jitter": 0.709,
                     },
                     "3.3.3.3 (*.pool.ntp.org)": {
                         "condition": "candidate",
                         "peerIpAddr": "3.3.3.3",
-                        "refid": "17.253.16.125",
-                        "stratumLevel": 2,
-                        "peerType": "unicast",
-                        "lastReceived": 1720764730.0,
-                        "pollInterval": 64,
-                        "reachabilityHistory": [True],
-                        "delay": 173.387,
-                        "offset": -0.221,
-                        "jitter": 0.709,
                     },
                 }
             }
@@ -347,41 +320,14 @@ poll interval unknown
                     "1.1.1.1 (*.pool.ntp.org)": {
                         "condition": "candidate",
                         "peerIpAddr": "1.1.1.1",
-                        "refid": "17.253.16.125",
-                        "stratumLevel": 2,
-                        "peerType": "unicast",
-                        "lastReceived": 1720764730.0,
-                        "pollInterval": 64,
-                        "reachabilityHistory": [True],
-                        "delay": 173.387,
-                        "offset": -0.221,
-                        "jitter": 0.709,
                     },
                     "2.2.2.2 (*.pool.ntp.org)": {
                         "condition": "sys.peer",
                         "peerIpAddr": "2.2.2.2",
-                        "refid": "17.253.16.125",
-                        "stratumLevel": 2,
-                        "peerType": "unicast",
-                        "lastReceived": 1720764730.0,
-                        "pollInterval": 64,
-                        "reachabilityHistory": [True],
-                        "delay": 173.387,
-                        "offset": -0.221,
-                        "jitter": 0.709,
                     },
                     "3.3.3.3 (*.pool.ntp.org)": {
                         "condition": "candidate1",
                         "peerIpAddr": "3.3.3.3",
-                        "refid": "17.253.16.125",
-                        "stratumLevel": 2,
-                        "peerType": "unicast",
-                        "lastReceived": 1720764730.0,
-                        "pollInterval": 64,
-                        "reachabilityHistory": [True],
-                        "delay": 173.387,
-                        "offset": -0.221,
-                        "jitter": 0.709,
                     },
                 }
             }
@@ -390,9 +336,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "Following NTP server details are not found or not ok:\n"
-                "{'ntp_servers': {'1.1.1.1': {'condition': 'Not sys.peer'},"
-                " '2.2.2.2': {'condition': 'Not candidate'}, '3.3.3.3': {'condition': 'Not candidate'}}}"
+                "For NTP peer 1.1.1.1 expected condition as 'sys.peer' but found 'candidate' instead.\n"
+                "For NTP peer 2.2.2.2 expected condition as 'candidate' but found 'sys.peer' instead.\n"
+                "For NTP peer 3.3.3.3 expected condition as 'candidate' but found 'candidate1' instead.\n"
             ],
         },
     },
@@ -403,11 +349,30 @@ poll interval unknown
         "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
         "expected": {
             "result": "failure",
-            "messages": [
-                "Following NTP server details are not found or not ok:\n"
-                "{'ntp_servers': {'1.1.1.1': {'status': 'Not configured'},"
-                " '2.2.2.2': {'status': 'Not configured'}, '3.3.3.3': {'status': 'Not configured'}}}"
-            ],
+            "messages": ["NTP peers are not configured."],
+        },
+    },
+    {
+        "name": "failure-one-peer-no-found",
+        "test": VerifyNTPAssociations,
+        "eos_data": [
+            {
+                "peers": {
+                    "1.1.1.1 (*.pool.ntp.org)": {
+                        "condition": "sys.peer",
+                        "peerIpAddr": "1.1.1.1",
+                    },
+                    "2.2.2.2 (*.pool.ntp.org)": {
+                        "condition": "candidate",
+                        "peerIpAddr": "2.2.2.2",
+                    },
+                }
+            }
+        ],
+        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["NTP peer 3.3.3.3 is not configured."],
         },
     },
 ]

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -296,19 +296,28 @@ poll interval unknown
                     "1.1.1.1": {
                         "condition": "sys.peer",
                         "peerIpAddr": "1.1.1.1",
+                        "stratumLevel": 1,
                     },
                     "2.2.2.2": {
                         "condition": "candidate",
                         "peerIpAddr": "2.2.2.2",
+                        "stratumLevel": 2,
                     },
                     "3.3.3.3": {
                         "condition": "candidate",
                         "peerIpAddr": "3.3.3.3",
+                        "stratumLevel": 2,
                     },
                 }
             }
         ],
-        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "inputs": {
+            "ntp_servers": [
+                {"server_address": "1.1.1.1", "preferred": True, "stratum": 1},
+                {"server_address": "2.2.2.2", "stratum": 2},
+                {"server_address": "3.3.3.3", "stratum": 2},
+            ]
+        },
         "expected": {"result": "success"},
     },
     {
@@ -320,23 +329,26 @@ poll interval unknown
                     "1.ntp.networks.com": {
                         "condition": "sys.peer",
                         "peerIpAddr": "1.1.1.1",
+                        "stratumLevel": 1,
                     },
                     "2.ntp.networks.com": {
                         "condition": "candidate",
                         "peerIpAddr": "2.2.2.2",
+                        "stratumLevel": 2,
                     },
                     "3.ntp.networks.com": {
                         "condition": "candidate",
                         "peerIpAddr": "3.3.3.3",
+                        "stratumLevel": 2,
                     },
                 }
             }
         ],
         "inputs": {
             "ntp_servers": [
-                {"server_address": "1.ntp.networks.com", "preferred": True},
-                {"server_address": "2.ntp.networks.com"},
-                {"server_address": "3.ntp.networks.com"},
+                {"server_address": "1.ntp.networks.com", "preferred": True, "stratum": 1},
+                {"server_address": "2.ntp.networks.com", "stratum": 2},
+                {"server_address": "3.ntp.networks.com", "stratum": 2},
             ]
         },
         "expected": {"result": "success"},
@@ -350,25 +362,34 @@ poll interval unknown
                     "1.1.1.1": {
                         "condition": "candidate",
                         "peerIpAddr": "1.1.1.1",
+                        "stratumLevel": 2,
                     },
                     "2.2.2.2": {
                         "condition": "sys.peer",
                         "peerIpAddr": "2.2.2.2",
+                        "stratumLevel": 2,
                     },
                     "3.3.3.3": {
                         "condition": "sys.peer",
                         "peerIpAddr": "3.3.3.3",
+                        "stratumLevel": 3,
                     },
                 }
             }
         ],
-        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "inputs": {
+            "ntp_servers": [
+                {"server_address": "1.1.1.1", "preferred": True, "stratum": 1},
+                {"server_address": "2.2.2.2", "stratum": 2},
+                {"server_address": "3.3.3.3", "stratum": 2},
+            ]
+        },
         "expected": {
             "result": "failure",
             "messages": [
-                "For NTP peer 1.1.1.1 expected condition as 'sys.peer' but found 'candidate' instead.\n"
-                "For NTP peer 2.2.2.2 expected condition as 'candidate' but found 'sys.peer' instead.\n"
-                "For NTP peer 3.3.3.3 expected condition as 'candidate' but found 'sys.peer' instead.\n"
+                "\nFor NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\nExpected `1` as the stratum, but found `2` instead."
+                "\nFor NTP peer 2.2.2.2:\nExpected `candidate` as the condition, but found `sys.peer` instead.\n"
+                "For NTP peer 3.3.3.3:\nExpected `candidate` as the condition, but found `sys.peer` instead.\nExpected `2` as the stratum, but found `3` instead."
             ],
         },
     },
@@ -376,14 +397,20 @@ poll interval unknown
         "name": "failure-no-peers",
         "test": VerifyNTPAssociations,
         "eos_data": [{"peers": {}}],
-        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "inputs": {
+            "ntp_servers": [
+                {"server_address": "1.1.1.1", "preferred": True, "stratum": 1},
+                {"server_address": "2.2.2.2", "stratum": 1},
+                {"server_address": "3.3.3.3", "stratum": 1},
+            ]
+        },
         "expected": {
             "result": "failure",
             "messages": ["NTP peers are not configured."],
         },
     },
     {
-        "name": "failure-one-peer-no-found",
+        "name": "failure-one-peer-not-found",
         "test": VerifyNTPAssociations,
         "eos_data": [
             {
@@ -391,15 +418,23 @@ poll interval unknown
                     "1.1.1.1": {
                         "condition": "sys.peer",
                         "peerIpAddr": "1.1.1.1",
+                        "stratumLevel": 1,
                     },
                     "2.2.2.2": {
                         "condition": "candidate",
                         "peerIpAddr": "2.2.2.2",
+                        "stratumLevel": 1,
                     },
                 }
             }
         ],
-        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "inputs": {
+            "ntp_servers": [
+                {"server_address": "1.1.1.1", "preferred": True, "stratum": 1},
+                {"server_address": "2.2.2.2", "stratum": 1},
+                {"server_address": "3.3.3.3", "stratum": 1},
+            ]
+        },
         "expected": {
             "result": "failure",
             "messages": ["NTP peer 3.3.3.3 is not configured."],
@@ -414,16 +449,23 @@ poll interval unknown
                     "1.1.1.1": {
                         "condition": "candidate",
                         "peerIpAddr": "1.1.1.1",
+                        "stratumLevel": 1,
                     }
                 }
             }
         ],
-        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "inputs": {
+            "ntp_servers": [
+                {"server_address": "1.1.1.1", "preferred": True, "stratum": 1},
+                {"server_address": "2.2.2.2", "stratum": 1},
+                {"server_address": "3.3.3.3", "stratum": 1},
+            ]
+        },
         "expected": {
             "result": "failure",
             "messages": [
-                "For NTP peer 1.1.1.1 expected condition as 'sys.peer' but found 'candidate' instead.\n"
-                "NTP peer 2.2.2.2 is not configured.\nNTP peer 3.3.3.3 is not configured.\n"
+                "\nFor NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\n"
+                "NTP peer 2.2.2.2 is not configured.\nNTP peer 3.3.3.3 is not configured."
             ],
         },
     },

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -293,15 +293,15 @@ poll interval unknown
         "eos_data": [
             {
                 "peers": {
-                    "1.1.1.1 (*.pool.ntp.org)": {
+                    "1.1.1.1": {
                         "condition": "sys.peer",
                         "peerIpAddr": "1.1.1.1",
                     },
-                    "2.2.2.2 (*.pool.ntp.org)": {
+                    "2.2.2.2": {
                         "condition": "candidate",
                         "peerIpAddr": "2.2.2.2",
                     },
-                    "3.3.3.3 (*.pool.ntp.org)": {
+                    "3.3.3.3": {
                         "condition": "candidate",
                         "peerIpAddr": "3.3.3.3",
                     },
@@ -312,21 +312,51 @@ poll interval unknown
         "expected": {"result": "success"},
     },
     {
+        "name": "success-pool-name",
+        "test": VerifyNTPAssociations,
+        "eos_data": [
+            {
+                "peers": {
+                    "1.ntp.networks.com": {
+                        "condition": "sys.peer",
+                        "peerIpAddr": "1.1.1.1",
+                    },
+                    "2.ntp.networks.com": {
+                        "condition": "candidate",
+                        "peerIpAddr": "2.2.2.2",
+                    },
+                    "3.ntp.networks.com": {
+                        "condition": "candidate",
+                        "peerIpAddr": "3.3.3.3",
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "ntp_servers": [
+                {"server_address": "1.ntp.networks.com", "preferred": True},
+                {"server_address": "2.ntp.networks.com"},
+                {"server_address": "3.ntp.networks.com"},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure",
         "test": VerifyNTPAssociations,
         "eos_data": [
             {
                 "peers": {
-                    "1.1.1.1 (*.pool.ntp.org)": {
+                    "1.1.1.1": {
                         "condition": "candidate",
                         "peerIpAddr": "1.1.1.1",
                     },
-                    "2.2.2.2 (*.pool.ntp.org)": {
+                    "2.2.2.2": {
                         "condition": "sys.peer",
                         "peerIpAddr": "2.2.2.2",
                     },
-                    "3.3.3.3 (*.pool.ntp.org)": {
-                        "condition": "candidate1",
+                    "3.3.3.3": {
+                        "condition": "sys.peer",
                         "peerIpAddr": "3.3.3.3",
                     },
                 }
@@ -338,7 +368,7 @@ poll interval unknown
             "messages": [
                 "For NTP peer 1.1.1.1 expected condition as 'sys.peer' but found 'candidate' instead.\n"
                 "For NTP peer 2.2.2.2 expected condition as 'candidate' but found 'sys.peer' instead.\n"
-                "For NTP peer 3.3.3.3 expected condition as 'candidate' but found 'candidate1' instead.\n"
+                "For NTP peer 3.3.3.3 expected condition as 'candidate' but found 'sys.peer' instead.\n"
             ],
         },
     },
@@ -358,11 +388,11 @@ poll interval unknown
         "eos_data": [
             {
                 "peers": {
-                    "1.1.1.1 (*.pool.ntp.org)": {
+                    "1.1.1.1": {
                         "condition": "sys.peer",
                         "peerIpAddr": "1.1.1.1",
                     },
-                    "2.2.2.2 (*.pool.ntp.org)": {
+                    "2.2.2.2": {
                         "condition": "candidate",
                         "peerIpAddr": "2.2.2.2",
                     },
@@ -381,7 +411,7 @@ poll interval unknown
         "eos_data": [
             {
                 "peers": {
-                    "1.1.1.1 (*.pool.ntp.org)": {
+                    "1.1.1.1": {
                         "condition": "candidate",
                         "peerIpAddr": "1.1.1.1",
                     }

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -375,4 +375,26 @@ poll interval unknown
             "messages": ["NTP peer 3.3.3.3 is not configured."],
         },
     },
+    {
+        "name": "failure-with-two-peers-not-found",
+        "test": VerifyNTPAssociations,
+        "eos_data": [
+            {
+                "peers": {
+                    "1.1.1.1 (*.pool.ntp.org)": {
+                        "condition": "candidate",
+                        "peerIpAddr": "1.1.1.1",
+                    }
+                }
+            }
+        ],
+        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "For NTP peer 1.1.1.1 expected condition as 'sys.peer' but found 'candidate' instead.\n"
+                "NTP peer 2.2.2.2 is not configured.\nNTP peer 3.3.3.3 is not configured.\n"
+            ],
+        },
+    },
 ]

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -14,6 +14,7 @@ from anta.tests.system import (
     VerifyFileSystemUtilization,
     VerifyMemoryUtilization,
     VerifyNTP,
+    VerifyNTPAssociations,
     VerifyReloadCause,
     VerifyUptime,
 )
@@ -285,5 +286,128 @@ poll interval unknown
         ],
         "inputs": None,
         "expected": {"result": "failure", "messages": ["The device is not synchronized with the configured NTP server(s): 'unsynchronised'"]},
+    },
+    {
+        "name": "success",
+        "test": VerifyNTPAssociations,
+        "eos_data": [
+            {
+                "peers": {
+                    "1.1.1.1 (*.pool.ntp.org)": {
+                        "condition": "sys.peer",
+                        "peerIpAddr": "1.1.1.1",
+                        "refid": "17.253.16.125",
+                        "stratumLevel": 2,
+                        "peerType": "unicast",
+                        "lastReceived": 1720764730.0,
+                        "pollInterval": 64,
+                        "reachabilityHistory": [True],
+                        "delay": 173.387,
+                        "offset": -0.221,
+                        "jitter": 0.709,
+                    },
+                    "2.2.2.2 (*.pool.ntp.org)": {
+                        "condition": "candidate",
+                        "peerIpAddr": "2.2.2.2",
+                        "refid": "17.253.16.125",
+                        "stratumLevel": 2,
+                        "peerType": "unicast",
+                        "lastReceived": 1720764730.0,
+                        "pollInterval": 64,
+                        "reachabilityHistory": [True],
+                        "delay": 173.387,
+                        "offset": -0.221,
+                        "jitter": 0.709,
+                    },
+                    "3.3.3.3 (*.pool.ntp.org)": {
+                        "condition": "candidate",
+                        "peerIpAddr": "3.3.3.3",
+                        "refid": "17.253.16.125",
+                        "stratumLevel": 2,
+                        "peerType": "unicast",
+                        "lastReceived": 1720764730.0,
+                        "pollInterval": 64,
+                        "reachabilityHistory": [True],
+                        "delay": 173.387,
+                        "offset": -0.221,
+                        "jitter": 0.709,
+                    },
+                }
+            }
+        ],
+        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure",
+        "test": VerifyNTPAssociations,
+        "eos_data": [
+            {
+                "peers": {
+                    "1.1.1.1 (*.pool.ntp.org)": {
+                        "condition": "candidate",
+                        "peerIpAddr": "1.1.1.1",
+                        "refid": "17.253.16.125",
+                        "stratumLevel": 2,
+                        "peerType": "unicast",
+                        "lastReceived": 1720764730.0,
+                        "pollInterval": 64,
+                        "reachabilityHistory": [True],
+                        "delay": 173.387,
+                        "offset": -0.221,
+                        "jitter": 0.709,
+                    },
+                    "2.2.2.2 (*.pool.ntp.org)": {
+                        "condition": "sys.peer",
+                        "peerIpAddr": "2.2.2.2",
+                        "refid": "17.253.16.125",
+                        "stratumLevel": 2,
+                        "peerType": "unicast",
+                        "lastReceived": 1720764730.0,
+                        "pollInterval": 64,
+                        "reachabilityHistory": [True],
+                        "delay": 173.387,
+                        "offset": -0.221,
+                        "jitter": 0.709,
+                    },
+                    "3.3.3.3 (*.pool.ntp.org)": {
+                        "condition": "candidate1",
+                        "peerIpAddr": "3.3.3.3",
+                        "refid": "17.253.16.125",
+                        "stratumLevel": 2,
+                        "peerType": "unicast",
+                        "lastReceived": 1720764730.0,
+                        "pollInterval": 64,
+                        "reachabilityHistory": [True],
+                        "delay": 173.387,
+                        "offset": -0.221,
+                        "jitter": 0.709,
+                    },
+                }
+            }
+        ],
+        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Following NTP server details are not found or not ok:\n"
+                "{'ntp_servers': {'1.1.1.1': {'condition': 'Not sys.peer'},"
+                " '2.2.2.2': {'condition': 'Not candidate'}, '3.3.3.3': {'condition': 'Not candidate'}}}"
+            ],
+        },
+    },
+    {
+        "name": "failure-no-peers",
+        "test": VerifyNTPAssociations,
+        "eos_data": [{"peers": {}}],
+        "inputs": {"ntp_servers": [{"server_address": "1.1.1.1", "preferred": True}, {"server_address": "2.2.2.2"}, {"server_address": "3.3.3.3"}]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Following NTP server details are not found or not ok:\n"
+                "{'ntp_servers': {'1.1.1.1': {'status': 'Not configured'},"
+                " '2.2.2.2': {'status': 'Not configured'}, '3.3.3.3': {'status': 'Not configured'}}}"
+            ],
+        },
     },
 ]


### PR DESCRIPTION
# Description

NTP associations for all NTP servers should be up as denoted by the "condition" field below, and the primary NTP server should be preferred.

primary server will have condition "sys.peer", and pri server is denoted using "preferred: true "
other servers will have condition "candidate"

Fixes #753 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
