### PR TITLE
feat(anta): Added the test case to verify Inbound/outbound stats for BGP neighbors

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -167,3 +167,33 @@ Revision = Annotated[int, Field(ge=1, le=99)]
 Hostname = Annotated[str, Field(pattern=REGEXP_TYPE_HOSTNAME)]
 Port = Annotated[int, Field(ge=1, le=65535)]
 RegexString = Annotated[str, AfterValidator(validate_regex)]
+BgpDropStats = Literal[
+    "inDropAsloop",
+    "inDropClusterIdLoop",
+    "inDropMalformedMpbgp",
+    "inDropOrigId",
+    "inDropNhLocal",
+    "inDropNhAfV6",
+    "prefixDroppedMartianV4",
+    "prefixDroppedMaxRouteLimitViolatedV4",
+    "prefixDroppedMartianV6",
+    "prefixDroppedMaxRouteLimitViolatedV6",
+    "prefixLuDroppedV4",
+    "prefixLuDroppedMartianV4",
+    "prefixLuDroppedMaxRouteLimitViolatedV4",
+    "prefixLuDroppedV6",
+    "prefixLuDroppedMartianV6",
+    "prefixLuDroppedMaxRouteLimitViolatedV6",
+    "prefixEvpnDroppedUnsupportedRouteType",
+    "prefixBgpLsDroppedReceptionUnsupported",
+    "outDropV4LocalAddr",
+    "outDropV6LocalAddr",
+    "prefixVpnIpv4DroppedImportMatchFailure",
+    "prefixVpnIpv4DroppedMaxRouteLimitViolated",
+    "prefixVpnIpv6DroppedImportMatchFailure",
+    "prefixVpnIpv6DroppedMaxRouteLimitViolated",
+    "prefixEvpnDroppedImportMatchFailure",
+    "prefixEvpnDroppedMaxRouteLimitViolated",
+    "prefixRtMembershipDroppedLocalAsReject",
+    "prefixRtMembershipDroppedMaxRouteLimitViolated",
+]

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -1229,12 +1229,15 @@ class VerifyBGPTimers(AntaTest):
 
 
 class VerifyBGPPeerDropStats(AntaTest):
-    """Verifies BGP NLRI drop statistics for the provided BGP IPv4 peer(s), checking for any non-zero values in various drop categories.
+    """Verifies BGP NLRI drop statistics for the provided BGP IPv4 peer(s).
+
+    By default, all drop statistics counters will be checked for any non-zero values.
+    An optional list of specific drop statistics can be provided for granular testing
 
     Expected Results
     ----------------
-    * Success: The test will pass if the BGP peer's drop statistics are zero.
-    * Failure: The test will fail if the BGP peer's drop statistics are non-zero.
+    * Success: The test will pass if the BGP peer's drop statistic(s) are zero.
+    * Failure: The test will fail if the BGP peer's drop statistic(s) are non-zero/Not Found or peer is not configured.
 
     Examples
     --------
@@ -1252,9 +1255,9 @@ class VerifyBGPPeerDropStats(AntaTest):
     """
 
     name = "VerifyBGPPeerDropStats"
-    description = "Verifies the NLRI drop Statistics of a BGP IPv4 peer."
+    description = "Verifies the NLRI drop statistics of a BGP IPv4 peer(s)."
     categories: ClassVar[list[str]] = ["bgp"]
-    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaTemplate(template="show bgp neighbors {peer} vrf {vrf}")]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaTemplate(template="show bgp neighbors {peer} vrf {vrf}", revision=3)]
 
     class Input(AntaTest.Input):
         """Input model for the VerifyBGPPeerDropStats test."""
@@ -1273,7 +1276,7 @@ class VerifyBGPPeerDropStats(AntaTest):
             """Optional list of drop statistics to be verified. If not provided, test will verifies all the drop statistics."""
 
     def render(self, template: AntaTemplate) -> list[AntaCommand]:
-        """Render the template for each Bgp peer in the input list."""
+        """Render the template for each BGP peer in the input list."""
         return [template.render(peer=str(bgp_peer.peer_address), vrf=bgp_peer.vrf) for bgp_peer in self.inputs.bgp_peers]
 
     @AntaTest.anta_test

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -1237,7 +1237,7 @@ class VerifyBGPPeerDropStats(AntaTest):
     Expected Results
     ----------------
     * Success: The test will pass if the BGP peer's drop statistic(s) are zero.
-    * Failure: The test will fail if the BGP peer's drop statistic(s) are non-zero/not found or peer is not configured.
+    * Failure: The test will fail if the BGP peer's drop statistic(s) are non-zero/Not Found or peer is not configured.
 
     Examples
     --------

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -1232,12 +1232,12 @@ class VerifyBGPPeerDropStats(AntaTest):
     """Verifies BGP NLRI drop statistics for the provided BGP IPv4 peer(s).
 
     By default, all drop statistics counters will be checked for any non-zero values.
