### PR TITLE
fix(anta): Add upper bound on Griffe requirement for v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dev = [
 ]
 doc = [
   "fontawesome_markdown",
-  "griffe",
+  "griffe >=0.46,<1.0.0",
   "mike==2.1.3",
   "mkdocs-autorefs>=0.4.1",
   "mkdocs-bootswatch>=1.1",


### PR DESCRIPTION
# Description
Griffe v1 was released so we need to put an upper bound on Griffe requirement until we update the code to support v1.

https://github.com/mkdocstrings/griffe/releases/tag/0.46.0

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
