### PR TITLE
ci: Add support for HTTPX 0.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "PyYAML>=6.0",
   "requests>=2.31.0",
   "rich>=13.5.2,<14",
-  "httpx>=0.27.0"
+  "httpx>=0.28.0"
 ]
 keywords = ["test", "anta", "Arista", "network", "automation", "networking", "devops", "netdevops"]
 classifiers = [
@@ -75,7 +75,7 @@ dev = [
   "pytest-httpx>=0.30.0",
   "pytest-metadata>=3.0.0",
   "pytest>=7.4.0",
-  "respx>=0.21.1",
+  "respx @ git+https://github.com/ndhansen/respx",
   "ruff>=0.5.4,<0.9.0",
   "tox>=4.10.0,<5.0.0",
   "types-PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "PyYAML>=6.0",
   "requests>=2.31.0",
   "rich>=13.5.2,<14",
-  "httpx>=0.28.0"
+  "httpx>=0.27.0"
 ]
 keywords = ["test", "anta", "Arista", "network", "automation", "networking", "devops", "netdevops"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dev = [
   "pytest-httpx>=0.30.0",
   "pytest-metadata>=3.0.0",
   "pytest>=7.4.0",
-  "respx @ git+https://github.com/ndhansen/respx",
+  "respx @ git+https://github.com/ndhansen/respx",  # until https://github.com/lundberg/respx/pull/278 is merged
   "ruff>=0.5.4,<0.9.0",
   "tox>=4.10.0,<5.0.0",
   "types-PyYAML",


### PR DESCRIPTION
# Description

Need to install a fork of respx until https://github.com/lundberg/respx/issues/277 is fixed.