-    An optional list of specific drop statistics can be provided for granular testing
+    An optional list of specific drop statistics can be provided for granular testing.
 
     Expected Results
     ----------------
     * Success: The test will pass if the BGP peer's drop statistic(s) are zero.
-    * Failure: The test will fail if the BGP peer's drop statistic(s) are non-zero/Not Found or peer is not configured.
+    * Failure: The test will fail if the BGP peer's drop statistic(s) are non-zero/not found or peer is not configured.
 
     Examples
     --------

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -567,6 +567,17 @@ anta.tests.routing:
             vrf: default
             hold_time: 180
             keep_alive_time: 60
+    - VerifyBGPPeerDropStats:
+        bgp_peers:
+          - peer_address: 10.101.0.4
+            vrf: default
+            drop_stats:
+              - inDropAsloop
+              - inDropClusterIdLoop
+              - inDropMalformedMpbgp
+              - inDropOrigId
+              - inDropNhLocal
+              - inDropNhAfV6
   ospf:
     - VerifyOSPFNeighborState:
     - VerifyOSPFNeighborCount:

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -3788,9 +3788,7 @@ DATA: list[dict[str, Any]] = [
         "name": "failure-not-found",
         "test": VerifyBGPPeerDropStats,
         "eos_data": [
-            {
-                "vrfs": {},
-            },
+            {"vrfs": {}},
             {"vrfs": {}},
         ],
         "inputs": {
@@ -3806,7 +3804,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Following BGP peers are not configured or drop stats are not correct:\n"
+                "The following BGP peers are not configured or have non-zero NLRI drop statistics counters:\n"
                 "{'10.100.0.8': {'default': 'Not configured'}, '10.100.0.9': {'MGMT': 'Not configured'}}"
             ],
         },
