### PR TITLE
refactor: Deprecate the ability to configure aaa config when collecting show-techs

### DIFF
--- a/anta/cli/exec/commands.py
+++ b/anta/cli/exec/commands.py
@@ -84,7 +84,10 @@ def snapshot(inventory: AntaInventory, tags: set[str] | None, commands_list: Pat
 )
 @click.option(
     "--configure",
-    help="Ensure devices have 'aaa authorization exec default local' configured (required for SCP on EOS). THIS WILL CHANGE THE CONFIGURATION OF YOUR NETWORK.",
+    help=(
+        "[DEPRECATED] Ensure devices have 'aaa authorization exec default local' configured (required for SCP on EOS). "
+        "THIS WILL CHANGE THE CONFIGURATION OF YOUR NETWORK."
+    ),
     default=False,
     is_flag=True,
     show_default=True,

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -129,7 +129,7 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
                     return
 
                 # TODO: ANTA 2.0.0
-                msg = "[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0"
+                msg = "[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0. Please add the required configuration on your devices before running this command. from ANTA."
                 logger.warning(msg)
 
                 commands = []

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -129,8 +129,10 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
                     return
 
                 # TODO: ANTA 2.0.0
-                msg = ("[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0. "
-                       "Please add the required configuration on your devices before running this command from ANTA.")
+                msg = (
+                    "[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0. "
+                    "Please add the required configuration on your devices before running this command from ANTA."
+                )
                 logger.warning(msg)
 
                 commands = []

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -129,7 +129,8 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
                     return
 
                 # TODO: ANTA 2.0.0
-                msg = "[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0. Please add the required configuration on your devices before running this command. from ANTA."
+                msg = ("[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0. "
+                       "Please add the required configuration on your devices before running this command from ANTA.")
                 logger.warning(msg)
 
                 commands = []

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -128,6 +128,10 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
                     logger.error("Unable to collect tech-support on %s: configuration 'aaa authorization exec default local' is not present", device.name)
                     return
 
+                # TODO: ANTA 2.0.0
+                msg = "[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0"
+                logger.warning(msg)
+
                 commands = []
                 # TODO: @mtache - add `config` field to `AntaCommand` object to handle this use case.
                 # Otherwise mypy complains about enable as it is only implemented for AsyncEOSDevice

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -235,9 +235,10 @@ Options:
                           tag1,tag2,tag3.  [env var: ANTA_TAGS]
   -o, --output PATH       Path for test catalog  [default: ./tech-support]
   --latest INTEGER        Number of scheduled show-tech to retrieve
-  --configure             Ensure devices have 'aaa authorization exec default
-                          local' configured (required for SCP on EOS). THIS
-                          WILL CHANGE THE CONFIGURATION OF YOUR NETWORK.
+  --configure             [DEPRECATED] Ensure devices have 'aaa authorization
+                          exec default local' configured (required for SCP on
+                          EOS). THIS WILL CHANGE THE CONFIGURATION OF YOUR
+                          NETWORK.
   --help                  Show this message and exit.
 ```
 
@@ -248,7 +249,10 @@ When executed, this command fetches tech-support files and downloads them locall
 ANTA uses SCP to download files from devices and will not trust unknown SSH hosts by default. Add the SSH public keys of your devices to your `known_hosts` file or use the `anta --insecure` option to ignore SSH host keys validation.
 
 The configuration `aaa authorization exec default` must be present on devices to be able to use SCP.
-ANTA can automatically configure `aaa authorization exec default local` using the `anta exec collect-tech-support --configure` option.
+
+!!! warning Deprecation
+    ANTA can automatically configure `aaa authorization exec default local` using the `anta exec collect-tech-support --configure` option but this option is deprecated and will be removed in ANTA 2.0.0.
+
 If you require specific AAA configuration for `aaa authorization exec default`, like `aaa authorization exec default none` or `aaa authorization exec default group tacacs+`, you will need to configure it manually.
 
 The `--latest` option allows retrieval of a specific number of the most recent tech-support files.


### PR DESCRIPTION
# Description

ANTA should not configure the devices - only outputing a nice error message when something is missing

Fixes #894 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)
