### PR TITLE
feat(anta): Added merge_catalogs function

### DIFF
--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -36,21 +36,6 @@ RawCatalogInput = dict[str, list[dict[str, Optional[dict[str, Any]]]]]
 ListAntaTestTuples = list[tuple[type[AntaTest], Optional[Union[AntaTest.Input, dict[str, Any]]]]]
 
 
-def merge_catalogs(catalogs: list[AntaCatalog]) -> AntaCatalog:
-    """Merge multiple AntaCatalog instances.
-
-    Parameters
-    ----------
-        catalogs: A list of AntaCatalog instances to merge.
-
-    Returns
-    -------
-        A new AntaCatalog instance containing the tests of all the input catalogs.
-    """
-    combined_tests = list(chain(*(catalog.tests for catalog in catalogs)))
-    return AntaCatalog(tests=combined_tests)
-
-
 class AntaTestDefinition(BaseModel):
     """Define a test with its associated inputs.
 
@@ -403,6 +388,21 @@ class AntaCatalog:
             raise
         return AntaCatalog(tests)
 
+    @classmethod
+    def merge_catalogs(cls, catalogs: list[AntaCatalog]) -> AntaCatalog:
+        """Merge multiple AntaCatalog instances.
+
+        Parameters
+        ----------
+            catalogs: A list of AntaCatalog instances to merge.
+
+        Returns
+        -------
+            A new AntaCatalog instance containing the tests of all the input catalogs.
+        """
+        combined_tests = list(chain(*(catalog.tests for catalog in catalogs)))
+        return cls(tests=combined_tests)
+
     def merge(self, catalog: AntaCatalog) -> AntaCatalog:
         """Merge two AntaCatalog instances.
 
@@ -416,11 +416,11 @@ class AntaCatalog:
         """
         # TODO: Use a decorator to deprecate this method instead. See https://github.com/aristanetworks/anta/issues/754
         warn(
-            message="AntaCatalog.merge() is deprecated and will be removed in ANTA v2.0. Use merge_catalogs() from the anta.catalog module instead.",
+            message="AntaCatalog.merge() is deprecated and will be removed in ANTA v2.0. Use AntaCatalog.merge_catalogs() instead.",
             category=DeprecationWarning,
             stacklevel=2,
         )
-        return merge_catalogs([self, catalog])
+        return self.merge_catalogs([self, catalog])
 
     def dump(self) -> AntaCatalogFile:
         """Return an AntaCatalogFile instance from this AntaCatalog instance.

--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -402,6 +402,7 @@ class AntaCatalog:
             raise
         return AntaCatalog(tests)
 
+    # TODO: Deprecate this method when https://github.com/aristanetworks/anta/issues/754 is resolved
     def merge(self, catalog: AntaCatalog) -> AntaCatalog:
         """Merge two AntaCatalog instances.
 

--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -14,6 +14,7 @@ from itertools import chain
 from json import load as json_load
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from warnings import warn
 
 from pydantic import BaseModel, ConfigDict, RootModel, ValidationError, ValidationInfo, field_validator, model_serializer, model_validator
 from pydantic.types import ImportString
@@ -402,7 +403,6 @@ class AntaCatalog:
             raise
         return AntaCatalog(tests)
 
-    # TODO: Deprecate this method when https://github.com/aristanetworks/anta/issues/754 is resolved
     def merge(self, catalog: AntaCatalog) -> AntaCatalog:
         """Merge two AntaCatalog instances.
 
