### PR TITLE
feat(anta): Added the test case to verify SNMP error counters

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -204,3 +204,6 @@ BgpDropStats = Literal[
 ]
 BgpUpdateError = Literal["inUpdErrWithdraw", "inUpdErrIgnore", "inUpdErrDisableAfiSafi", "disabledAfiSafi", "lastUpdErrTime"]
 BfdProtocol = Literal["bgp", "isis", "lag", "ospf", "ospfv3", "pim", "route-input", "static-bfd", "static-route", "vrrp", "vxlan"]
+SnmpErrorCounter = Literal[
+    "inVersionErrs", "inBadCommunityNames", "inBadCommunityUses", "inParseErrs", "outTooBigErrs", "outNoSuchNameErrs", "outBadValueErrs", "outGeneralErrs"
+]

--- a/anta/tests/snmp.py
+++ b/anta/tests/snmp.py
@@ -7,28 +7,14 @@
 # mypy: disable-error-code=attr-defined
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, get_args
 
-from pydantic import BaseModel, model_validator
-
-from anta.custom_types import PositiveInteger
+from anta.custom_types import PositiveInteger, SnmpErrorCounter
 from anta.models import AntaCommand, AntaTest
 from anta.tools import get_value
 
 if TYPE_CHECKING:
     from anta.models import AntaTemplate
-
-# Define the valid SNMP error counters as a list
-SNMP_COUNTERS: list[str] = [
-    "inVersionErrs",
-    "inBadCommunityNames",
-    "inBadCommunityUses",
-    "inParseErrs",
-    "outTooBigErrs",
-    "outNoSuchNameErrs",
-    "outBadValueErrs",
-    "outGeneralErrs",
-]
 
 
 class VerifySnmpStatus(AntaTest):
@@ -253,8 +239,8 @@ class VerifySnmpContact(AntaTest):
             self.result.is_success()
 
 
-class VerifySnmpErrors(AntaTest):
-    """Verifies the number of SNMP error counter(s) processed.
+class VerifySnmpErrorCounters(AntaTest):
+    """Verifies the SNMP error counters.
 
     By default, all  error counters will be checked for any non-zero values.
     An optional list of specific error counters can be provided for granular testing.
