### PR TITLE
fix(anta): Remove JSON output when saving to a file

### DIFF
--- a/anta/cli/nrfu/commands.py
+++ b/anta/cli/nrfu/commands.py
@@ -42,7 +42,7 @@ def table(ctx: click.Context, group_by: Literal["device", "test"] | None) -> Non
     type=click.Path(file_okay=True, dir_okay=False, exists=False, writable=True, path_type=pathlib.Path),
     show_envvar=True,
     required=False,
-    help="Path to save report as a file",
+    help="Path to save report as a JSON file",
 )
 def json(ctx: click.Context, output: pathlib.Path | None) -> None:
     """ANTA command to check network state with JSON result."""

--- a/anta/cli/nrfu/utils.py
+++ b/anta/cli/nrfu/utils.py
@@ -94,14 +94,21 @@ def print_table(ctx: click.Context, group_by: Literal["device", "test"] | None =
 
 
 def print_json(ctx: click.Context, output: pathlib.Path | None = None) -> None:
-    """Print result in a json format."""
+    """Print results as JSON. If output is provided, save to file instead."""
     results = _get_result_manager(ctx)
-    console.print()
-    console.print(Panel("JSON results", style="cyan"))
-    rich.print_json(results.json)
-    if output is not None:
-        with output.open(mode="w", encoding="utf-8") as fout:
-            fout.write(results.json)
+
+    if output is None:
+        console.print()
+        console.print(Panel("JSON results", style="cyan"))
+        rich.print_json(results.json)
+    else:
+        try:
+            with output.open(mode="w", encoding="utf-8") as file:
+                file.write(results.json)
+            console.print(f"JSON results saved to {output} ✅", style="cyan")
+        except OSError:
+            console.print(f"Failed to save JSON results to {output} ❌", style="cyan")
+            ctx.exit(ExitCode.USAGE_ERROR)
 
 
 def print_text(ctx: click.Context) -> None:

--- a/docs/cli/nrfu.md
+++ b/docs/cli/nrfu.md
@@ -120,7 +120,7 @@ anta nrfu --test VerifyZeroTouch table
 
 ## Performing NRFU with JSON rendering
 
-The JSON rendering command in NRFU testing is useful in generating a JSON output that can subsequently be passed on to another tool for reporting purposes.
+The JSON rendering command in NRFU testing will generate an output of all test results in JSON format.
 
 ### Command overview
 
@@ -131,12 +131,12 @@ Usage: anta nrfu json [OPTIONS]
   ANTA command to check network state with JSON result.
 
 Options:
-  -o, --output FILE  Path to save report as a file  [env var:
+  -o, --output FILE  Path to save report as a JSON file  [env var:
                      ANTA_NRFU_JSON_OUTPUT]
   --help             Show this message and exit.
 ```
 
-The `--output` option allows you to save the JSON report as a file.
+The `--output` option allows you to save the JSON report as a file. If specified, no output will be displayed in the terminal. This is useful for further processing or integration with other tools.
 
 ### Example
 

--- a/tests/units/cli/nrfu/test_commands.py
+++ b/tests/units/cli/nrfu/test_commands.py
@@ -90,6 +90,15 @@ def test_anta_nrfu_json(click_runner: CliRunner) -> None:
             assert res["result"] == "success"
 
 
+def test_anta_nrfu_json_output(click_runner: CliRunner, tmp_path: Path) -> None:
+    """Test anta nrfu json with output file."""
+    json_output = tmp_path / "test.json"
+    result = click_runner.invoke(anta, ["nrfu", "json", "--output", str(json_output)])
+    assert result.exit_code == ExitCode.OK
+    assert "JSON results saved to" in result.output
+    assert json_output.exists()
+
+
 def test_anta_nrfu_template(click_runner: CliRunner) -> None:
     """Test anta nrfu, catalog is given via env."""
     result = click_runner.invoke(anta, ["nrfu", "tpl-report", "--template", str(DATA_DIR / "template.j2")])

--- a/tests/units/cli/nrfu/test_commands.py
+++ b/tests/units/cli/nrfu/test_commands.py
@@ -94,6 +94,11 @@ def test_anta_nrfu_json_output(click_runner: CliRunner, tmp_path: Path) -> None:
     """Test anta nrfu json with output file."""
     json_output = tmp_path / "test.json"
     result = click_runner.invoke(anta, ["nrfu", "json", "--output", str(json_output)])
+
+    # Making sure the output is not printed to stdout
+    match = re.search(r"\[\n {2}{[\s\S]+ {2}}\n\]", result.output)
+    assert match is None
+
     assert result.exit_code == ExitCode.OK
     assert "JSON results saved to" in result.output
     assert json_output.exists()

--- a/tests/units/cli/nrfu/test_commands.py
+++ b/tests/units/cli/nrfu/test_commands.py
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
 
 DATA_DIR: Path = Path(__file__).parent.parent.parent.parent.resolve() / "data"
 
-pathlib_open = Path.open
-
 
 def test_anta_nrfu_table_help(click_runner: CliRunner) -> None:
     """Test anta nrfu table --help."""


### PR DESCRIPTION
# Description

When using the CLI command `anta nrfu json --output ./results.json`, results will be saved in a JSON file without printing to the console.

Fixes #760 

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