@@ -414,6 +414,12 @@ class AntaCatalog:
         -------
             A new AntaCatalog instance containing the tests of the two instances.
         """
+        # TODO: Use a decorator to deprecate this method instead. See https://github.com/aristanetworks/anta/issues/754
+        warn(
+            message="AntaCatalog.merge() is deprecated and will be removed in ANTA v2.0. Use merge_catalogs() from the anta.catalog module instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return merge_catalogs([self, catalog])
 
     def dump(self) -> AntaCatalogFile:

--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -10,6 +10,7 @@ import logging
 import math
 from collections import defaultdict
 from inspect import isclass
+from itertools import chain
 from json import load as json_load
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
@@ -32,6 +33,21 @@ RawCatalogInput = dict[str, list[dict[str, Optional[dict[str, Any]]]]]
 
 # [ ( <AntaTest class>, <input_as AntaTest.Input or dict or None > ), ... ]
 ListAntaTestTuples = list[tuple[type[AntaTest], Optional[Union[AntaTest.Input, dict[str, Any]]]]]
+
+
+def merge_catalogs(catalogs: list[AntaCatalog]) -> AntaCatalog:
+    """Merge multiple AntaCatalog instances.
+
+    Parameters
+    ----------
+        catalogs: A list of AntaCatalog instances to merge.
+
+    Returns
+    -------
+        A new AntaCatalog instance containing the tests of all the input catalogs.
+    """
+    combined_tests = list(chain(*(catalog.tests for catalog in catalogs)))
+    return AntaCatalog(tests=combined_tests)
 
 
 class AntaTestDefinition(BaseModel):
@@ -397,7 +413,7 @@ class AntaCatalog:
         -------
             A new AntaCatalog instance containing the tests of the two instances.
         """
