### PR TITLE
fix(anta.tests): Fix BGP tests failures

### DIFF
--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -273,6 +273,7 @@ class VerifyBGPPeersHealth(AntaTest):
                 # Check if the BGP session is established
                 if peer["state"] != "Established":
                     self.result.is_failure(f"{address_family} Peer: {peer['peerAddress']} - Session state is not established - State: {peer['state']}")
+                    continue
 
                 # Check if the AFI/SAFI state is negotiated
                 capability_status = get_value(peer, f"neighborCapabilities.multiprotocolCaps.{address_family.eos_key}")
@@ -280,10 +281,11 @@ class VerifyBGPPeersHealth(AntaTest):
                     self.result.is_failure(f"{address_family} Peer: {peer['peerAddress']} - AFI/SAFI state is not negotiated - {format_data(capability_status)}")
 
                 # Check the TCP session message queues
-                inq = peer["peerTcpInfo"]["inputQueueLength"]
-                outq = peer["peerTcpInfo"]["outputQueueLength"]
-                if address_family.check_tcp_queues and (inq != 0 or outq != 0):
-                    self.result.is_failure(f"{address_family} Peer: {peer['peerAddress']} - Session has non-empty message queues - InQ: {inq}, OutQ: {outq}")
+                if address_family.check_tcp_queues:
+                    inq = peer["peerTcpInfo"]["inputQueueLength"]
+                    outq = peer["peerTcpInfo"]["outputQueueLength"]
+                    if inq != 0 or outq != 0:
+                        self.result.is_failure(f"{address_family} Peer: {peer['peerAddress']} - Session has non-empty message queues - InQ: {inq}, OutQ: {outq}")
 
 
 class VerifyBGPSpecificPeers(AntaTest):
@@ -374,6 +376,7 @@ class VerifyBGPSpecificPeers(AntaTest):
                 # Check if the BGP session is established
                 if peer_data["state"] != "Established":
                     self.result.is_failure(f"{address_family} Peer: {peer_ip} - Session state is not established - State: {peer_data['state']}")
+                    continue
 
                 # Check if the AFI/SAFI state is negotiated
                 capability_status = get_value(peer_data, f"neighborCapabilities.multiprotocolCaps.{address_family.eos_key}")
@@ -384,10 +387,11 @@ class VerifyBGPSpecificPeers(AntaTest):
                     self.result.is_failure(f"{address_family} Peer: {peer_ip} - AFI/SAFI state is not negotiated - {format_data(capability_status)}")
 
                 # Check the TCP session message queues
-                inq = peer_data["peerTcpInfo"]["inputQueueLength"]
-                outq = peer_data["peerTcpInfo"]["outputQueueLength"]
-                if address_family.check_tcp_queues and (inq != 0 or outq != 0):
-                    self.result.is_failure(f"{address_family} Peer: {peer_ip} - Session has non-empty message queues - InQ: {inq}, OutQ: {outq}")
+                if address_family.check_tcp_queues:
+                    inq = peer_data["peerTcpInfo"]["inputQueueLength"]
+                    outq = peer_data["peerTcpInfo"]["outputQueueLength"]
+                    if inq != 0 or outq != 0:
+                        self.result.is_failure(f"{address_family} Peer: {peer_ip} - Session has non-empty message queues - InQ: {inq}, OutQ: {outq}")
 
 
 class VerifyBGPExchangedRoutes(AntaTest):

--- a/docs/advanced_usages/custom-tests.md
+++ b/docs/advanced_usages/custom-tests.md
@@ -341,7 +341,7 @@ class VerifyTemperature(AntaTest):
 !!! warning ""
     This section is required only if you are not merging your development into ANTA. Otherwise, just follow [contribution guide](../contribution.md).
 