@@ -268,50 +254,37 @@ class VerifySnmpErrors(AntaTest):
     --------
     ```yaml
     anta.tests.snmp:
-      - VerifySnmpErrors:
+      - VerifySnmpErrorCounters:
           error_counters:
             - inVersionErrs
             - inBadCommunityNames
     """
 
-    name = "VerifySnmpErrors"
-    description = "Verifies the number of SNMP error counter(s) processed."
+    name = "VerifySnmpErrorCounters"
+    description = "Verifies the SNMP error counters."
     categories: ClassVar[list[str]] = ["snmp"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show snmp", revision=1)]
 
     class Input(AntaTest.Input):
-        """Input model for the VerifySnmpErrors test."""
+        """Input model for the VerifySnmpErrorCounters test."""
 
-        error_counters: list[str] | None = None
-        """Optional list of SNMP error counters to be verified. If not provided, test will verifies all the counters."""
-
-        @model_validator(mode="after")
-        def validate_inputs(self: BaseModel) -> BaseModel:
-            """Validate the inputs provided to the VerifySnmpErrors test.
-
-            The valid SNMP error counter must be provided.
-            """
-            if self.error_counters:
-                for error_counter in self.error_counters:
-                    if error_counter not in SNMP_COUNTERS:
-                        msg = f"Invalid Error counter {error_counter}. Must be one of {SNMP_COUNTERS}."
-                        raise ValueError(msg)
-            return self
+        error_counters: list[SnmpErrorCounter] | None = None
+        """Optional list of SNMP error counters to be verified. If not provided, test will verifies all error counters."""
 
     @AntaTest.anta_test
     def test(self) -> None:
-        """Main test function for VerifySnmpErrors."""
+        """Main test function for VerifySnmpErrorCounters."""
         error_counters = self.inputs.error_counters
         command_output = self.instance_commands[0].json_output
 
         # Verify SNMP PDU counters.
         if not (snmp_counters := get_value(command_output, "counters")):
-            self.result.is_failure("SNMP counter details are not found.")
+            self.result.is_failure("SNMP counters not found.")
             return
 
         # In case SNMP error counters not provided, It will check all the error counters.
         if not error_counters:
-            error_counters = SNMP_COUNTERS
+            error_counters = list(get_args(SnmpErrorCounter))
 
         error_counters_not_ok = {counter: value for counter in error_counters if (value := snmp_counters.get(counter))}
 
@@ -319,4 +292,4 @@ class VerifySnmpErrors(AntaTest):
         if not error_counters_not_ok:
             self.result.is_success()
         else:
-            self.result.is_failure(f"The following SNMP error counter(s) are not found or have non-zero counter:\n{error_counters_not_ok}")
+            self.result.is_failure(f"The following SNMP error counters are not found or have non-zero error counters:\n{error_counters_not_ok}")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -398,7 +398,7 @@ anta.tests.snmp:
       location: New York
   - VerifySnmpContact:
       contact: Jon@example.com
-  - VerifySNMPErrors:
+  - VerifySnmpErrors:
       error_counters:
         - inVersionErrs
         - inBadCommunityNames

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -398,7 +398,7 @@ anta.tests.snmp:
       location: New York
   - VerifySnmpContact:
       contact: Jon@example.com
-  - VerifySnmpErrors:
+  - VerifySnmpErrorCounters:
       error_counters:
         - inVersionErrs
         - inBadCommunityNames

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -398,6 +398,10 @@ anta.tests.snmp:
       location: New York
   - VerifySnmpContact:
       contact: Jon@example.com
+  - VerifySNMPErrors:
+      error_counters:
+        - inVersionErrs
+        - inBadCommunityNames
 
 anta.tests.software:
   - VerifyEOSVersion:

--- a/tests/units/anta_tests/test_snmp.py
+++ b/tests/units/anta_tests/test_snmp.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from anta.tests.snmp import VerifySnmpContact, VerifySnmpIPv4Acl, VerifySnmpIPv6Acl, VerifySnmpLocation, VerifySnmpStatus
+from anta.tests.snmp import VerifySnmpContact, VerifySNMPErrors, VerifySnmpIPv4Acl, VerifySnmpIPv6Acl, VerifySnmpLocation, VerifySnmpStatus
 from tests.units.anta_tests import test
 
 DATA: list[dict[str, Any]] = [
@@ -150,6 +150,80 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": ["SNMP contact is not configured."],
+        },
+    },
+    {
+        "name": "success",
+        "test": VerifySNMPErrors,
+        "eos_data": [
+            {
+                "counters": {
+                    "inVersionErrs": 0,
+                    "inBadCommunityNames": 0,
+                    "inBadCommunityUses": 0,
+                    "inParseErrs": 0,
+                    "outTooBigErrs": 0,
+                    "outNoSuchNameErrs": 0,
+                    "outBadValueErrs": 0,
+                    "outGeneralErrs": 0,
+                },
+            }
+        ],
+        "inputs": {},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-specific-counters",
+        "test": VerifySNMPErrors,
+        "eos_data": [
+            {
+                "counters": {
+                    "inVersionErrs": 0,
+                    "inBadCommunityNames": 0,
+                    "inBadCommunityUses": 0,
+                    "inParseErrs": 0,
+                    "outTooBigErrs": 5,
+                    "outNoSuchNameErrs": 0,
+                    "outBadValueErrs": 10,
+                    "outGeneralErrs": 1,
+                },
+            }
+        ],
+        "inputs": {"error_counters": ["inVersionErrs", "inParseErrs"]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-counters-not-found",
+        "test": VerifySNMPErrors,
+        "eos_data": [
+            {
+                "counters": {},
+            }
+        ],
+        "inputs": {},
+        "expected": {"result": "failure", "messages": ["SNMP counter details not found."]},
+    },
+    {
+        "name": "failure-incorrect-counters",
+        "test": VerifySNMPErrors,
+        "eos_data": [
+            {
+                "counters": {
+                    "inVersionErrs": 1,
+                    "inBadCommunityNames": 0,
+                    "inBadCommunityUses": 0,
+                    "inParseErrs": 2,
+                    "outTooBigErrs": 0,
+                    "outNoSuchNameErrs": 0,
+                    "outBadValueErrs": 2,
+                    "outGeneralErrs": 0,
+                },
+            }
+        ],
+        "inputs": {},
+        "expected": {
+            "result": "failure",
+            "messages": ["The following SNMP error counter(s) are not found or have non-zero counter:\ninVersionErrs, inParseErrs, outBadValueErrs"],
         },
     },
 ]

--- a/tests/units/anta_tests/test_snmp.py
+++ b/tests/units/anta_tests/test_snmp.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from anta.tests.snmp import VerifySnmpContact, VerifySNMPErrors, VerifySnmpIPv4Acl, VerifySnmpIPv6Acl, VerifySnmpLocation, VerifySnmpStatus
+from anta.tests.snmp import VerifySnmpContact, VerifySnmpErrors, VerifySnmpIPv4Acl, VerifySnmpIPv6Acl, VerifySnmpLocation, VerifySnmpStatus
 from tests.units.anta_tests import test
 
 DATA: list[dict[str, Any]] = [
@@ -154,7 +154,7 @@ DATA: list[dict[str, Any]] = [
     },
     {
         "name": "success",
-        "test": VerifySNMPErrors,
+        "test": VerifySnmpErrors,
         "eos_data": [
             {
                 "counters": {
@@ -174,7 +174,7 @@ DATA: list[dict[str, Any]] = [
     },
     {
         "name": "success-specific-counters",
-        "test": VerifySNMPErrors,
+        "test": VerifySnmpErrors,
         "eos_data": [
             {
                 "counters": {
@@ -194,18 +194,18 @@ DATA: list[dict[str, Any]] = [
     },
     {
         "name": "failure-counters-not-found",
-        "test": VerifySNMPErrors,
+        "test": VerifySnmpErrors,
         "eos_data": [
             {
                 "counters": {},
             }
         ],
         "inputs": {},
-        "expected": {"result": "failure", "messages": ["SNMP counter details not found."]},
+        "expected": {"result": "failure", "messages": ["SNMP counter details are not found."]},
     },
     {
         "name": "failure-incorrect-counters",
-        "test": VerifySNMPErrors,
+        "test": VerifySnmpErrors,
         "eos_data": [
             {
                 "counters": {
@@ -223,7 +223,9 @@ DATA: list[dict[str, Any]] = [
         "inputs": {},
         "expected": {
             "result": "failure",
-            "messages": ["The following SNMP error counter(s) are not found or have non-zero counter:\ninVersionErrs, inParseErrs, outBadValueErrs"],
+            "messages": [
+                "The following SNMP error counter(s) are not found or have non-zero counter:\n{'inVersionErrs': 1, 'inParseErrs': 2, 'outBadValueErrs': 2}"
+            ],
         },
     },
 ]

--- a/tests/units/anta_tests/test_snmp.py
+++ b/tests/units/anta_tests/test_snmp.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from anta.tests.snmp import VerifySnmpContact, VerifySnmpErrors, VerifySnmpIPv4Acl, VerifySnmpIPv6Acl, VerifySnmpLocation, VerifySnmpStatus
+from anta.tests.snmp import VerifySnmpContact, VerifySnmpErrorCounters, VerifySnmpIPv4Acl, VerifySnmpIPv6Acl, VerifySnmpLocation, VerifySnmpStatus
 from tests.units.anta_tests import test
 
 DATA: list[dict[str, Any]] = [
@@ -154,7 +154,7 @@ DATA: list[dict[str, Any]] = [
     },
     {
         "name": "success",
-        "test": VerifySnmpErrors,
+        "test": VerifySnmpErrorCounters,
         "eos_data": [
             {
                 "counters": {
@@ -174,7 +174,7 @@ DATA: list[dict[str, Any]] = [
     },
     {
         "name": "success-specific-counters",
-        "test": VerifySnmpErrors,
+        "test": VerifySnmpErrorCounters,
         "eos_data": [
             {
                 "counters": {
@@ -194,18 +194,18 @@ DATA: list[dict[str, Any]] = [
     },
     {
         "name": "failure-counters-not-found",
-        "test": VerifySnmpErrors,
+        "test": VerifySnmpErrorCounters,
         "eos_data": [
             {
                 "counters": {},
             }
         ],
         "inputs": {},
-        "expected": {"result": "failure", "messages": ["SNMP counter details are not found."]},
+        "expected": {"result": "failure", "messages": ["SNMP counters not found."]},
     },
     {
         "name": "failure-incorrect-counters",
-        "test": VerifySnmpErrors,
+        "test": VerifySnmpErrorCounters,
         "eos_data": [
             {
                 "counters": {
@@ -224,7 +224,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "The following SNMP error counter(s) are not found or have non-zero counter:\n{'inVersionErrs': 1, 'inParseErrs': 2, 'outBadValueErrs': 2}"
+                "The following SNMP error counters are not found or have non-zero error counters:\n{'inVersionErrs': 1, 'inParseErrs': 2, 'outBadValueErrs': 2}"
             ],
         },
     },


### PR DESCRIPTION
# Description

Verifies the number of SNMP error counter(s) processed.

    By default, all  error counters will be checked for any non-zero values.
    An optional list of specific error counters can be provided for granular testing.

    Expected Results
    ----------------
    * Success: The test will pass if the SNMP error counter(s) are zero/None.
    * Failure: The test will fail if the SNMP error counter(s) are non-zero/not None/Not Found or is not configured.

Fixes #834 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