-        return AntaCatalog(tests=self.tests + catalog.tests)
+        return merge_catalogs([self, catalog])
 
     def dump(self) -> AntaCatalogFile:
         """Return an AntaCatalogFile instance from this AntaCatalog instance.

--- a/docs/usage-inventory-catalog.md
+++ b/docs/usage-inventory-catalog.md
@@ -307,15 +307,13 @@ Once you run `anta nrfu table`, you will see following output:
 └───────────┴────────────────────────────┴─────────────┴────────────┴───────────────────────────────────────────────┴───────────────┘
 ```
 
-### Merging Catalogs
+### Example script to merge catalogs
 
-**Example script to merge catalogs using the new `merge_catalogs` function**
-
-The following script reads all the files in `intended/test_catalogs/` with names `<device_name>-catalog.yml` and merge them together inside one big catalog `anta-catalog.yml` using the new `merge_catalogs` function.
+The following script reads all the files in `intended/test_catalogs/` with names `<device_name>-catalog.yml` and merge them together inside one big catalog `anta-catalog.yml` using the new `AntaCatalog.merge_catalogs()` class method.
 
 ```python
 #!/usr/bin/env python
-from anta.catalog import AntaCatalog, merge_catalogs
+from anta.catalog import AntaCatalog
 
 from pathlib import Path
 from anta.models import AntaTest
@@ -336,38 +334,11 @@ if __name__ == "__main__":
         catalogs.append(catalog)
 
     # Merge all catalogs
-    merged_catalog = merge_catalogs(catalogs)
+    merged_catalog = AntaCatalog.merge_catalogs(catalogs)
 
     # Save the merged catalog to a file
     with open(Path('anta-catalog.yml'), "w") as f:
         f.write(catalog.dump().yaml())
 ```
 !!! warning
-    The `AntaCatalog.merge()` method is deprecated and will be removed in ANTA v2.0. Please use the `merge_catalogs()` function from the `anta.catalog` module instead.
-
-**For reference: Deprecated method (to be removed in ANTA v2.0)**
-
-```python
-#!/usr/bin/env python
-from anta.catalog import AntaCatalog
-
-from pathlib import Path
-from anta.models import AntaTest
-
-
-CATALOG_SUFFIX = '-catalog.yml'
-CATALOG_DIR = 'intended/test_catalogs/'
-
-if __name__ == "__main__":
-    catalog = AntaCatalog()
-    for file in Path(CATALOG_DIR).glob('*'+CATALOG_SUFFIX):
-        c = AntaCatalog.parse(file)
-        device = str(file).removesuffix(CATALOG_SUFFIX).removeprefix(CATALOG_DIR)
-        print(f"Merging test catalog for device {device}")
-        # Apply filters to all tests for this device
-        for test in c.tests:
-            test.inputs.filters = AntaTest.Input.Filters(tags=[device])
-        catalog = catalog.merge(c)  # This line uses the deprecated method
-    with open(Path('anta-catalog.yml'), "w") as f:
-        f.write(catalog.dump().yaml())
-```
+    The `AntaCatalog.merge()` method is deprecated and will be removed in ANTA v2.0. Please use the `AntaCatalog.merge_catalogs()` class method instead.

--- a/tests/units/test_catalog.py
+++ b/tests/units/test_catalog.py
@@ -13,7 +13,7 @@ import pytest
 from pydantic import ValidationError
 from yaml import safe_load
 
-from anta.catalog import AntaCatalog, AntaCatalogFile, AntaTestDefinition
+from anta.catalog import AntaCatalog, AntaCatalogFile, AntaTestDefinition, merge_catalogs
 from anta.models import AntaTest
 from anta.tests.interfaces import VerifyL3MTU
 from anta.tests.mlag import VerifyMlagStatus
@@ -198,6 +198,18 @@ TESTS_SETTER_FAIL_DATA: list[dict[str, Any]] = [
         "error": "A test in the catalog must be an AntaTestDefinition instance",
     },
 ]
+
+
+def test_merge_catalogs() -> None:
+    """Test the merge_catalogs function."""
+    # Load catalogs of different sizes
+    small_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog.yml")
+    medium_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog_medium.yml")
+    tagged_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog_with_tags.yml")
+
+    # Merge the catalogs and check the number of tests
+    final_catalog = merge_catalogs([small_catalog, medium_catalog, tagged_catalog])
+    assert len(final_catalog.tests) == 240
 
 
 class TestAntaCatalog:

--- a/tests/units/test_catalog.py
+++ b/tests/units/test_catalog.py
@@ -13,7 +13,7 @@ import pytest
 from pydantic import ValidationError
 from yaml import safe_load
 
-from anta.catalog import AntaCatalog, AntaCatalogFile, AntaTestDefinition, merge_catalogs
+from anta.catalog import AntaCatalog, AntaCatalogFile, AntaTestDefinition
 from anta.models import AntaTest
 from anta.tests.interfaces import VerifyL3MTU
 from anta.tests.mlag import VerifyMlagStatus
@@ -200,18 +200,6 @@ TESTS_SETTER_FAIL_DATA: list[dict[str, Any]] = [
 ]
 
 
-def test_merge_catalogs() -> None:
-    """Test the merge_catalogs function."""
-    # Load catalogs of different sizes
-    small_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog.yml")
-    medium_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog_medium.yml")
-    tagged_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog_with_tags.yml")
-
-    # Merge the catalogs and check the number of tests
-    final_catalog = merge_catalogs([small_catalog, medium_catalog, tagged_catalog])
-    assert len(final_catalog.tests) == 240
-
-
 class TestAntaCatalog:
     """Test for anta.catalog.AntaCatalog."""
 
@@ -356,6 +344,17 @@ class TestAntaCatalog:
         assert len(tests) == 3
         tests = catalog.get_tests_by_tags(tags={"leaf", "spine"}, strict=True)
         assert len(tests) == 1
+
+    def test_merge_catalogs(self) -> None:
+        """Test the merge_catalogs function."""
+        # Load catalogs of different sizes
+        small_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog.yml")
+        medium_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog_medium.yml")
+        tagged_catalog = AntaCatalog.parse(DATA_DIR / "test_catalog_with_tags.yml")
+
+        # Merge the catalogs and check the number of tests
+        final_catalog = AntaCatalog.merge_catalogs([small_catalog, medium_catalog, tagged_catalog])
+        assert len(final_catalog.tests) == len(small_catalog.tests) + len(medium_catalog.tests) + len(tagged_catalog.tests)
 
     def test_merge(self) -> None:
         """Test AntaCatalog.merge()."""

--- a/tests/units/test_catalog.py
+++ b/tests/units/test_catalog.py
@@ -366,11 +366,15 @@ class TestAntaCatalog:
         catalog3: AntaCatalog = AntaCatalog.parse(DATA_DIR / "test_catalog_medium.yml")
         assert len(catalog3.tests) == 228
 
-        assert len(catalog1.merge(catalog2).tests) == 2
+        with pytest.deprecated_call():
+            merged_catalog = catalog1.merge(catalog2)
+        assert len(merged_catalog.tests) == 2
         assert len(catalog1.tests) == 1
         assert len(catalog2.tests) == 1
 
-        assert len(catalog2.merge(catalog3).tests) == 229
+        with pytest.deprecated_call():
+            merged_catalog = catalog2.merge(catalog3)
+        assert len(merged_catalog.tests) == 229
         assert len(catalog2.tests) == 1
         assert len(catalog3.tests) == 228
 


### PR DESCRIPTION
# Description

- Added `merge_catalogs` function to the `catalog.py` module.
- Updated `AntaCatalog.merge` to use that function.

Fixes #715 

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
