### PR TITLE
ci: remove "0x000" calls in codspeed flame graphs

### DIFF
--- a/anta/runner.py
+++ b/anta/runner.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from anta import GITHUB_SUGGESTION
 from anta.logger import anta_log_exception, exc_to_str
 from anta.models import AntaTest
-from anta.tools import Catchtime, cprofile
+from anta.tools import Catchtime
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
@@ -207,7 +207,6 @@ def get_coroutines(selected_tests: defaultdict[AntaDevice, set[AntaTestDefinitio
     return coros
 
 
-@cprofile()
 async def main(  # noqa: PLR0913
     manager: ResultManager,
     inventory: AntaInventory,

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from anta import GITHUB_SUGGESTION
 from anta.logger import anta_log_exception, exc_to_str
 from anta.models import AntaTest
-from anta.tools import Catchtime
+from anta.tools import Catchtime, cprofile
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
@@ -207,6 +207,7 @@ def get_coroutines(selected_tests: defaultdict[AntaDevice, set[AntaTestDefinitio
     return coros
 
 
+@cprofile()
 async def main(  # noqa: PLR0913
     manager: ResultManager,
     inventory: AntaInventory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
   "pytest-cov>=4.1.0",
   "pytest-dependency",
   "pytest-codspeed>=2.2.0",
+  "pytest-benchmark",
   "respx",
   "pytest-html>=3.2.0",
   "pytest-httpx>=0.30.0",

--- a/tests/benchmark/test_anta.py
+++ b/tests/benchmark/test_anta.py
@@ -3,7 +3,6 @@
 # that can be found in the LICENSE file.
 """Benchmark tests for ANTA."""
 
-import asyncio
 import logging
 from unittest.mock import patch
 
@@ -30,19 +29,19 @@ logger = logging.getLogger(__name__)
     ],
     indirect=True,
 )
-def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
+async def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
     """Test and benchmark ANTA in Dry-Run Mode."""
     # Disable logging during ANTA execution to avoid having these function time in benchmarks
     logging.disable()
 
-    def bench() -> ResultManager:
+    async def bench() -> ResultManager:
         """Need to wrap the ANTA Runner to instantiate a new ResultManger for each benchmark run."""
         manager = ResultManager()
         catalog.clear_indexes()
-        asyncio.run(main(manager, inventory, catalog, dry_run=True))
+        await main(manager, inventory, catalog, dry_run=True)
         return manager
 
-    manager = benchmark(bench)
+    manager = await benchmark(bench)
 
     logging.disable(logging.NOTSET)
     if len(manager.results) != len(inventory) * len(catalog.tests):
@@ -62,19 +61,19 @@ def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, invento
 @patch("anta.models.AntaTest.collect", collect)
 @patch("anta.device.AntaDevice.collect_commands", collect_commands)
 @respx.mock  # Mock eAPI responses
-def test_anta(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
+async def test_anta(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
     """Test and benchmark ANTA. Mock eAPI responses."""
     # Disable logging during ANTA execution to avoid having these function time in benchmarks
     logging.disable()
 
-    def bench() -> ResultManager:
+    async def bench() -> ResultManager:
         """Need to wrap the ANTA Runner to instantiate a new ResultManger for each benchmark run."""
         manager = ResultManager()
         catalog.clear_indexes()
-        asyncio.run(main(manager, inventory, catalog))
+        await main(manager, inventory, catalog)
         return manager
 
-    manager = benchmark(bench)
+    manager = await benchmark(bench)
 
     logging.disable(logging.NOTSET)
 

--- a/tests/benchmark/test_anta.py
+++ b/tests/benchmark/test_anta.py
@@ -35,22 +35,12 @@ async def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, i
     # Disable logging during ANTA execution to avoid having these function time in benchmarks
     logging.disable()
 
-    manager = ResultManager()
-
-    async def bench() -> ResultManager:
+    @benchmark
+    async def _() -> None:
         """Need to wrap the ANTA Runner to instantiate a new ResultManger for each benchmark run and reset the catalog indexes."""
         manager = ResultManager()
         catalog.clear_indexes()
         await main(manager, inventory, catalog, dry_run=True)
-        return manager
-
-    manager = await benchmark(bench)
-
-    logging.disable(logging.NOTSET)
-    if len(manager.results) != len(inventory) * len(catalog.tests):
-        pytest.fail(f"Expected {len(inventory) * len(catalog.tests)} tests but got {len(manager.results)}", pytrace=False)
-    bench_info = "\n--- ANTA NRFU Dry-Run Benchmark Information ---\n" f"Test count: {len(manager.results)}\n" "-----------------------------------------------"
-    logger.info(bench_info)
 
 
 @pytest.mark.parametrize(

--- a/tests/benchmark/test_anta.py
+++ b/tests/benchmark/test_anta.py
@@ -39,8 +39,8 @@ def test_anta_dry_run(benchmark: BenchmarkFixture, event_loop: asyncio.AbstractE
         """Need to wrap the ANTA Runner to instantiate a new ResultManger for each benchmark run."""
         manager = ResultManager()
         catalog.clear_indexes()
-        event_loop.create_task(main(manager, inventory, catalog, dry_run=True), name="benchmark-anta-dry-run")
-        event_loop.run_forever()
+        t = event_loop.create_task(main(manager, inventory, catalog, dry_run=True), name="benchmark-anta-dry-run")
+        event_loop.run_until_complete(t)
         return manager
 
     manager = benchmark(bench)

--- a/tests/benchmark/test_anta.py
+++ b/tests/benchmark/test_anta.py
@@ -39,7 +39,8 @@ def test_anta_dry_run(benchmark: BenchmarkFixture, event_loop: asyncio.AbstractE
         """Need to wrap the ANTA Runner to instantiate a new ResultManger for each benchmark run."""
         manager = ResultManager()
         catalog.clear_indexes()
-        event_loop.run_until_complete(main(manager, inventory, catalog, dry_run=True))
+        event_loop.create_task(main(manager, inventory, catalog, dry_run=True), name="benchmark-anta-dry-run")
+        event_loop.run_forever()
         return manager
 
     manager = benchmark(bench)


### PR DESCRIPTION
# Description

Trying to remove "0x000" calls in codspeed flame graphs. See screenshot below:

<img width="850" alt="Screenshot 2024-10-07 at 16 44 01" src="https://github.com/user-attachments/assets/c44e5d08-707d-4f8d-8e5f-437bcc14acd3">

They seem to represent an asyncio task.
The name "0x00" changes between benchmarks and prevent comparing code within the asyncio task.
Tried to name the task using https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_task but it did not work.

<!-- Delete not relevant items !-->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)
