### PR TITLE
fix(anta.cli): Disable env variable for --help and --version

### DIFF
--- a/anta/cli/_main.py
+++ b/anta/cli/_main.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 
 @click.group(cls=AliasedGroup)
 @click.pass_context
-@click.version_option(__version__)
+@click.help_option(allow_from_autoenv=False)
+@click.version_option(__version__, allow_from_autoenv=False)
 @click.option(
     "--log-file",
     help="Send the logs to a file. If logging level is DEBUG, only INFO or higher will be sent to stdout.",


### PR DESCRIPTION
# Description

without this we get

```
ANTA_VERSION=42 anta get tags

Usage: anta [OPTIONS] COMMAND [ARGS]...
Try 'anta --help' for help.

Error: Invalid value for '--version': '42' is not a valid boolean.


ANTA_HELP=42 anta get tags
Usage: anta [OPTIONS] COMMAND [ARGS]...
Try 'anta --help' for help.

Error: Invalid value for '--help': '42' is not a valid boolean.
```

Fixes #868

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
