### PR TITLE
fix(anta): Implement Pydantic class to replace RawCatalogInput type

### DIFF
--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -22,7 +22,7 @@ from pydantic_core import PydanticCustomError
 from yaml import YAMLError, safe_dump, safe_load
 
 from anta.logger import anta_log_exception
-from anta.models import AntaTest, RawCatalogInputModel
+from anta.models import AntaTest
 
 if TYPE_CHECKING:
     import sys
@@ -34,6 +34,43 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
+
+
+class RawCatalogInputModuleOptionModel(RootModel[dict[str, Any] | None]):  # pylint: disable=R0903
+    """Model capturing test option in catalog input."""
+
+    root: dict[str, Any] | None
+
+
+class RawCatalogInputModuleModel(RootModel[dict[str, RawCatalogInputModuleOptionModel]]):  # pylint: disable=R0903
+    """Model capturing test module in catalog input."""
+
+    root: dict[str, RawCatalogInputModuleOptionModel]
+
+
+class RawCatalogInputModel(RootModel[dict[str, list[RawCatalogInputModuleModel]]]):  # pylint: disable=R0903
+    """
+    Model for tests catalog input defined by user.
+
+    Originally defined with:
+        RawCatalogInput = dict[str, list[dict[str, Optional[dict[str, Any]]]]]
+
+    Example:
+        raw_catalog_input = RawCatalogInputModel.parse_obj({
+            "module_name": [
+                {"test_name": {"key": "value"}},
+                {"another_test": None}
+            ]
+        })
+    """
+
+    root: dict[str, list[RawCatalogInputModuleModel]]
+
+
+class AntaParamsBaseModel(BaseModel):
+    """Extends BaseModel and overwrite __getattr__ to return None on missing attribute."""
+
+    model_config = ConfigDict(extra="forbid")
 
 
 # [ ( <AntaTest class>, <input_as AntaTest.Input or dict or None > ), ... ]

