### PR TITLE
fix(anta.cli): Print multiple messages for anta nrfu text

### DIFF
--- a/anta/cli/nrfu/utils.py
+++ b/anta/cli/nrfu/utils.py
@@ -116,8 +116,12 @@ def print_text(ctx: click.Context) -> None:
     """Print results as simple text."""
     console.print()
     for test in _get_result_manager(ctx).results:
-        message = f" ({test.messages[0]!s})" if len(test.messages) > 0 else ""
-        console.print(f"{test.name} :: {test.test} :: [{test.result}]{test.result.upper()}[/{test.result}]{message}", highlight=False)
+        if len(test.messages) <= 1:
+            message = test.messages[0] if len(test.messages) == 1 else ""
+            console.print(f"{test.name} :: {test.test} :: [{test.result}]{test.result.upper()}[/{test.result}]({message})", highlight=False)
+        else:  # len(test.messages) > 1
+            console.print(f"{test.name} :: {test.test} :: [{test.result}]{test.result.upper()}[/{test.result}]", highlight=False)
+            console.print("\n".join(f"    {message}" for message in test.messages), highlight=False)
 
 
 def print_jinja(results: ResultManager, template: pathlib.Path, output: pathlib.Path | None = None) -> None:

--- a/tests/data/test_catalog_double_failure.yml
+++ b/tests/data/test_catalog_double_failure.yml
@@ -1,0 +1,13 @@
+---
+anta.tests.interfaces:
+  - VerifyInterfacesSpeed:
+      interfaces:
+        - name: Ethernet2
+          auto: False
+          speed: 10
+        - name: Ethernet3
+          auto: True
+          speed: 100
+        - name: Ethernet4
+          auto: False
+          speed: 2.5

--- a/tests/units/cli/conftest.py
+++ b/tests/units/cli/conftest.py
@@ -39,6 +39,7 @@ MOCK_CLI_JSON: dict[str, asynceapi.EapiCommandError | dict[str, Any]] = {
         errmsg="Invalid command",
         not_exec=[],
     ),
+    "show interfaces": {},
 }
 
 MOCK_CLI_TEXT: dict[str, asynceapi.EapiCommandError | str] = {

--- a/tests/units/cli/nrfu/test_commands.py
+++ b/tests/units/cli/nrfu/test_commands.py
@@ -76,6 +76,19 @@ def test_anta_nrfu_text(click_runner: CliRunner) -> None:
     assert "leaf1 :: VerifyEOSVersion :: SUCCESS" in result.output
 
 
+def test_anta_nrfu_text_multiple_failures(click_runner: CliRunner) -> None:
+    """Test anta nrfu text with multiple failures, catalog is given via env."""
+    result = click_runner.invoke(anta, ["nrfu", "text"], env={"ANTA_CATALOG": str(DATA_DIR / "test_catalog_double_failure.yml")})
+    assert result.exit_code == ExitCode.OK
+    assert (
+        """spine1 :: VerifyInterfacesSpeed :: FAILURE
+    Interface `Ethernet2` is not found.
+    Interface `Ethernet3` is not found.
+    Interface `Ethernet4` is not found."""
+        in result.output
+    )
+
+
 def test_anta_nrfu_json(click_runner: CliRunner) -> None:
     """Test anta nrfu, catalog is given via env."""
     result = click_runner.invoke(anta, ["nrfu", "json"])


### PR DESCRIPTION
# Description

Print multiple messages in text output when present

```
leaf1 :: VerifyInterfacesSpeed :: FAILURE
    Interface `Ethernet2` is not found.
    Interface `Ethernet3` is not found.
    Interface `Ethernet4` is not found.
```

Fixes #895

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
