### PR TITLE
fix(anta.tests): Fix VerifySSHStatus to support 4.32 text output

### DIFF
--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -57,7 +57,7 @@ class VerifySSHStatus(AntaTest):
         except StopIteration:
             self.result.is_failure("Could not find SSH status in returned output.")
             return
-        status = line.split("is ")[1]
+        status = line.split()[-1]
 
         if status == "disabled":
             self.result.is_success()

--- a/tests/units/anta_tests/test_security.py
+++ b/tests/units/anta_tests/test_security.py
@@ -45,11 +45,31 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "failure", "messages": ["Could not find SSH status in returned output."]},
     },
     {
-        "name": "failure-ssh-disabled",
+        "name": "failure-ssh-enabled",
         "test": VerifySSHStatus,
         "eos_data": ["SSHD status for Default VRF is enabled\nSSH connection limit is 50\nSSH per host connection limit is 20\nFIPS status: disabled\n\n"],
         "inputs": None,
         "expected": {"result": "failure", "messages": ["SSHD status for Default VRF is enabled"]},
+    },
+    {
+        "name": "success-4.32",
+        "test": VerifySSHStatus,
+        "eos_data": [
+            "User certificate authentication methods: none (neither trusted CA nor SSL profile configured)\n"
+            "SSHD status for Default VRF: disabled\nSSH connection limit: 50\nSSH per host connection limit: 20\nFIPS status: disabled\n\n"
+        ],
+        "inputs": None,
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-ssh-enabled-4.32",
+        "test": VerifySSHStatus,
+        "eos_data": [
+            "User certificate authentication methods: none (neither trusted CA nor SSL profile configured)\n"
+            "SSHD status for Default VRF: enabled\nSSH connection limit: 50\nSSH per host connection limit: 20\nFIPS status: disabled\n\n"
+        ],
+        "inputs": None,
+        "expected": {"result": "failure", "messages": ["SSHD status for Default VRF: enabled"]},
     },
     {
         "name": "success",


### PR DESCRIPTION
# Description

EOS 4.32 changed the text output of `show management ssh`, breaking our existing logic. New logic handles both pre and post 4.32 outputs.

Fixes # (issue id)

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
