### PR TITLE
fix(anta.tests): Adjust revision for show management cvx

### DIFF
--- a/anta/tests/cvx.py
+++ b/anta/tests/cvx.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from anta.models import AntaCommand, AntaTest
+from anta.tools import get_value
 
 if TYPE_CHECKING:
     from anta.models import AntaTemplate
@@ -71,7 +72,7 @@ class VerifyManagementCVX(AntaTest):
     """
 
     categories: ClassVar[list[str]] = ["cvx"]
-    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show management cvx", revision=1)]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show management cvx", revision=3)]
 
     class Input(AntaTest.Input):
         """Input model for the VerifyManagementCVX test."""
@@ -84,6 +85,5 @@ class VerifyManagementCVX(AntaTest):
         """Main test function for VerifyManagementCVX."""
         command_output = self.instance_commands[0].json_output
         self.result.is_success()
-        cluster_status = command_output["clusterStatus"]
-        if (cluster_state := cluster_status.get("enabled")) != self.inputs.enabled:
+        if (cluster_state := get_value(command_output, "clusterStatus.enabled")) != self.inputs.enabled:
             self.result.is_failure(f"Management CVX status is not valid: {cluster_state}")

--- a/tests/units/anta_tests/test_cvx.py
+++ b/tests/units/anta_tests/test_cvx.py
@@ -140,9 +140,16 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
-        "name": "failure",
+        "name": "failure - no enabled state",
         "test": VerifyManagementCVX,
         "eos_data": [{"clusterStatus": {}}],
+        "inputs": {"enabled": False},
+        "expected": {"result": "failure", "messages": ["Management CVX status is not valid: None"]},
+    },
+    {
+        "name": "failure - no clusterStatus",
+        "test": VerifyManagementCVX,
+        "eos_data": [{}],
         "inputs": {"enabled": False},
         "expected": {"result": "failure", "messages": ["Management CVX status is not valid: None"]},
     },


### PR DESCRIPTION
# Description

Test is throwing error when run on a a device not running CVX at all. Looking at the unit tests, it feels the revision for the command should be `3` and not `1` (cf issue comments)

Fixes #953

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
