### PR TITLE
fix(anta.tests): Fix VerifyNTPAssociations to support IP-DNS peers

### DIFF
--- a/anta/input_models/__init__.py
+++ b/anta/input_models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Package related to all ANTA tests input models."""

--- a/anta/input_models/system.py
+++ b/anta/input_models/system.py
@@ -3,6 +3,8 @@
 # that can be found in the LICENSE file.
 """Module containing input models for system tests."""
 
+from __future__ import annotations
+
 from ipaddress import IPv4Address
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/anta/input_models/system.py
+++ b/anta/input_models/system.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Module containing input models for system tests."""
+
+from ipaddress import IPv4Address
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from anta.custom_types import Hostname
+
+
+class NTPServer(BaseModel):
+    """Model for a NTP server."""
+
+    model_config = ConfigDict(extra="forbid")
+    server_address: Hostname | IPv4Address
+    """The NTP server address as an IPv4 address or hostname. The NTP server name defined in the running configuration
+    of the device may change during DNS resolution, which is not handled in ANTA. Please provide the DNS-resolved server name.
+    For example, 'ntp.example.com' in the configuration might resolve to 'ntp3.example.com' in the device output."""
+    preferred: bool = False
+    """Optional preferred for NTP server. If not provided, it defaults to `False`."""
+    stratum: int = Field(ge=0, le=16)
+    """NTP stratum level (0 to 15) where 0 is the reference clock and 16 indicates unsynchronized.
+    Values should be between 0 and 15 for valid synchronization and 16 represents an out-of-sync state."""
+
+    def __str__(self) -> str:
+        """Representation of the NTPServer model."""
+        return f"{self.server_address} (Preferred: {self.preferred}, Stratum: {self.stratum})"

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -366,15 +366,15 @@ class VerifyNTPAssociations(AntaTest):
         for ntp_server in self.inputs.ntp_servers:
             server_address = str(ntp_server.server_address)
 
-            # Collecting the expected NTP peer details.
-            expected_peer_details = {"condition": "sys.peer" if ntp_server.preferred else "candidate", "stratum": ntp_server.stratum}
-
             # Check if NTP server details exists.
             matching_peer = next((peer for peer in peer_details if server_address in peer), None)
 
             if not matching_peer:
                 failures += f"NTP peer {server_address} is not configured.\n"
                 continue
+
+            # Collecting the expected NTP peer details.
+            expected_peer_details = {"condition": "sys.peer" if ntp_server.preferred else "candidate", "stratum": ntp_server.stratum}
 
             # Collecting the actual NTP peer details.
             actual_peer_details = {

--- a/docs/api/tests.system.md
+++ b/docs/api/tests.system.md
@@ -7,6 +7,8 @@ anta_title: ANTA catalog for System tests
   ~ that can be found in the LICENSE file.
   -->
 
+# Tests
+
 ::: anta.tests.system
     options:
       show_root_heading: false
@@ -18,3 +20,15 @@ anta_title: ANTA catalog for System tests
       filters:
         - "!test"
         - "!render"
+
+# Input models
+
+::: anta.input_models.system
+
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false
+      show_bases: false
+      anta_hide_test_module_description: true
+      show_labels: true
+      filters: ["!^__str__"]

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -347,6 +347,39 @@ poll interval unknown
         "expected": {"result": "success"},
     },
     {
+        "name": "success-ip-dns",
+        "test": VerifyNTPAssociations,
+        "eos_data": [
+            {
+                "peers": {
+                    "1.1.1.1 (1.ntp.networks.com)": {
+                        "condition": "sys.peer",
+                        "peerIpAddr": "1.1.1.1",
+                        "stratumLevel": 1,
+                    },
+                    "2.2.2.2 (2.ntp.networks.com)": {
+                        "condition": "candidate",
+                        "peerIpAddr": "2.2.2.2",
+                        "stratumLevel": 2,
+                    },
+                    "3.3.3.3 (3.ntp.networks.com)": {
+                        "condition": "candidate",
+                        "peerIpAddr": "3.3.3.3",
+                        "stratumLevel": 2,
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "ntp_servers": [
+                {"server_address": "1.1.1.1", "preferred": True, "stratum": 1},
+                {"server_address": "2.2.2.2", "stratum": 2},
+                {"server_address": "3.3.3.3", "stratum": 2},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure",
         "test": VerifyNTPAssociations,
         "eos_data": [

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -413,9 +413,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "For NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\nExpected `1` as the stratum, but found `2` instead.\n"
-                "For NTP peer 2.2.2.2:\nExpected `candidate` as the condition, but found `sys.peer` instead.\n"
-                "For NTP peer 3.3.3.3:\nExpected `candidate` as the condition, but found `sys.peer` instead.\nExpected `2` as the stratum, but found `3` instead."
+                "1.1.1.1 (Preferred: True, Stratum: 1) - Bad association; Condition: candidate, Stratum: 2",
+                "2.2.2.2 (Preferred: False, Stratum: 2) - Bad association; Condition: sys.peer, Stratum: 2",
+                "3.3.3.3 (Preferred: False, Stratum: 2) - Bad association; Condition: sys.peer, Stratum: 3",
             ],
         },
     },
@@ -432,7 +432,7 @@ poll interval unknown
         },
         "expected": {
             "result": "failure",
-            "messages": ["None of NTP peers are not configured."],
+            "messages": ["No NTP peers configured"],
         },
     },
     {
@@ -463,7 +463,7 @@ poll interval unknown
         },
         "expected": {
             "result": "failure",
-            "messages": ["NTP peer 3.3.3.3 is not configured."],
+            "messages": ["3.3.3.3 (Preferred: False, Stratum: 1) - Not configured"],
         },
     },
     {
@@ -490,8 +490,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "For NTP peer 1.1.1.1:\nExpected `sys.peer` as the condition, but found `candidate` instead.\n"
-                "NTP peer 2.2.2.2 is not configured.\nNTP peer 3.3.3.3 is not configured."
+                "1.1.1.1 (Preferred: True, Stratum: 1) - Bad association; Condition: candidate, Stratum: 1",
+                "2.2.2.2 (Preferred: False, Stratum: 1) - Not configured",
+                "3.3.3.3 (Preferred: False, Stratum: 1) - Not configured",
             ],
         },
     },


### PR DESCRIPTION
# Description

Update VerifyNTPAssociations test to support IP-DNS peers in the JSON output. We now check if the provided NTP server IP or DNS is matching either the peer key or `peerIpAddr` in the details.

Fixes #900 

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
