### PR TITLE
feat(anta): Refactor VerifyReachability test case to add coverage for DF Bit, packet size

### DIFF
--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -33,16 +33,24 @@ class VerifyReachability(AntaTest):
             - source: Management0
               destination: 1.1.1.1
               vrf: MGMT
+              df_bit: True
+              size: 100
             - source: Management0
               destination: 8.8.8.8
               vrf: MGMT
+              df_bit: True
+              size: 100
     ```
     """
 
     name = "VerifyReachability"
     description = "Test the network reachability to one or many destination IP(s)."
     categories: ClassVar[list[str]] = ["connectivity"]
-    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaTemplate(template="ping vrf {vrf} {destination} source {source} repeat {repeat}", revision=1)]
+    # Removing the <space> between '{size}' and '{df_bit}' to compensate the df-bit set default value
+    # i.e if df-bit kept disable then it will add redundant space in between the command
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
+        AntaTemplate(template="ping vrf {vrf} {destination} source {source} size {size}{df_bit} repeat {repeat}", revision=1)
+    ]
 
     class Input(AntaTest.Input):
         """Input model for the VerifyReachability test."""
@@ -61,15 +69,27 @@ class VerifyReachability(AntaTest):
             """VRF context. Defaults to `default`."""
             repeat: int = 2
             """Number of ping repetition. Defaults to 2."""
+            size: int = 100
+            """Specify datagram size. Defaults to 100"""
+            df_bit: bool = False
+            """Enable do not fragment bit in IP header. Defaults to False"""
 
     def render(self, template: AntaTemplate) -> list[AntaCommand]:
         """Render the template for each host in the input list."""
-        return [template.render(destination=host.destination, source=host.source, vrf=host.vrf, repeat=host.repeat) for host in self.inputs.hosts]
+        commands = []
+        for host in self.inputs.hosts:
+            # Enables do not fragment bit in IP header if needed else keeping disable.
+            # Adding the <space> at start to compensate change in AntaTemplate
+            df_bit = " df-bit" if host.df_bit else ""
+            command = template.render(destination=host.destination, source=host.source, vrf=host.vrf, repeat=host.repeat, size=host.size, df_bit=df_bit)
+            commands.append(command)
+        return commands
 
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyReachability."""
         failures = []
+
         for command in self.instance_commands:
             src = command.params.source
             dst = command.params.destination

--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -70,9 +70,9 @@ class VerifyReachability(AntaTest):
             repeat: int = 2
             """Number of ping repetition. Defaults to 2."""
             size: int = 100
-            """Specify datagram size. Defaults to 100"""
+            """Specify datagram size. Defaults to 100."""
             df_bit: bool = False
-            """Enable do not fragment bit in IP header. Defaults to False"""
+            """Enable do not fragment bit in IP header. Defaults to False."""
 
     def render(self, template: AntaTemplate) -> list[AntaCommand]:
         """Render the template for each host in the input list."""

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -98,9 +98,13 @@ anta.tests.connectivity:
         - source: Management1
           destination: 1.1.1.1
           vrf: MGMT
+          df_bit: True
+          size: 100
         - source: Management1
           destination: 8.8.8.8
           vrf: MGMT
+          df_bit: True
+          size: 100
   - VerifyLLDPNeighbors:
       neighbors:
         - port: Ethernet1

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -100,6 +100,28 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
+        "name": "success-df-bit-size",
+        "test": VerifyReachability,
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "Management0", "repeat": 5, "size": 1500, "df_bit": True}]},
+        "eos_data": [
+            {
+                "messages": [
+                    """PING 10.0.0.1 (10.0.0.1) from 172.20.20.6 : 1472(1500) bytes of data.
+                1480 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=0.085 ms
+                1480 bytes from 10.0.0.1: icmp_seq=2 ttl=64 time=0.020 ms
+                1480 bytes from 10.0.0.1: icmp_seq=3 ttl=64 time=0.019 ms
+                1480 bytes from 10.0.0.1: icmp_seq=4 ttl=64 time=0.018 ms
+                1480 bytes from 10.0.0.1: icmp_seq=5 ttl=64 time=0.017 ms
+
+                --- 10.0.0.1 ping statistics ---
+                5 packets transmitted, 5 received, 0% packet loss, time 0ms
+                rtt min/avg/max/mdev = 0.017/0.031/0.085/0.026 ms, ipg/ewma 0.061/0.057 ms""",
+                ],
+            },
+        ],
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure-ip",
         "test": VerifyReachability,
         "inputs": {"hosts": [{"destination": "10.0.0.11", "source": "10.0.0.5"}, {"destination": "10.0.0.2", "source": "10.0.0.5"}]},
@@ -166,6 +188,28 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "expected": {"result": "failure", "messages": ["Connectivity test failed for the following source-destination pairs: [('Management0', '10.0.0.11')]"]},
+    },
+    {
+        "name": "failure-size",
+        "test": VerifyReachability,
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "Management0", "repeat": 5, "size": 1501, "df_bit": True}]},
+        "eos_data": [
+            {
+                "messages": [
+                    """PING 10.0.0.1 (10.0.0.1) from 172.20.20.6 : 1473(1501) bytes of data.
+                ping: local error: message too long, mtu=1500
+                ping: local error: message too long, mtu=1500
+                ping: local error: message too long, mtu=1500
+                ping: local error: message too long, mtu=1500
+                ping: local error: message too long, mtu=1500
+
+                --- 10.0.0.1 ping statistics ---
+                5 packets transmitted, 0 received, +5 errors, 100% packet loss, time 40ms
+                """,
+                ],
+            },
+        ],
+        "expected": {"result": "failure", "messages": ["Connectivity test failed for the following source-destination pairs: [('Management0', '10.0.0.1')]"]},
     },
     {
         "name": "success",


### PR DESCRIPTION
# Description

- Updated the test case to include optional field of DF bit(Updated input model for df-bit) in command.
- Included optional field of packet size variation(Updated input model for packet size) in command.

Fixes #756 

# Checklist:


- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
