### PR TITLE
ci: add prepare_tests and get_coroutines benchmarks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,14 @@
 {
   "ruff.enable": true,
   "ruff.configuration": "pyproject.toml",
-  "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": [
     "tests"
   ],
-  "python.languageServer": "Pylance",
   "githubIssues.issueBranchTitle": "issues/${issueNumber}-${issueTitle}",
-  "editor.formatOnPaste": true,
-  "files.trimTrailingWhitespace": true,
-  "workbench.remoteIndicator.showExtensionRecommendations": true,
+  "pylint.importStrategy": "fromEnvironment",
+  "pylint.args": [
+    "--rcfile=pyproject.toml"
+  ],
 
 }

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -38,3 +38,16 @@ def catalog(anta_mock_env: AntaMockEnvironment) -> AntaCatalog:
 def pytest_terminal_summary(terminalreporter: TerminalReporter) -> None:
     """Display the total number of ANTA unit test cases used to benchmark."""
     terminalreporter.write_sep("=", f"{TEST_CASE_COUNT} ANTA test cases")
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Paranetrize inventory for benchmark tests."""
+    if "inventory" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "inventory",
+            [
+                pytest.param({"count": 1, "disable_cache": True, "reachable": True}, id="1-device"),
+                pytest.param({"count": 2, "disable_cache": True, "reachable": True}, id="2-devices"),
+            ],
+            indirect=True,
+        )

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -43,6 +43,10 @@ def pytest_terminal_summary(terminalreporter: TerminalReporter) -> None:
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Paranetrize inventory for benchmark tests."""
     if "inventory" in metafunc.fixturenames:
+        for marker in metafunc.definition.iter_markers(name="parametrize"):
+            if "inventory" in marker.args[0]:
+                # Do not override test function parametrize marker for inventory arg
+                return
         metafunc.parametrize(
             "inventory",
             [

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -41,7 +41,7 @@ def pytest_terminal_summary(terminalreporter: TerminalReporter) -> None:
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
-    """Paranetrize inventory for benchmark tests."""
+    """Parametrize inventory for benchmark tests."""
     if "inventory" in metafunc.fixturenames:
         for marker in metafunc.definition.iter_markers(name="parametrize"):
             if "inventory" in marker.args[0]:

--- a/tests/benchmark/test_anta.py
+++ b/tests/benchmark/test_anta.py
@@ -22,19 +22,18 @@ from .utils import collect, collect_commands
 logger = logging.getLogger(__name__)
 
 
-def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
-    """Test and benchmark ANTA in Dry-Run Mode."""
+def test_anta_dry_run(benchmark: BenchmarkFixture, event_loop: asyncio.AbstractEventLoop, catalog: AntaCatalog, inventory: AntaInventory) -> None:
+    """Benchmark ANTA in Dry-Run Mode."""
     # Disable logging during ANTA execution to avoid having these function time in benchmarks
     logging.disable()
 
-    def bench() -> ResultManager:
-        """Need to wrap the ANTA Runner to instantiate a new ResultManger for each benchmark run."""
+    def _() -> ResultManager:
         manager = ResultManager()
         catalog.clear_indexes()
-        asyncio.run(main(manager, inventory, catalog, dry_run=True))
+        event_loop.run_until_complete(main(manager, inventory, catalog, dry_run=True))
         return manager
 
-    manager = benchmark(bench)
+    manager = benchmark(_)
 
     logging.disable(logging.NOTSET)
     if len(manager.results) != len(inventory) * len(catalog.tests):
@@ -46,19 +45,18 @@ def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, invento
 @patch("anta.models.AntaTest.collect", collect)
 @patch("anta.device.AntaDevice.collect_commands", collect_commands)
 @respx.mock  # Mock eAPI responses
-def test_anta(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
-    """Test and benchmark ANTA. Mock eAPI responses."""
+def test_anta(benchmark: BenchmarkFixture, event_loop: asyncio.AbstractEventLoop, catalog: AntaCatalog, inventory: AntaInventory) -> None:
+    """Benchmark ANTA."""
     # Disable logging during ANTA execution to avoid having these function time in benchmarks
     logging.disable()
 
-    def bench() -> ResultManager:
-        """Need to wrap the ANTA Runner to instantiate a new ResultManger for each benchmark run."""
+    def _() -> ResultManager:
         manager = ResultManager()
         catalog.clear_indexes()
-        asyncio.run(main(manager, inventory, catalog))
+        event_loop.run_until_complete(main(manager, inventory, catalog))
         return manager
 
-    manager = benchmark(bench)
+    manager = benchmark(_)
 
     logging.disable(logging.NOTSET)
 

--- a/tests/benchmark/test_anta.py
+++ b/tests/benchmark/test_anta.py
@@ -22,14 +22,6 @@ from .utils import collect, collect_commands
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize(
-    "inventory",
-    [
-        pytest.param({"count": 1, "disable_cache": True, "reachable": False}, id="1 device"),
-        pytest.param({"count": 2, "disable_cache": True, "reachable": False}, id="2 devices"),
-    ],
-    indirect=True,
-)
 def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
     """Test and benchmark ANTA in Dry-Run Mode."""
     # Disable logging during ANTA execution to avoid having these function time in benchmarks
@@ -51,14 +43,6 @@ def test_anta_dry_run(benchmark: BenchmarkFixture, catalog: AntaCatalog, invento
     logger.info(bench_info)
 
 
-@pytest.mark.parametrize(
-    "inventory",
-    [
-        pytest.param({"count": 1, "disable_cache": True}, id="1 device"),
-        pytest.param({"count": 2, "disable_cache": True}, id="2 devices"),
-    ],
-    indirect=True,
-)
 @patch("anta.models.AntaTest.collect", collect)
 @patch("anta.device.AntaDevice.collect_commands", collect_commands)
 @respx.mock  # Mock eAPI responses

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Benchmark tests for anta.runner."""
+
+import logging
+
+from pytest_codspeed import BenchmarkFixture
+
+from anta.catalog import AntaCatalog
+from anta.inventory import AntaInventory
+from anta.result_manager import ResultManager
+from anta.runner import get_coroutines, prepare_tests
+
+
+def test_prepare_tests(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
+    """Test and benchmark ANTA in Dry-Run Mode."""
+    # Disable logging during ANTA execution to avoid having these function time in benchmarks
+    logging.disable()
+
+    selected_tests = benchmark(lambda: prepare_tests(inventory=inventory, catalog=catalog, tests=None, tags=None))
+
+    assert selected_tests is not None
+    assert len(selected_tests) == len(inventory)
+    assert sum(len(tests) for tests in selected_tests.values()) == len(inventory) * len(catalog.tests)
+
+
+def test_get_coroutines(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
+    """Test and benchmark ANTA in Dry-Run Mode."""
+    # Disable logging during ANTA execution to avoid having these function time in benchmarks
+    logging.disable()
+
+    selected_tests = prepare_tests(inventory=inventory, catalog=catalog, tests=None, tags=None)
+
+    assert selected_tests is not None
+    manager = ResultManager()
+    coroutines = benchmark(lambda: get_coroutines(selected_tests=selected_tests, manager=manager))
+    for coros in coroutines:
+        coros.close()
+
+    count = sum(len(tests) for tests in selected_tests.values())
+    assert count == len(coroutines) == len(manager.results)

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -5,31 +5,29 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from anta.result_manager import ResultManager
 from anta.runner import get_coroutines, prepare_tests
 
 if TYPE_CHECKING:
     from collections import defaultdict
-    from collections.abc import Coroutine
 
     from pytest_codspeed import BenchmarkFixture
 
     from anta.catalog import AntaCatalog, AntaTestDefinition
     from anta.device import AntaDevice
     from anta.inventory import AntaInventory
-    from anta.result_manager.models import TestResult
 
 
 def test_prepare_tests(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
     """Benchmark `anta.runner.prepare_tests`."""
 
-    def bench() -> defaultdict[AntaDevice, set[AntaTestDefinition]] | None:
+    def _() -> defaultdict[AntaDevice, set[AntaTestDefinition]] | None:
         catalog.clear_indexes()
         return prepare_tests(inventory=inventory, catalog=catalog, tests=None, tags=None)
 
-    selected_tests = benchmark(bench)
+    selected_tests = benchmark(_)
 
     assert selected_tests is not None
     assert len(selected_tests) == len(inventory)
@@ -42,10 +40,7 @@ def test_get_coroutines(benchmark: BenchmarkFixture, catalog: AntaCatalog, inven
 
     assert selected_tests is not None
 
-    def bench() -> list[Coroutine[Any, Any, TestResult]]:
-        return get_coroutines(selected_tests=selected_tests, manager=ResultManager())
-
-    coroutines = benchmark(bench)
+    coroutines = benchmark(lambda: get_coroutines(selected_tests=selected_tests, manager=ResultManager()))
     for coros in coroutines:
         coros.close()
 

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -3,22 +3,31 @@
 # that can be found in the LICENSE file.
 """Benchmark tests for anta.runner."""
 
-import logging
+from __future__ import annotations
 
-from pytest_codspeed import BenchmarkFixture
+from typing import TYPE_CHECKING
 
-from anta.catalog import AntaCatalog
-from anta.inventory import AntaInventory
 from anta.result_manager import ResultManager
 from anta.runner import get_coroutines, prepare_tests
 
+if TYPE_CHECKING:
+    from collections import defaultdict
+
+    from pytest_codspeed import BenchmarkFixture
+
+    from anta.catalog import AntaCatalog, AntaTestDefinition
+    from anta.device import AntaDevice
+    from anta.inventory import AntaInventory
+
 
 def test_prepare_tests(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
-    """Test and benchmark ANTA in Dry-Run Mode."""
-    # Disable logging during ANTA execution to avoid having these function time in benchmarks
-    logging.disable()
+    """Benchmark `anta.runner.prepare_tests`."""
 
-    selected_tests = benchmark(lambda: prepare_tests(inventory=inventory, catalog=catalog, tests=None, tags=None))
+    def bench() -> defaultdict[AntaDevice, set[AntaTestDefinition]] | None:
+        catalog.clear_indexes()
+        return prepare_tests(inventory=inventory, catalog=catalog, tests=None, tags=None)
+
+    selected_tests = benchmark(bench)
 
     assert selected_tests is not None
     assert len(selected_tests) == len(inventory)
@@ -26,10 +35,7 @@ def test_prepare_tests(benchmark: BenchmarkFixture, catalog: AntaCatalog, invent
 
 
 def test_get_coroutines(benchmark: BenchmarkFixture, catalog: AntaCatalog, inventory: AntaInventory) -> None:
-    """Test and benchmark ANTA in Dry-Run Mode."""
-    # Disable logging during ANTA execution to avoid having these function time in benchmarks
-    logging.disable()
-
+    """Benchmark `anta.runner.get_coroutines`."""
     selected_tests = prepare_tests(inventory=inventory, catalog=catalog, tests=None, tags=None)
 
     assert selected_tests is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from anta.inventory import AntaInventory
 DATA_DIR: Path = Path(__file__).parent.resolve() / "data"
 
 
-@pytest.fixture(params=[{"count": 1}], ids=["1-reachable-device-without-cache"])
+@pytest.fixture
 def inventory(request: pytest.FixtureRequest) -> Iterator[AntaInventory]:
     """Generate an ANTA inventory."""
     user = "admin"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,13 +22,15 @@ def inventory(request: pytest.FixtureRequest) -> Iterator[AntaInventory]:
     """Generate an ANTA inventory."""
     user = "admin"
     password = "password"  # noqa: S105
-    disable_cache = request.param.get("disable_cache", True)
-    reachable = request.param.get("reachable", True)
-    if "filename" in request.param:
-        inv = AntaInventory.parse(DATA_DIR / request.param["filename"], username=user, password=password, disable_cache=disable_cache)
+    params = request.param if hasattr(request, "param") else {}
+    count = params.get("count", 1)
+    disable_cache = params.get("disable_cache", True)
+    reachable = params.get("reachable", True)
+    if "filename" in params:
+        inv = AntaInventory.parse(DATA_DIR / params["filename"], username=user, password=password, disable_cache=disable_cache)
     else:
         inv = AntaInventory()
-        for i in range(request.param["count"]):
+        for i in range(count):
             inv.add_device(
                 AsyncEOSDevice(
                     host=f"device-{i}.anta.arista.com",

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -83,15 +83,3 @@ def yaml_file(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
     content: dict[str, Any] = request.param
     file.write_text(yaml.dump(content, allow_unicode=True))
     return file
-
-
-def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
-    """Paranetrize inventory for unit tests."""
-    if "inventory" in metafunc.fixturenames:
-        metafunc.parametrize(
-            "inventory",
-            [
-                pytest.param({"count": 1, "disable_cache": True, "reachable": True}, id="1-reachable-device-without-cache"),
-            ],
-            indirect=True,
-        )

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -83,3 +83,15 @@ def yaml_file(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
     content: dict[str, Any] = request.param
     file.write_text(yaml.dump(content, allow_unicode=True))
     return file
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    """Paranetrize inventory for unit tests."""
+    if "inventory" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "inventory",
+            [
+                pytest.param({"count": 1, "disable_cache": True, "reachable": True}, id="1-reachable-device-without-cache"),
+            ],
+            indirect=True,
+        )


### PR DESCRIPTION
# Description

Add benchmarks for synchronous functions `anta.runner.get_coroutines` and `anta.runner.prepare_tests`.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
