### PR TITLE
feat(anta): Added the test case to verify the BGP route origin

### DIFF
--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -593,6 +593,22 @@ anta.tests.routing:
             update_errors:
               - inUpdErrWithdraw
               - inUpdErrIgnore
+    - VerifyBGPRouteOrigin:
+        route_entries:
+          - prefix: 10.100.0.128/31
+            vrf: default
+            paths:
+              - nexthop: 10.100.0.10
+                origin: Igp
+              - nexthop: 10.100.4.5
+                origin: Incomplete
+          - prefix: 10.100.0.130/31
+            vrf: default
+            paths:
+              - nexthop: 10.100.0.8
+                origin: Igp
+              - nexthop: 10.100.0.10
+                origin: Igp
   ospf:
     - VerifyOSPFNeighborState:
     - VerifyOSPFNeighborCount:


### PR DESCRIPTION
# Description

Verifies BGP route origin for the provided IPv4 Network(s).

    Expected Results
    ----------------
    * Success: The test will pass if the BGP route's origin matches expected origin type.
    * Failure: The test will fail if the BGP route's origin does not matches with expected origin type or BGP route entry(s) not found.

Fixes #811 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
