### PR TITLE
fix(anta)!: Fix tags behavior to reflect the documentation

### DIFF
--- a/anta/runner.py
+++ b/anta/runner.py
@@ -149,17 +149,20 @@ def prepare_tests(
     # Create the device to tests mapping from the tags
     for device in inventory.devices:
         if tags:
-            if not any(tag in device.tags for tag in tags):
+            # If there are CLI tags, execute tests with matching tags for this device
+            matching_tags = tags.intersection(device.tags)
+            if not matching_tags:
                 # The device does not have any selected tag, skipping
                 continue
+            device_to_tests[device].update(catalog.get_tests_by_tags(matching_tags))
         else:
             # If there is no CLI tags, execute all tests that do not have any tags
             device_to_tests[device].update(catalog.tag_to_tests[None])
 
-        # Add the tests with matching tags from device tags
-        device_to_tests[device].update(catalog.get_tests_by_tags(device.tags))
+            # Then add the tests with matching tags from device tags
+            device_to_tests[device].update(catalog.get_tests_by_tags(device.tags))
 
-    if len(device_to_tests.values()) == 0:
+    if sum(len(tests) for tests in device_to_tests.values()) == 0:
         msg = (
             f"There are no tests{f' matching the tags {tags} ' if tags else ' '}to run in the current test catalog and device inventory, please verify your inputs."
         )

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -152,8 +152,7 @@ def prepare_tests(
     for device in inventory.devices:
         if tags:
             # If there are CLI tags, execute tests with matching tags for this device
-            matching_tags = tags.intersection(device.tags)
-            if not matching_tags:
+            if not (matching_tags := tags.intersection(device.tags)):
                 # The device does not have any selected tag, skipping
                 continue
             device_to_tests[device].update(catalog.get_tests_by_tags(matching_tags))

--- a/anta/runner.py
+++ b/anta/runner.py
@@ -146,6 +146,8 @@ def prepare_tests(
     # Using a set to avoid inserting duplicate tests
     device_to_tests: defaultdict[AntaDevice, set[AntaTestDefinition]] = defaultdict(set)
 
+    total_test_count = 0
+
     # Create the device to tests mapping from the tags
     for device in inventory.devices:
         if tags:
@@ -162,7 +164,9 @@ def prepare_tests(
             # Then add the tests with matching tags from device tags
             device_to_tests[device].update(catalog.get_tests_by_tags(device.tags))
 
-    if sum(len(tests) for tests in device_to_tests.values()) == 0:
+        total_test_count += len(device_to_tests[device])
+
+    if total_test_count == 0:
         msg = (
             f"There are no tests{f' matching the tags {tags} ' if tags else ' '}to run in the current test catalog and device inventory, please verify your inputs."
         )

--- a/docs/cli/tag-management.md
+++ b/docs/cli/tag-management.md
@@ -4,9 +4,7 @@
   ~ that can be found in the LICENSE file.
   -->
 
-ANTA commands can be used with a `--tags` option. This option **filters the inventory** with the specified tag(s) when running the command.
-
-Tags can also be used to **restrict a specific test** to a set of devices when using `anta nrfu`.
+ANTA uses tags to define test-to-device mappings (tests run on devices with matching tags) and the `--tags` CLI option acts as a filter to execute specific test/device combinations.
 
 ## Defining tags
 

--- a/tests/data/test_inventory_with_tags.yml
+++ b/tests/data/test_inventory_with_tags.yml
@@ -3,7 +3,7 @@ anta_inventory:
   hosts:
     - name: leaf1
       host: leaf1.anta.arista.com
-      tags: ["leaf"]
+      tags: ["leaf", "dc1"]
     - name: leaf2
       host: leaf2.anta.arista.com
       tags: ["leaf"]

--- a/tests/units/test_runner.py
+++ b/tests/units/test_runner.py
@@ -138,6 +138,7 @@ def test_adjust_rlimit_nofile_invalid_env(caplog: pytest.LogCaptureFixture) -> N
         pytest.param({"filename": "test_inventory_with_tags.yml"}, None, {"VerifyMlagStatus", "VerifyUptime"}, 3, 5, id="filtered-tests"),
         pytest.param({"filename": "test_inventory_with_tags.yml"}, {"leaf"}, {"VerifyMlagStatus", "VerifyUptime"}, 2, 4, id="1-tag-filtered-tests"),
         pytest.param({"filename": "test_inventory_with_tags.yml"}, {"invalid"}, None, 0, 0, id="invalid-tag"),
+        pytest.param({"filename": "test_inventory_with_tags.yml"}, {"dc1"}, None, 0, 0, id="device-tag-no-tests"),
     ],
     indirect=["inventory"],
 )


### PR DESCRIPTION
# Description

#827 fixed multiple `--tags` CLI support but introduced an issue where test-to-device tag matching wasn't properly enforced.

This PR now reflects the behavior specified in the [Tag Management ](https://anta.arista.com/stable/cli/tag-management/#using-tags) documentation.



# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
