### PR TITLE
feat(anta): Added the test case to verify multiple routes with only specific nodes as next-hops

### DIFF
--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -494,6 +494,13 @@ anta.tests.routing:
         routes:
           - 10.1.0.1
           - 10.1.0.2
+    - VerifyRouteEntry:
+        route_entries:
+          - prefix: 10.10.0.1/32
+            vrf: default
+            nexthops:
+              - 10.100.0.8
+              - 10.100.0.10
   bgp:
     - VerifyBGPPeerCount:
         address_families:


### PR DESCRIPTION
# Description

Verifies the route entries of given IPv4 network(s).

    Supports `strict: True` to verify that only the specified nexthops by which routes are learned, requiring an exact match.

    Expected Results
    ----------------
    * Success: The test will pass if the route entry with given nexthop(s) present for given network(s).
    * Failure: The test will fail if the routes not found or route entry with given nexthop(s) not present for given network(s).

Fixes #819 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
