### PR TITLE
ci: Ignore cryptography>43.0.0 warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
           - '<!--|  ~|  -->'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.2
+    rev: v0.5.4
     hooks:
     - id: ruff
       name: Run Ruff linter

--- a/anta/models.py
+++ b/anta/models.py
@@ -57,7 +57,7 @@ class AntaTemplate:
 
     # pylint: disable=too-few-public-methods
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         template: str,
         version: Literal[1, "latest"] = "latest",

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -123,7 +123,7 @@ def _add_bgp_routes_failure(
     # Iterate over the expected BGP routes
     for route in bgp_routes:
         str_route = str(route)
-        failure = {"bgp_peers": {peer: {vrf: {route_type: {str_route: Any}}}}}
+        failure: dict[str, Any] = {"bgp_peers": {peer: {vrf: {route_type: {}}}}}
 
         # Check if the route is missing in the BGP output
         if str_route not in bgp_output:

--- a/asynceapi/device.py
+++ b/asynceapi/device.py
@@ -54,7 +54,7 @@ class Device(httpx.AsyncClient):
     EAPI_OFMT_OPTIONS = ("json", "text")
     EAPI_DEFAULT_OFMT = "json"
 
-    def __init__(  # noqa: PLR0913  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         host: str | None = None,
         username: str | None = None,

--- a/asynceapi/errors.py
+++ b/asynceapi/errors.py
@@ -24,7 +24,7 @@ class EapiCommandError(RuntimeError):
         not_exec: a list of commands that were not executed
     """
 
-    def __init__(self, failed: str, errors: list[str], errmsg: str, passed: list[str | dict[str, Any]], not_exec: list[dict[str, Any]]) -> None:  # noqa: PLR0913  # pylint: disable=too-many-arguments
+    def __init__(self, failed: str, errors: list[str], errmsg: str, passed: list[str | dict[str, Any]], not_exec: list[dict[str, Any]]) -> None:  # pylint: disable=too-many-arguments
         """Initialize for the EapiCommandError exception."""
         self.failed = failed
         self.errmsg = errmsg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
   "pytest-html>=3.2.0",
   "pytest-metadata>=3.0.0",
   "pytest>=7.4.0",
-  "ruff>=0.5.0,<0.6.0",
+  "ruff>=0.5.4,<0.6.0",
   "tox>=4.10.0,<5.0.0",
   "types-PyYAML",
   "types-pyOpenSSL",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,9 @@ filterwarnings = [
   "default:pkg_resources is deprecated:DeprecationWarning",
   # Need to investigate the following - only occuring when running the full pytest suite
   "ignore:Exception ignored in.*:pytest.PytestUnraisableExceptionWarning",
+  # Ignore cryptography >=43.0.0 warnings until asyncssh issue is fixed
+  "ignore:ARC4:cryptography.utils.CryptographyDeprecationWarning",
+  "ignore:TripleDES:cryptography.utils.CryptographyDeprecationWarning",
 
 ]
 


### PR DESCRIPTION
# Description

cryptography 43.0.0 generate warnings and we run pytest with transforming warning into erros.
Opened this: https://github.com/ronf/asyncssh/issues/674 but in the meantime accepting the warning in our CI

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