@@ -3873,9 +3871,170 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Following BGP peers are not configured or drop stats are not correct:\n"
-                "{'10.100.0.8': {'default': ['prefixDroppedMartianV4', 'prefixDroppedMaxRouteLimitViolatedV4']}, "
-                "'10.100.0.9': {'MGMT': ['inDropOrigId', 'inDropNhLocal']}}"
+                "The following BGP peers are not configured or have non-zero NLRI drop statistics counters:\n"
+                "{'10.100.0.8': {'default': {'prefixDroppedMartianV4': 1, 'prefixDroppedMaxRouteLimitViolatedV4': 1}}, "
+                "'10.100.0.9': {'MGMT': {'inDropOrigId': 1, 'inDropNhLocal': 1}}}"
+            ],
+        },
+    },
+    {
+        "name": "success-all-drop-stats",
+        "test": VerifyBGPPeerDropStats,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.8",
+                                "dropStats": {
+                                    "inDropAsloop": 0,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 0,
+                                    "inDropNhLocal": 0,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 0,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 0,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+            {
+                "vrfs": {
+                    "MGMT": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.9",
+                                "dropStats": {
+                                    "inDropAsloop": 0,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 0,
+                                    "inDropNhLocal": 0,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 0,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 0,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {"peer_address": "10.100.0.8", "vrf": "default"},
+                {"peer_address": "10.100.0.9", "vrf": "MGMT"},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-all-drop-stats",
+        "test": VerifyBGPPeerDropStats,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.8",
+                                "dropStats": {
+                                    "inDropAsloop": 3,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 1,
+                                    "inDropNhLocal": 1,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 1,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 1,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+            {
+                "vrfs": {
+                    "MGMT": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.9",
+                                "dropStats": {
+                                    "inDropAsloop": 2,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 1,
+                                    "inDropNhLocal": 1,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 0,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 0,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {"peer_address": "10.100.0.8", "vrf": "default"},
+                {"peer_address": "10.100.0.9", "vrf": "MGMT"},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following BGP peers are not configured or have non-zero NLRI drop statistics counters:\n"
+                "{'10.100.0.8': {'default': {'inDropAsloop': 3, 'inDropOrigId': 1, 'inDropNhLocal': 1, "
+                "'prefixDroppedMartianV4': 1, 'prefixDroppedMaxRouteLimitViolatedV4': 1}}, "
+                "'10.100.0.9': {'MGMT': {'inDropAsloop': 2, 'inDropOrigId': 1, 'inDropNhLocal': 1}}}"
+            ],
+        },
+    },
+    {
+        "name": "failure-drop-stat-not-found",
+        "test": VerifyBGPPeerDropStats,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.8",
+                                "dropStats": {
+                                    "inDropAsloop": 3,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 1,
+                                    "inDropNhLocal": 1,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 1,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {"peer_address": "10.100.0.8", "vrf": "default", "drop_stats": ["inDropAsloop", "inDropOrigId", "inDropNhLocal", "prefixDroppedMartianV4"]}
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "The following BGP peers are not configured or have non-zero NLRI drop statistics counters:\n"
+                "{'10.100.0.8': {'default': {'inDropAsloop': 3, 'inDropOrigId': 1, 'inDropNhLocal': 1, 'prefixDroppedMartianV4': 'Not Found'}}}"
             ],
         },
     },

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -15,6 +15,7 @@ from anta.tests.routing.bgp import (
     VerifyBGPExchangedRoutes,
     VerifyBGPPeerASNCap,
     VerifyBGPPeerCount,
+    VerifyBGPPeerDropStats,
     VerifyBGPPeerMD5Auth,
     VerifyBGPPeerMPCaps,
     VerifyBGPPeerRouteRefreshCap,
@@ -3719,6 +3720,162 @@ DATA: list[dict[str, Any]] = [
                 "Following BGP peers are not configured or hold and keep-alive timers are not correct:\n"
                 "{'172.30.11.1': {'default': {'hold_time': 160, 'keep_alive_time': 60}}, "
                 "'172.30.11.11': {'MGMT': {'hold_time': 120, 'keep_alive_time': 40}}}"
+            ],
+        },
+    },
+    {
+        "name": "success",
+        "test": VerifyBGPPeerDropStats,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.8",
+                                "dropStats": {
+                                    "inDropAsloop": 0,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 0,
+                                    "inDropNhLocal": 0,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 0,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 0,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+            {
+                "vrfs": {
+                    "MGMT": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.9",
+                                "dropStats": {
+                                    "inDropAsloop": 0,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 0,
+                                    "inDropNhLocal": 0,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 0,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 0,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {
+                    "peer_address": "10.100.0.8",
+                    "vrf": "default",
+                    "drop_stats": ["prefixDroppedMartianV4", "prefixDroppedMaxRouteLimitViolatedV4", "prefixDroppedMartianV6"],
+                },
+                {"peer_address": "10.100.0.9", "vrf": "MGMT", "drop_stats": ["inDropClusterIdLoop", "inDropOrigId", "inDropNhLocal"]},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-not-found",
+        "test": VerifyBGPPeerDropStats,
+        "eos_data": [
+            {
+                "vrfs": {},
+            },
+            {"vrfs": {}},
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {
+                    "peer_address": "10.100.0.8",
+                    "vrf": "default",
+                    "drop_stats": ["prefixDroppedMartianV4", "prefixDroppedMaxRouteLimitViolatedV4", "prefixDroppedMartianV6"],
+                },
+                {"peer_address": "10.100.0.9", "vrf": "MGMT", "drop_stats": ["inDropClusterIdLoop", "inDropOrigId", "inDropNhLocal"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Following BGP peers are not configured or drop stats are not correct:\n"
+                "{'10.100.0.8': {'default': 'Not configured'}, '10.100.0.9': {'MGMT': 'Not configured'}}"
+            ],
+        },
+    },
+    {
+        "name": "failure",
+        "test": VerifyBGPPeerDropStats,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.8",
+                                "dropStats": {
+                                    "inDropAsloop": 0,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 1,
+                                    "inDropNhLocal": 1,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 1,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 1,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+            {
+                "vrfs": {
+                    "MGMT": {
+                        "peerList": [
+                            {
+                                "peerAddress": "10.100.0.9",
+                                "dropStats": {
+                                    "inDropAsloop": 0,
+                                    "inDropClusterIdLoop": 0,
+                                    "inDropMalformedMpbgp": 0,
+                                    "inDropOrigId": 1,
+                                    "inDropNhLocal": 1,
+                                    "inDropNhAfV6": 0,
+                                    "prefixDroppedMartianV4": 0,
+                                    "prefixDroppedMaxRouteLimitViolatedV4": 0,
+                                    "prefixDroppedMartianV6": 0,
+                                },
+                            }
+                        ]
+                    },
+                },
+            },
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {
+                    "peer_address": "10.100.0.8",
+                    "vrf": "default",
+                    "drop_stats": ["prefixDroppedMartianV4", "prefixDroppedMaxRouteLimitViolatedV4", "prefixDroppedMartianV6"],
+                },
+                {"peer_address": "10.100.0.9", "vrf": "MGMT", "drop_stats": ["inDropClusterIdLoop", "inDropOrigId", "inDropNhLocal"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Following BGP peers are not configured or drop stats are not correct:\n"
+                "{'10.100.0.8': {'default': ['prefixDroppedMartianV4', 'prefixDroppedMaxRouteLimitViolatedV4']}, "
+                "'10.100.0.9': {'MGMT': ['inDropOrigId', 'inDropNhLocal']}}"
             ],
         },
     },


### PR DESCRIPTION
# Description

This test case checks if specified BGP drop statistics are zero, ensuring that no BGP messages
    are being dropped.(Inbound updates, Inbound paths, Outbound paths).

    Expected Results
    ----------------
    * Success: The test will pass if the BGP peer's drop statistics are zero.
    * Failure: The test will fail if the BGP peer's drop statistics are non-zero.

Fixes #769 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