--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -49,8 +49,7 @@ class RawCatalogInputModuleModel(RootModel[dict[str, RawCatalogInputModuleOption
 
 
 class RawCatalogInputModel(RootModel[dict[str, list[RawCatalogInputModuleModel]]]):  # pylint: disable=R0903
-    """
-    Model for tests catalog input defined by user.
+    """Model for tests catalog input defined by user.
 
     Originally defined with:
         RawCatalogInput = dict[str, list[dict[str, Optional[dict[str, Any]]]]]

--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -67,12 +67,6 @@ class RawCatalogInputModel(RootModel[dict[str, list[RawCatalogInputModuleModel]]
     root: dict[str, list[RawCatalogInputModuleModel]]
 
 
-class AntaParamsBaseModel(BaseModel):
-    """Extends BaseModel and overwrite __getattr__ to return None on missing attribute."""
-
-    model_config = ConfigDict(extra="forbid")
-
-
 # [ ( <AntaTest class>, <input_as AntaTest.Input or dict or None > ), ... ]
 ListAntaTestTuples = list[tuple[type[AntaTest], Optional[Union[AntaTest.Input, dict[str, Any]]]]]
 

--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -22,7 +22,7 @@ from pydantic_core import PydanticCustomError
 from yaml import YAMLError, safe_dump, safe_load
 
 from anta.logger import anta_log_exception
-from anta.models import AntaTest
+from anta.models import AntaTest, RawCatalogInputModel
 
 if TYPE_CHECKING:
     import sys
@@ -35,8 +35,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# { <module_name> : [ { <test_class_name>: <input_as_dict_or_None> }, ... ] }
-RawCatalogInput = dict[str, list[dict[str, Optional[dict[str, Any]]]]]
 
 # [ ( <AntaTest class>, <input_as AntaTest.Input or dict or None > ), ... ]
 ListAntaTestTuples = list[tuple[type[AntaTest], Optional[Union[AntaTest.Input, dict[str, Any]]]]]
@@ -358,10 +356,10 @@ class AntaCatalog:
         return AntaCatalog.from_dict(data, filename=filename)
 
     @staticmethod
-    def from_dict(data: RawCatalogInput, filename: str | Path | None = None) -> AntaCatalog:
+    def from_dict(data: RawCatalogInputModel, filename: str | Path | None = None) -> AntaCatalog:
         """Create an AntaCatalog instance from a dictionary data structure.
 
-        See RawCatalogInput type alias for details.
+        See RawCatalogInputModel type alias for details.
         It is the data structure returned by `yaml.load()` function of a valid
         YAML Test Catalog file.
 
@@ -387,7 +385,7 @@ class AntaCatalog:
             raise TypeError(msg)
 
         try:
-            catalog_data = AntaCatalogFile(data)  # type: ignore[arg-type]
+            catalog_data = AntaCatalogFile(data)
         except ValidationError as e:
             anta_log_exception(
                 e,

--- a/anta/catalog.py
+++ b/anta/catalog.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class RawCatalogInputModuleOptionModel(RootModel[dict[str, Any] | None]):  # pylint: disable=R0903
+class RawCatalogInputModuleOptionModel(RootModel[Union[dict[str, Any], None]]):  # pylint: disable=R0903
     """Model capturing test option in catalog input."""
 
     root: dict[str, Any] | None

--- a/anta/models.py
+++ b/anta/models.py
@@ -35,37 +35,6 @@ F = TypeVar("F", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
 
-class RawCatalogInputModuleOptionModel(BaseModel):
-    """Model capturing test option in catalog input."""
-
-    root: dict[str, Any] | None
-
-
-class RawCatalogInputModuleModel(BaseModel):
-    """Model capturing test module in catalog input."""
-
-    root: dict[str, RawCatalogInputModuleOptionModel]
-
-
-class RawCatalogInputModel(BaseModel):
-    """
-    Model for tests catalog input defined by user.
-
-    Originally defined with:
-        RawCatalogInput = dict[str, list[dict[str, Optional[dict[str, Any]]]]]
-
-    Example:
-        raw_catalog_input = RawCatalogInputModel.parse_obj({
-            "module_name": [
-                {"test_name": {"key": "value"}},
-                {"another_test": None}
-            ]
-        })
-    """
-
-    root: dict[str, list[RawCatalogInputModuleModel]]
-
-
 class AntaParamsBaseModel(BaseModel):
     """Extends BaseModel and overwrite __getattr__ to return None on missing attribute."""
 

--- a/anta/models.py
+++ b/anta/models.py
@@ -35,6 +35,37 @@ F = TypeVar("F", bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
 
 
+class RawCatalogInputModuleOptionModel(BaseModel):
+    """Model capturing test option in catalog input."""
+
+    root: dict[str, Any] | None
+
+
+class RawCatalogInputModuleModel(BaseModel):
+    """Model capturing test module in catalog input."""
+
+    root: dict[str, RawCatalogInputModuleOptionModel]
+
+
+class RawCatalogInputModel(BaseModel):
+    """
+    Model for tests catalog input defined by user.
+
+    Originally defined with:
+        RawCatalogInput = dict[str, list[dict[str, Optional[dict[str, Any]]]]]
+
+    Example:
+        raw_catalog_input = RawCatalogInputModel.parse_obj({
+            "module_name": [
+                {"test_name": {"key": "value"}},
+                {"another_test": None}
+            ]
+        })
+    """
+
+    root: dict[str, list[RawCatalogInputModuleModel]]
+
+
 class AntaParamsBaseModel(BaseModel):
     """Extends BaseModel and overwrite __getattr__ to return None on missing attribute."""
 


### PR DESCRIPTION
# Description

Implement a pydantic class to replace typing definition of `RawCatalogInput`. So it can be used as a JSON schema to validate user input like inventory models.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
