### PR TITLE
feat(anta): Added test case to verify registered protocol for IPv4 BFD peers

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -198,3 +198,4 @@ BgpDropStats = Literal[
     "prefixRtMembershipDroppedMaxRouteLimitViolated",
 ]
 BgpUpdateError = Literal["inUpdErrWithdraw", "inUpdErrIgnore", "inUpdErrDisableAfiSafi", "disabledAfiSafi", "lastUpdErrTime"]
+BfdProtocol = Literal["bgp", "isis", "lag", "ospf", "ospfv3", "pim", "route-input", "static-bfd", "static-route", "vrrp", "vxlan"]

--- a/anta/tests/bfd.py
+++ b/anta/tests/bfd.py
@@ -293,8 +293,7 @@ class VerifyBFDPeersRegProtocols(AntaTest):
     Expected Results
     ----------------
     * Success: The test will pass if IPv4 BFD peers are registered with specified protocol(s).
-    * Failure: The test will fail if IPv4 BFD peers are not found, any BFD session is not established,
-    or the specified protocol(s) are not registered on the BFD peer(s).
+    * Failure: The test will fail if IPv4 BFD peers are not found or the specified protocol(s) are not registered on the BFD peer(s).
 
     Examples
     --------

--- a/anta/tests/bfd.py
+++ b/anta/tests/bfd.py
@@ -292,8 +292,8 @@ class VerifyBFDPeersRegProtocols(AntaTest):
 
     Expected Results
     ----------------
-    * Success: The test will pass if IPv4 BFD peers are registered with specified protocol(s).
-    * Failure: The test will fail if IPv4 BFD peers are not found or the specified protocol(s) are not registered on the BFD peer(s).
+    * Success: The test will pass if IPv4 BFD peers are registered with the specified protocol(s).
+    * Failure: The test will fail if IPv4 BFD peers are not found or the specified protocol(s) are not registered for the BFD peer(s).
 
     Examples
     --------
@@ -351,12 +351,13 @@ class VerifyBFDPeersRegProtocols(AntaTest):
                 failures[peer] = {vrf: "Not Configured"}
                 continue
 
-            # Check registered protocols if specified.
-            actual_protocols = get_value(bfd_output, "peerStatsDetail.apps")
-            if not all(protocol in actual_protocols for protocol in protocols):
-                failures[peer] = {vrf: {"protocols": actual_protocols}}
+            # Check registered protocols
+            difference = set(protocols) - set(get_value(bfd_output, "peerStatsDetail.apps"))
+
+            if difference:
+                failures[peer] = {vrf: sorted(difference)}
 
         if not failures:
             self.result.is_success()
         else:
-            self.result.is_failure(f"The following BFD peers are not configured or specified protocol(s) are not registered:\n{failures}")
+            self.result.is_failure(f"The following BFD peers are not configured or have non-registered protocol(s):\n{failures}")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -69,8 +69,6 @@ anta.tests.bfd:
           vrf: default
         - peer_address: 192.0.255.7
           vrf: default
-          protocols:
-            - isis
   - VerifyBFDPeersIntervals:
       bfd_peers:
         - peer_address: 192.0.255.8
@@ -85,6 +83,13 @@ anta.tests.bfd:
           multiplier: 3
   - VerifyBFDPeersHealth:
       down_threshold: 2
+  - VerifyBFDPeersRegProtocols:
+      bfd_peers:
+        - peer_address: 192.0.255.8
+          vrf: default
+          protocols:
+            - bgp
+            - isis
 
 anta.tests.configuration:
   - VerifyZeroTouch:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -69,6 +69,8 @@ anta.tests.bfd:
           vrf: default
         - peer_address: 192.0.255.7
           vrf: default
+          protocols:
+            - isis
   - VerifyBFDPeersIntervals:
       bfd_peers:
         - peer_address: 192.0.255.8

--- a/tests/units/anta_tests/test_bfd.py
+++ b/tests/units/anta_tests/test_bfd.py
@@ -10,7 +10,7 @@ from typing import Any
 
 # pylint: disable=C0413
 # because of the patch above
