### PR TITLE
feat(anta): Updated VerifyBFDPeersIntervals for failure message to be in milliseconds like the inputs

### DIFF
--- a/anta/tests/bfd.py
+++ b/anta/tests/bfd.py
@@ -159,8 +159,8 @@ class VerifyBFDPeersIntervals(AntaTest):
             vrf = bfd_peers.vrf
 
             # Converting milliseconds intervals into actual value
-            tx_interval = bfd_peers.tx_interval * 1000
-            rx_interval = bfd_peers.rx_interval * 1000
+            tx_interval = bfd_peers.tx_interval
+            rx_interval = bfd_peers.rx_interval
             multiplier = bfd_peers.multiplier
             bfd_output = get_value(
                 self.instance_commands[0].json_output,
@@ -174,17 +174,18 @@ class VerifyBFDPeersIntervals(AntaTest):
                 continue
 
             bfd_details = bfd_output.get("peerStatsDetail", {})
-            intervals_ok = (
-                bfd_details.get("operTxInterval") == tx_interval and bfd_details.get("operRxInterval") == rx_interval and bfd_details.get("detectMult") == multiplier
-            )
+            op_tx_interval = bfd_details.get("operTxInterval") // 1000
+            op_rx_interval = bfd_details.get("operRxInterval") // 1000
+            detect_multiplier = bfd_details.get("detectMult")
+            intervals_ok = op_tx_interval == tx_interval and op_rx_interval == rx_interval and detect_multiplier == multiplier
 
             # Check timers of BFD peer
             if not intervals_ok:
                 failures[peer] = {
                     vrf: {
-                        "tx_interval": bfd_details.get("operTxInterval"),
-                        "rx_interval": bfd_details.get("operRxInterval"),
-                        "multiplier": bfd_details.get("detectMult"),
+                        "tx_interval": op_tx_interval,
+                        "rx_interval": op_rx_interval,
+                        "multiplier": detect_multiplier,
                     }
                 }
 

--- a/anta/tests/bfd.py
+++ b/anta/tests/bfd.py
@@ -157,22 +157,21 @@ class VerifyBFDPeersIntervals(AntaTest):
         for bfd_peers in self.inputs.bfd_peers:
             peer = str(bfd_peers.peer_address)
             vrf = bfd_peers.vrf
-
-            # Converting milliseconds intervals into actual value
             tx_interval = bfd_peers.tx_interval
             rx_interval = bfd_peers.rx_interval
             multiplier = bfd_peers.multiplier
+
+            # Check if BFD peer configured
             bfd_output = get_value(
                 self.instance_commands[0].json_output,
                 f"vrfs..{vrf}..ipv4Neighbors..{peer}..peerStats..",
                 separator="..",
             )
-
-            # Check if BFD peer configured
             if not bfd_output:
                 failures[peer] = {vrf: "Not Configured"}
                 continue
 
+            # Convert interval timer(s) into milliseconds to be consistent with the inputs.
             bfd_details = bfd_output.get("peerStatsDetail", {})
             op_tx_interval = bfd_details.get("operTxInterval") // 1000
             op_rx_interval = bfd_details.get("operRxInterval") // 1000

--- a/tests/units/anta_tests/test_bfd.py
+++ b/tests/units/anta_tests/test_bfd.py
@@ -163,8 +163,8 @@ DATA: list[dict[str, Any]] = [
             "result": "failure",
             "messages": [
                 "Following BFD peers are not configured or timers are not correct:\n"
-                "{'192.0.255.7': {'default': {'tx_interval': 1300000, 'rx_interval': 1200000, 'multiplier': 4}}, "
-                "'192.0.255.70': {'MGMT': {'tx_interval': 120000, 'rx_interval': 120000, 'multiplier': 5}}}"
+                "{'192.0.255.7': {'default': {'tx_interval': 1300, 'rx_interval': 1200, 'multiplier': 4}}, "
+                "'192.0.255.70': {'MGMT': {'tx_interval': 120, 'rx_interval': 120, 'multiplier': 5}}}"
             ],
         },
     },


### PR DESCRIPTION
# Description

In eAPI reports the interval timers are in microseconds instead of milliseconds so converted timers in to milliseconds to be consistent with the inputs.

Fixes #799 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