-For that, you need to create your own Python package as described in this [hitchhiker's guide](https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/) to package Python code. We assume it is well known and we won't focus on this aspect. Thus, your package must be impartable by ANTA hence available in the module search path `sys.path` (you can use `PYTHONPATH` for example).
+For that, you need to create your own Python package as described in this [hitchhiker's guide](https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/) to package Python code. We assume it is well known and we won't focus on this aspect. Thus, your package must be importable by ANTA hence available in the module search path `sys.path` (you can use `PYTHONPATH` for example).
 
 It is very similar to what is documented in [catalog section](../usage-inventory-catalog.md) but you have to use your own package name.2
 

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -525,19 +525,16 @@ DATA: list[dict[str, Any]] = [
                                 "peerAddress": "10.100.0.12",
                                 "state": "Idle",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4Unicast": {"advertised": True, "received": True, "enabled": True}}},
-                                "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
                             {
                                 "peerAddress": "10.100.0.13",
                                 "state": "Idle",
                                 "neighborCapabilities": {"multiprotocolCaps": {"dps": {"advertised": True, "received": True, "enabled": True}}},
-                                "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
                             {
                                 "peerAddress": "10.100.0.14",
-                                "state": "Idle",
+                                "state": "Active",
                                 "neighborCapabilities": {"multiprotocolCaps": {"linkState": {"advertised": True, "received": True, "enabled": True}}},
-                                "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
                         ]
                     },
@@ -545,9 +542,8 @@ DATA: list[dict[str, Any]] = [
                         "peerList": [
                             {
                                 "peerAddress": "10.100.0.12",
-                                "state": "Idle",
+                                "state": "Active",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4SrTe": {"advertised": True, "received": True, "enabled": True}}},
-                                "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
                         ]
                     },
@@ -566,9 +562,9 @@ DATA: list[dict[str, Any]] = [
             "result": "failure",
             "messages": [
                 "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.100.0.12 - Session state is not established - State: Idle",
-                "AFI: ipv4 SAFI: sr-te VRF: MGMT Peer: 10.100.0.12 - Session state is not established - State: Idle",
+                "AFI: ipv4 SAFI: sr-te VRF: MGMT Peer: 10.100.0.12 - Session state is not established - State: Active",
                 "AFI: path-selection Peer: 10.100.0.13 - Session state is not established - State: Idle",
-                "AFI: link-state Peer: 10.100.0.14 - Session state is not established - State: Idle",
+                "AFI: link-state Peer: 10.100.0.14 - Session state is not established - State: Active",
             ],
         },
     },
@@ -582,19 +578,19 @@ DATA: list[dict[str, Any]] = [
                         "peerList": [
                             {
                                 "peerAddress": "10.100.0.12",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4Unicast": {"advertised": False, "received": False, "enabled": True}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
                             {
                                 "peerAddress": "10.100.0.13",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"dps": {"advertised": True, "received": False, "enabled": False}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
                             {
                                 "peerAddress": "10.100.0.14",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"linkState": {"advertised": False, "received": False, "enabled": False}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
@@ -604,7 +600,7 @@ DATA: list[dict[str, Any]] = [
                         "peerList": [
                             {
                                 "peerAddress": "10.100.0.12",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4SrTe": {"advertised": False, "received": False, "enabled": False}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
@@ -624,13 +620,9 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.100.0.12 - Session state is not established - State: Idle",
                 "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.100.0.12 - AFI/SAFI state is not negotiated - Advertised: False, Received: False, Enabled: True",
-                "AFI: ipv4 SAFI: sr-te VRF: MGMT Peer: 10.100.0.12 - Session state is not established - State: Idle",
                 "AFI: ipv4 SAFI: sr-te VRF: MGMT Peer: 10.100.0.12 - AFI/SAFI state is not negotiated - Advertised: False, Received: False, Enabled: False",
-                "AFI: path-selection Peer: 10.100.0.13 - Session state is not established - State: Idle",
                 "AFI: path-selection Peer: 10.100.0.13 - AFI/SAFI state is not negotiated - Advertised: True, Received: False, Enabled: False",
-                "AFI: link-state Peer: 10.100.0.14 - Session state is not established - State: Idle",
                 "AFI: link-state Peer: 10.100.0.14 - AFI/SAFI state is not negotiated - Advertised: False, Received: False, Enabled: False",
             ],
         },
@@ -645,19 +637,19 @@ DATA: list[dict[str, Any]] = [
                         "peerList": [
                             {
                                 "peerAddress": "10.100.0.12",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4Unicast": {"advertised": True, "received": True, "enabled": True}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 4, "inputQueueLength": 2},
                             },
                             {
                                 "peerAddress": "10.100.0.13",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"dps": {"advertised": True, "received": True, "enabled": True}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 1, "inputQueueLength": 1},
                             },
                             {
                                 "peerAddress": "10.100.0.14",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"linkState": {"advertised": True, "received": True, "enabled": True}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 2, "inputQueueLength": 3},
                             },
@@ -667,7 +659,7 @@ DATA: list[dict[str, Any]] = [
                         "peerList": [
                             {
                                 "peerAddress": "10.100.0.12",
-                                "state": "Idle",
+                                "state": "Established",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4SrTe": {"advertised": True, "received": True, "enabled": True}}},
                                 "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 1, "inputQueueLength": 5},
                             },
@@ -687,13 +679,9 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.100.0.12 - Session state is not established - State: Idle",
                 "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.100.0.12 - Session has non-empty message queues - InQ: 2, OutQ: 4",
-                "AFI: ipv4 SAFI: sr-te VRF: MGMT Peer: 10.100.0.12 - Session state is not established - State: Idle",
                 "AFI: ipv4 SAFI: sr-te VRF: MGMT Peer: 10.100.0.12 - Session has non-empty message queues - InQ: 5, OutQ: 1",
-                "AFI: path-selection Peer: 10.100.0.13 - Session state is not established - State: Idle",
                 "AFI: path-selection Peer: 10.100.0.13 - Session has non-empty message queues - InQ: 1, OutQ: 1",
-                "AFI: link-state Peer: 10.100.0.14 - Session state is not established - State: Idle",
                 "AFI: link-state Peer: 10.100.0.14 - Session has non-empty message queues - InQ: 3, OutQ: 2",
             ],
         },
@@ -823,7 +811,6 @@ DATA: list[dict[str, Any]] = [
                                 "peerAddress": "10.100.0.12",
                                 "state": "Idle",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4Unicast": {"advertised": True, "received": True, "enabled": True}}},
-                                "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             }
                         ]
                     },
@@ -833,7 +820,6 @@ DATA: list[dict[str, Any]] = [
                                 "peerAddress": "10.100.0.14",
                                 "state": "Idle",
                                 "neighborCapabilities": {"multiprotocolCaps": {"ipv4Unicast": {"advertised": True, "received": True, "enabled": True}}},
-                                "peerTcpInfo": {"state": "ESTABLISHED", "outputQueueLength": 0, "inputQueueLength": 0},
                             },
                         ]
                     },


### PR DESCRIPTION
# Description

`peerTcpInfo` key is not present in the BGP output if the session is not `Established` so we need to skip that check in the logic.

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
