### PR TITLE
feat(anta)!: Use HTTP HEAD request instead of a TCP connection to check if device is online

### DIFF
--- a/anta/device.py
+++ b/anta/device.py
@@ -539,12 +539,17 @@ class AsyncEOSDevice(AntaDevice):
         """Update attributes of an AsyncEOSDevice instance.
 
         This coroutine must update the following attributes of AsyncEOSDevice:
-        - is_online: When a device IP is reachable and a port can be open
+        - is_online: When a device eAPI HTTP endpoint is accessible
         - established: When a command execution succeeds
         - hw_model: The hardware model of the device
         """
         logger.debug("Refreshing device %s", self.name)
-        self.is_online = await self._session.check_connection()
+        try:
+            self.is_online = await self._session.check_api_endpoint()
+        except HTTPError as e:
+            self.is_online = False
+            logger.warning("Could not connect to device %s: %s", self.name, e)
+
         if self.is_online:
             show_version = AntaCommand(command="show version")
             await self._collect(show_version)
@@ -558,8 +563,6 @@ class AsyncEOSDevice(AntaDevice):
                 # and it is nice to get a meaninfule error message
                 elif self.hw_model == "":
                     logger.critical("Got an empty 'modelName' in the 'show version' returned by device %s", self.name)
-        else:
-            logger.warning("Could not connect to device %s: cannot open eAPI port", self.name)
 
         self.established = bool(self.is_online and self.hw_model)
 

--- a/tests/units/cli/conftest.py
+++ b/tests/units/cli/conftest.py
@@ -123,7 +123,7 @@ def click_runner(capsys: pytest.CaptureFixture[str], anta_env: dict[str, str]) -
 
     # Patch asynceapi methods used by AsyncEOSDevice. See tests/units/test_device.py
     with (
-        patch("asynceapi.device.Device.check_connection", return_value=True),
+        patch("asynceapi.device.Device.check_api_endpoint", return_value=True),
         patch("asynceapi.device.Device.cli", side_effect=cli),
         patch("asyncssh.connect"),
         patch(

--- a/tests/units/test_device.py
+++ b/tests/units/test_device.py
@@ -429,29 +429,8 @@ REFRESH_PARAMS: list[ParameterSet] = [
     pytest.param(
         {},
         (
-            {"return_value": False},
-            {
-                "return_value": {
-                    "mfgName": "Arista",
-                    "modelName": "DCS-7280CR3-32P4-F",
-                    "hardwareRevision": "11.00",
-                    "serialNumber": "JPE19500066",
-                    "systemMacAddress": "fc:bd:67:3d:13:c5",
-                    "hwMacAddress": "fc:bd:67:3d:13:c5",
-                    "configMacAddress": "00:00:00:00:00:00",
-                    "version": "4.31.1F-34361447.fraserrel (engineering build)",
-                    "architecture": "x86_64",
-                    "internalVersion": "4.31.1F-34361447.fraserrel",
-                    "internalBuildId": "4940d112-a2fc-4970-8b5a-a16cd03fd08c",
-                    "imageFormatVersion": "3.0",
-                    "imageOptimization": "Default",
-                    "bootupTimestamp": 1700729434.5892005,
-                    "uptime": 20666.78,
-                    "memTotal": 8099732,
-                    "memFree": 4989568,
-                    "isIntlVersion": False,
-                }
-            },
+            {"side_effect": HTTPError(message="Unauthorized")},
+            {},
         ),
         {"is_online": False, "established": False, "hw_model": None},
         id="is not online",
@@ -655,7 +634,7 @@ class TestAsyncEOSDevice:
         """Test AsyncEOSDevice.refresh()."""
         with patch.object(async_device._session, "check_connection", **patch_kwargs[0]), patch.object(async_device._session, "cli", **patch_kwargs[1]):
             await async_device.refresh()
-            async_device._session.check_connection.assert_called_once()  # type: ignore[attr-defined] # asynceapi.Device.check_connection is patched
+            async_device._session.check_api_endpoint.assert_called_once()  # type: ignore[attr-defined] # asynceapi.Device.check_connection is patched
             if expected["is_online"]:
                 async_device._session.cli.assert_called_once()  # type: ignore[attr-defined] # asynceapi.Device.cli is patched
             assert async_device.is_online == expected["is_online"]

--- a/tests/units/test_device.py
+++ b/tests/units/test_device.py
@@ -632,9 +632,9 @@ class TestAsyncEOSDevice:
     )
     async def test_refresh(self, async_device: AsyncEOSDevice, patch_kwargs: list[dict[str, Any]], expected: dict[str, Any]) -> None:
         """Test AsyncEOSDevice.refresh()."""
-        with patch.object(async_device._session, "check_connection", **patch_kwargs[0]), patch.object(async_device._session, "cli", **patch_kwargs[1]):
+        with patch.object(async_device._session, "check_api_endpoint", **patch_kwargs[0]), patch.object(async_device._session, "cli", **patch_kwargs[1]):
             await async_device.refresh()
-            async_device._session.check_api_endpoint.assert_called_once()  # type: ignore[attr-defined] # asynceapi.Device.check_connection is patched
+            async_device._session.check_api_endpoint.assert_called_once()  # type: ignore[attr-defined] # asynceapi.Device.check_api_endpoint is patched
             if expected["is_online"]:
                 async_device._session.cli.assert_called_once()  # type: ignore[attr-defined] # asynceapi.Device.cli is patched
             assert async_device.is_online == expected["is_online"]


### PR DESCRIPTION
# Description

Use HTTP HEAD request to check connection to a device instead of pure L3 check.
This allows to check connectivity on devices behind a reverse proxy, so rather than checking the reverse proxy is alive using HTTP the request will be forwarded to the right device.

The change is as close to the original as possible, but we could potentially check if the credentials are correct as well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