-from anta.tests.bfd import VerifyBFDPeersHealth, VerifyBFDPeersIntervals, VerifyBFDSpecificPeers
+from anta.tests.bfd import VerifyBFDPeersHealth, VerifyBFDPeersIntervals, VerifyBFDPeersRegProtocols, VerifyBFDSpecificPeers
 from tests.lib.anta import test  # noqa: F401; pylint: disable=W0611
 
 DATA: list[dict[str, Any]] = [
@@ -205,55 +205,6 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
-        "name": "success-protocols",
-        "test": VerifyBFDSpecificPeers,
-        "eos_data": [
-            {
-                "vrfs": {
-                    "default": {
-                        "ipv4Neighbors": {
-                            "192.0.255.7": {
-                                "peerStats": {
-                                    "": {
-                                        "status": "up",
-                                        "remoteDisc": 108328132,
-                                        "peerStatsDetail": {
-                                            "role": "active",
-                                            "apps": ["bgp"],
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "MGMT": {
-                        "ipv4Neighbors": {
-                            "192.0.255.70": {
-                                "peerStats": {
-                                    "": {
-                                        "status": "up",
-                                        "remoteDisc": 108328132,
-                                        "peerStatsDetail": {
-                                            "role": "active",
-                                            "apps": ["ospf"],
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    },
-                }
-            }
-        ],
-        "inputs": {
-            "bfd_peers": [
-                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["bgp"]},
-                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["ospf"]},
-            ]
-        },
-        "expected": {"result": "success"},
-    },
-    {
         "name": "failure-no-peer",
         "test": VerifyBFDSpecificPeers,
         "eos_data": [
@@ -290,7 +241,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "For following BFD peers, session parameters are not Ok:\n{'192.0.255.7': {'CS': 'Not Configured'}, '192.0.255.70': {'MGMT': 'Not Configured'}}"
+                "Following BFD peers are not configured, status is not up or remote disc is zero:\n"
+                "{'192.0.255.7': {'CS': 'Not Configured'}, '192.0.255.70': {'MGMT': 'Not Configured'}}"
             ],
         },
     },
@@ -331,121 +283,9 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "For following BFD peers, session parameters are not Ok:\n"
+                "Following BFD peers are not configured, status is not up or remote disc is zero:\n"
                 "{'192.0.255.7': {'default': {'status': 'Down', 'remote_disc': 108328132}}, "
                 "'192.0.255.70': {'MGMT': {'status': 'Down', 'remote_disc': 0}}}"
-            ],
-        },
-    },
-    {
-        "name": "failure-protocols",
-        "test": VerifyBFDSpecificPeers,
-        "eos_data": [
-            {
-                "vrfs": {
-                    "default": {
-                        "ipv4Neighbors": {
-                            "192.0.255.7": {
-                                "peerStats": {
-                                    "": {
-                                        "status": "up",
-                                        "remoteDisc": 108328132,
-                                        "peerStatsDetail": {
-                                            "role": "active",
-                                            "apps": ["ospf"],
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "MGMT": {
-                        "ipv4Neighbors": {
-                            "192.0.255.70": {
-                                "peerStats": {
-                                    "": {
-                                        "status": "up",
-                                        "remoteDisc": 108328132,
-                                        "peerStatsDetail": {
-                                            "role": "active",
-                                            "apps": ["bgp"],
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    },
-                }
-            }
-        ],
-        "inputs": {
-            "bfd_peers": [
-                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["isis"]},
-                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["isis"]},
-            ]
-        },
-        "expected": {
-            "result": "failure",
-            "messages": [
-                "For following BFD peers, session parameters are not Ok:\n"
-                "{'192.0.255.7': {'default': {'protocols': ['ospf']}}, "
-                "'192.0.255.70': {'MGMT': {'protocols': ['bgp']}}}"
-            ],
-        },
-    },
-    {
-        "name": "failure-misc",
-        "test": VerifyBFDSpecificPeers,
-        "eos_data": [
-            {
-                "vrfs": {
-                    "default": {
-                        "ipv4Neighbors": {
-                            "192.0.255.7": {
-                                "peerStats": {
-                                    "": {
-                                        "status": "down",
-                                        "remoteDisc": 0,
-                                        "peerStatsDetail": {
-                                            "role": "active",
-                                            "apps": ["ospf"],
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "MGMT": {
-                        "ipv4Neighbors": {
-                            "192.0.255.70": {
-                                "peerStats": {
-                                    "": {
-                                        "status": "down",
-                                        "remoteDisc": 0,
-                                        "peerStatsDetail": {
-                                            "role": "active",
-                                            "apps": ["bgp"],
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    },
-                }
-            }
-        ],
-        "inputs": {
-            "bfd_peers": [
-                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["isis"]},
-                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["isis"]},
-            ]
-        },
-        "expected": {
-            "result": "failure",
-            "messages": [
-                "For following BFD peers, session parameters are not Ok:\n"
-                "{'192.0.255.7': {'default': {'status': 'down', 'remote_disc': 0, 'protocols': ['ospf']}}, "
-                "'192.0.255.70': {'MGMT': {'status': 'down', 'remote_disc': 0, 'protocols': ['bgp']}}}"
             ],
         },
     },
@@ -676,6 +516,135 @@ DATA: list[dict[str, Any]] = [
             "messages": [
                 "Following BFD peers were down:\n192.0.255.7 in default VRF was down 3 hours ago.\n"
                 "192.0.255.71 in default VRF was down 3 hours ago.\n192.0.255.17 in default VRF was down 3 hours ago."
+            ],
+        },
+    },
+    {
+        "name": "success",
+        "test": VerifyBFDPeersRegProtocols,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "ipv4Neighbors": {
+                            "192.0.255.7": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "up",
+                                        "remoteDisc": 108328132,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["ospf"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MGMT": {
+                        "ipv4Neighbors": {
+                            "192.0.255.70": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "up",
+                                        "remoteDisc": 108328132,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["bgp"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "bfd_peers": [
+                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["ospf"]},
+                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["bgp"]},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure",
+        "test": VerifyBFDPeersRegProtocols,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "ipv4Neighbors": {
+                            "192.0.255.7": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "down",
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["ospf"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MGMT": {
+                        "ipv4Neighbors": {
+                            "192.0.255.70": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "up",
+                                        "remoteDisc": 0,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["bgp"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "bfd_peers": [
+                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["isis"]},
+                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["isis"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following BFD peers are not configured or specified protocol(s) are not registered:\n"
+                "{'192.0.255.7': {'default': {'status': 'down'}}, "
+                "'192.0.255.70': {'MGMT': {'protocols': ['bgp']}}}"
+            ],
+        },
+    },
+    {
+        "name": "failure-not-found",
+        "test": VerifyBFDPeersRegProtocols,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {},
+                    "MGMT": {},
+                }
+            }
+        ],
+        "inputs": {
+            "bfd_peers": [
+                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["isis"]},
+                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["isis"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following BFD peers are not configured or specified protocol(s) are not registered:\n"
+                "{'192.0.255.7': {'default': 'Not Configured'}, '192.0.255.70': {'MGMT': 'Not Configured'}}"
             ],
         },
     },

--- a/tests/units/anta_tests/test_bfd.py
+++ b/tests/units/anta_tests/test_bfd.py
@@ -579,7 +579,7 @@ DATA: list[dict[str, Any]] = [
                             "192.0.255.7": {
                                 "peerStats": {
                                     "": {
-                                        "status": "down",
+                                        "status": "up",
                                         "peerStatsDetail": {
                                             "role": "active",
                                             "apps": ["ospf"],
@@ -618,7 +618,7 @@ DATA: list[dict[str, Any]] = [
             "result": "failure",
             "messages": [
                 "The following BFD peers are not configured or specified protocol(s) are not registered:\n"
-                "{'192.0.255.7': {'default': {'status': 'down'}}, "
+                "{'192.0.255.7': {'default': {'protocols': ['ospf']}}, "
                 "'192.0.255.70': {'MGMT': {'protocols': ['bgp']}}}"
             ],
         },

--- a/tests/units/anta_tests/test_bfd.py
+++ b/tests/units/anta_tests/test_bfd.py
@@ -205,6 +205,55 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
+        "name": "success-protocols",
+        "test": VerifyBFDSpecificPeers,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "ipv4Neighbors": {
+                            "192.0.255.7": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "up",
+                                        "remoteDisc": 108328132,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["bgp"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MGMT": {
+                        "ipv4Neighbors": {
+                            "192.0.255.70": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "up",
+                                        "remoteDisc": 108328132,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["ospf"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "bfd_peers": [
+                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["bgp"]},
+                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["ospf"]},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure-no-peer",
         "test": VerifyBFDSpecificPeers,
         "eos_data": [
@@ -241,8 +290,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Following BFD peers are not configured, status is not up or remote disc is zero:\n"
-                "{'192.0.255.7': {'CS': 'Not Configured'}, '192.0.255.70': {'MGMT': 'Not Configured'}}"
+                "For following BFD peers, session parameters are not Ok:\n{'192.0.255.7': {'CS': 'Not Configured'}, '192.0.255.70': {'MGMT': 'Not Configured'}}"
             ],
         },
     },
@@ -283,9 +331,121 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Following BFD peers are not configured, status is not up or remote disc is zero:\n"
+                "For following BFD peers, session parameters are not Ok:\n"
                 "{'192.0.255.7': {'default': {'status': 'Down', 'remote_disc': 108328132}}, "
                 "'192.0.255.70': {'MGMT': {'status': 'Down', 'remote_disc': 0}}}"
+            ],
+        },
+    },
+    {
+        "name": "failure-protocols",
+        "test": VerifyBFDSpecificPeers,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "ipv4Neighbors": {
+                            "192.0.255.7": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "up",
+                                        "remoteDisc": 108328132,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["ospf"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MGMT": {
+                        "ipv4Neighbors": {
+                            "192.0.255.70": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "up",
+                                        "remoteDisc": 108328132,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["bgp"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "bfd_peers": [
+                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["isis"]},
+                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["isis"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "For following BFD peers, session parameters are not Ok:\n"
+                "{'192.0.255.7': {'default': {'protocols': ['ospf']}}, "
+                "'192.0.255.70': {'MGMT': {'protocols': ['bgp']}}}"
+            ],
+        },
+    },
+    {
+        "name": "failure-misc",
+        "test": VerifyBFDSpecificPeers,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "ipv4Neighbors": {
+                            "192.0.255.7": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "down",
+                                        "remoteDisc": 0,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["ospf"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "MGMT": {
+                        "ipv4Neighbors": {
+                            "192.0.255.70": {
+                                "peerStats": {
+                                    "": {
+                                        "status": "down",
+                                        "remoteDisc": 0,
+                                        "peerStatsDetail": {
+                                            "role": "active",
+                                            "apps": ["bgp"],
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "bfd_peers": [
+                {"peer_address": "192.0.255.7", "vrf": "default", "protocols": ["isis"]},
+                {"peer_address": "192.0.255.70", "vrf": "MGMT", "protocols": ["isis"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "For following BFD peers, session parameters are not Ok:\n"
+                "{'192.0.255.7': {'default': {'status': 'down', 'remote_disc': 0, 'protocols': ['ospf']}}, "
+                "'192.0.255.70': {'MGMT': {'status': 'down', 'remote_disc': 0, 'protocols': ['bgp']}}}"
             ],
         },
     },

--- a/tests/units/anta_tests/test_bfd.py
+++ b/tests/units/anta_tests/test_bfd.py
@@ -617,9 +617,9 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "The following BFD peers are not configured or specified protocol(s) are not registered:\n"
-                "{'192.0.255.7': {'default': {'protocols': ['ospf']}}, "
-                "'192.0.255.70': {'MGMT': {'protocols': ['bgp']}}}"
+                "The following BFD peers are not configured or have non-registered protocol(s):\n"
+                "{'192.0.255.7': {'default': ['isis']}, "
+                "'192.0.255.70': {'MGMT': ['isis']}}"
             ],
         },
     },
@@ -643,7 +643,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "The following BFD peers are not configured or specified protocol(s) are not registered:\n"
+                "The following BFD peers are not configured or have non-registered protocol(s):\n"
                 "{'192.0.255.7': {'default': 'Not Configured'}, '192.0.255.70': {'MGMT': 'Not Configured'}}"
             ],
         },


### PR DESCRIPTION
# Description

All neighbor IPs where PEER_GROUP has BFD_ENABLED=true should be displayed with respective registered protocol(i.e ISIS or BGP etc)

**Note: Added revision fix in VerifyBFDPeersIntervals, VerifyBFDSpecificPeers revision 1 as later revision introduces additional nesting for type**

Fixes #766 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)


