### PR TITLE
doc(anta.tests): Update logging tests docstrings for clarity

### DIFF
--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -170,10 +170,22 @@ class VerifyLoggingHosts(AntaTest):
 class VerifyLoggingLogsGeneration(AntaTest):
     """Verifies if logs are generated.
 
+    This test performs the following checks:
+
+      1. Sends a test log message at the **informational** level
+      2. Retrieves the most recent logs (last 30 seconds)
+      3. Verifies that the test message was successfully logged
+
+    !!! warning
+        EOS logging buffer should be set to severity level `informational` or higher for this test to work.
+
     Expected Results
     ----------------
-    * Success: The test will pass if logs are generated.
-    * Failure: The test will fail if logs are NOT generated.
+    * Success: If logs are being generated and the test message is found in recent logs.
+    * Failure: If any of the following occur:
+        - The test message is not found in recent logs
+        - The logging system is not capturing new messages
+        - No logs are being generated
 
     Examples
     --------
@@ -205,10 +217,23 @@ class VerifyLoggingLogsGeneration(AntaTest):
 class VerifyLoggingHostname(AntaTest):
     """Verifies if logs are generated with the device FQDN.
 
+    This test performs the following checks:
+
+      1. Retrieves the device's configured FQDN
+      2. Sends a test log message at the **informational** level
+      3. Retrieves the most recent logs (last 30 seconds)
+      4. Verifies that the test message includes the complete FQDN of the device
+
+    !!! warning
+          EOS logging buffer should be set to severity level `informational` or higher for this test to work.
+
     Expected Results
     ----------------
-    * Success: The test will pass if logs are generated with the device FQDN.
-    * Failure: The test will fail if logs are NOT generated with the device FQDN.
+    * Success: If logs are generated with the device's complete FQDN.
+    * Failure: If any of the following occur:
+        - The test message is not found in recent logs
+        - The log message does not include the device's FQDN
+        - The FQDN in the log message doesn't match the configured FQDN
 
     Examples
     --------
@@ -247,10 +272,24 @@ class VerifyLoggingHostname(AntaTest):
 class VerifyLoggingTimestamp(AntaTest):
     """Verifies if logs are generated with the appropriate timestamp.
 
+    This test performs the following checks:
+
+      1. Sends a test log message at the **informational** level
+      2. Retrieves the most recent logs (last 30 seconds)
+      3. Verifies that the test message is present with a high-resolution RFC3339 timestamp format
+        - Example format: `2024-01-25T15:30:45.123456+00:00`
+        - Includes microsecond precision
+        - Contains timezone offset
+
+    !!! warning
+          EOS logging buffer should be set to severity level `informational` or higher for this test to work.
+
     Expected Results
     ----------------
-    * Success: The test will pass if logs are generated with the appropriate timestamp.
-    * Failure: The test will fail if logs are NOT generated with the appropriate timestamp.
+    * Success: If logs are generated with the correct high-resolution RFC3339 timestamp format.
+    * Failure: If any of the following occur:
+        - The test message is not found in recent logs
+        - The timestamp format does not match the expected RFC3339 format
 
     Examples
     --------


### PR DESCRIPTION
# Description

Update:
- VerifyLoggingTimestamp
- VerifyLoggingHostname
- VerifyLoggingLogsGeneration

To specify that the tests will work only when EOS is configured with logging buffer secerity level info or higher.


# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
