### PR TITLE
doc: Add gh-admonition plugin

### DIFF
--- a/docs/advanced_usages/as-python-lib.md
+++ b/docs/advanced_usages/as-python-lib.md
@@ -6,8 +6,8 @@
 
 ANTA is a Python library that can be used in user applications. This section describes how you can leverage ANTA Python modules to help you create your own NRFU solution.
 
-!!! tip
-    If you are unfamiliar with asyncio, refer to the Python documentation relevant to your Python version - https://docs.python.org/3/library/asyncio.html
+> [!TIP]
+> If you are unfamiliar with asyncio, refer to the Python documentation relevant to your Python version - https://docs.python.org/3/library/asyncio.html
 
 ## [AntaDevice](../api/device.md#anta.device.AntaDevice) Abstract Class
 
@@ -47,8 +47,10 @@ The [AntaInventory](../api/inventory.md#anta.inventory.AntaInventory) class is a
 --8<-- "parse_anta_inventory_file.py"
 ```
 
-!!! note "How to create your inventory file"
-    Please visit this [dedicated section](../usage-inventory-catalog.md) for how to use inventory and catalog files.
+> [!NOTE]
+> __How to create your inventory file__
+>
+> Please visit this [dedicated section](../usage-inventory-catalog.md) for how to use inventory and catalog files.
 
 ### Run EOS commands
 

--- a/docs/advanced_usages/as-python-lib.md
+++ b/docs/advanced_usages/as-python-lib.md
@@ -48,7 +48,7 @@ The [AntaInventory](../api/inventory.md#anta.inventory.AntaInventory) class is a
 ```
 
 > [!NOTE]
-> __How to create your inventory file__
+> **How to create your inventory file**
 >
 > Please visit this [dedicated section](../usage-inventory-catalog.md) for how to use inventory and catalog files.
 

--- a/docs/advanced_usages/custom-tests.md
+++ b/docs/advanced_usages/custom-tests.md
@@ -83,12 +83,12 @@ Full AntaTest API documentation is available in the [API documentation section](
         heading_level: 10
 
 > [!NOTE]
-> __Logger object__
+> **Logger object**
 >
 > ANTA already provides comprehensive logging at every steps of a test execution. The [AntaTest](../api/models.md#anta.models.AntaTest) class also provides a `logger` attribute that is a Python logger specific to the test instance. See [Python documentation](https://docs.python.org/3/library/logging.html) for more information.
 
 > [!NOTE]
-> __AntaDevice object__
+> **AntaDevice object**
 >
 > Even if `device` is not a private attribute, you should not need to access this object in your code.
 
@@ -198,13 +198,13 @@ class <YourTestName>(AntaTest):
 ```
 
 > [!TIP]
-> __Command revision and version__
+> **Command revision and version**
 >
-> * Most of EOS commands return a JSON structure according to a model (some commands may not be modeled hence the necessity to use `text` outformat sometimes.
-> * The model can change across time (adding feature, ... ) and when the model is changed in a non backward-compatible way, the **revision** number is bumped. The initial model starts with **revision** 1.
-> * A **revision** applies to a particular CLI command whereas a **version** is global to an eAPI call. The **version** is internally translated to a specific **revision** for each CLI command in the RPC call. The currently supported **version** values  are `1` and `latest`.
-> * A **revision takes precedence over a version** (e.g. if a command is run with version="latest" and revision=1, the first revision of the model is returned)
-> * By default, eAPI returns the first revision of each model to ensure that when upgrading, integrations with existing tools are not broken. This is done by using by default `version=1` in eAPI calls.
+> - Most of EOS commands return a JSON structure according to a model (some commands may not be modeled hence the necessity to use `text` outformat sometimes.
+> - The model can change across time (adding feature, ... ) and when the model is changed in a non backward-compatible way, the **revision** number is bumped. The initial model starts with **revision** 1.
+> - A **revision** applies to a particular CLI command whereas a **version** is global to an eAPI call. The **version** is internally translated to a specific **revision** for each CLI command in the RPC call. The currently supported **version** values  are `1` and `latest`.
+> - A **revision takes precedence over a version** (e.g. if a command is run with version="latest" and revision=1, the first revision of the model is returned)
+> - By default, eAPI returns the first revision of each model to ensure that when upgrading, integrations with existing tools are not broken. This is done by using by default `version=1` in eAPI calls.
 >
 > By default, ANTA uses `version="latest"` in AntaCommand, but when developing tests, the revision MUST be provided when the outformat of the command is `json`. As explained earlier, this is to ensure that the eAPI always returns the same output model and that the test remains always valid from the day it was created. For some commands, you may also want to run them with a different revision or version.
 >

--- a/docs/advanced_usages/custom-tests.md
+++ b/docs/advanced_usages/custom-tests.md
@@ -4,8 +4,8 @@
   ~ that can be found in the LICENSE file.
   -->
 
-!!! info
-    This documentation applies for both creating tests in ANTA or creating your own test package.
+> [!INFO]
+> This documentation applies for both creating tests in ANTA or creating your own test package.
 
 ANTA is not only a Python library with a CLI and a collection of built-in tests, it is also a framework you can extend by building your own tests.
 
@@ -64,8 +64,8 @@ Full AntaTest API documentation is available in the [API documentation section](
 - `categories` (`list[str]`): A list of categories in which the test belongs.
 - `commands` (`[list[AntaCommand | AntaTemplate]]`): A list of command to collect from devices. This list **must** be a list of [AntaCommand](../api/models.md#anta.models.AntaCommand) or [AntaTemplate](../api/models.md#anta.models.AntaTemplate) instances. Rendering [AntaTemplate](../api/models.md#anta.models.AntaTemplate) instances will be discussed later.
 
-!!! info
-    All these class attributes are mandatory. If any attribute is missing, a `NotImplementedError` exception will be raised during class instantiation.
+> [!INFO]
+> All these class attributes are mandatory. If any attribute is missing, a `NotImplementedError` exception will be raised during class instantiation.
 
 ### Instance Attributes
 
@@ -82,11 +82,15 @@ Full AntaTest API documentation is available in the [API documentation section](
         show_root_toc_entry: false
         heading_level: 10
 
-!!! note "Logger object"
-    ANTA already provides comprehensive logging at every steps of a test execution. The [AntaTest](../api/models.md#anta.models.AntaTest) class also provides a `logger` attribute that is a Python logger specific to the test instance. See [Python documentation](https://docs.python.org/3/library/logging.html) for more information.
+> [!NOTE]
+> __Logger object__
+>
+> ANTA already provides comprehensive logging at every steps of a test execution. The [AntaTest](../api/models.md#anta.models.AntaTest) class also provides a `logger` attribute that is a Python logger specific to the test instance. See [Python documentation](https://docs.python.org/3/library/logging.html) for more information.
 
-!!! note "AntaDevice object"
-    Even if `device` is not a private attribute, you should not need to access this object in your code.
+> [!NOTE]
+> __AntaDevice object__
+>
+> Even if `device` is not a private attribute, you should not need to access this object in your code.
 
 ### Test Inputs
 
@@ -129,8 +133,8 @@ Full `ResultOverwrite` model documentation is available in [API documentation se
         show_root_toc_entry: false
         heading_level: 10
 
-!!! note
-    The pydantic model is configured using the [`extra=forbid`](https://docs.pydantic.dev/latest/usage/model_config/#extra-attributes) that will fail input validation if extra fields are provided.
+> [!NOTE]
+> The pydantic model is configured using the [`extra=forbid`](https://docs.pydantic.dev/latest/usage/model_config/#extra-attributes) that will fail input validation if extra fields are provided.
 
 ### Methods
 
@@ -160,8 +164,8 @@ In this section, we will go into all the details of writing an [AntaTest](../api
 Import [anta.models.AntaTest](../api/models.md#anta.models.AntaTest) and define your own class.
 Define the mandatory class attributes using [anta.models.AntaCommand](../api/models.md#anta.models.AntaCommand), [anta.models.AntaTemplate](../api/models.md#anta.models.AntaTemplate) or both.
 
-!!! info
-    Caching can be disabled per `AntaCommand` or `AntaTemplate` by setting the `use_cache` argument to `False`. For more details about how caching is implemented in ANTA, please refer to [Caching in ANTA](../advanced_usages/caching.md).
+> [!NOTE]
+> Caching can be disabled per `AntaCommand` or `AntaTemplate` by setting the `use_cache` argument to `False`. For more details about how caching is implemented in ANTA, please refer to [Caching in ANTA](../advanced_usages/caching.md).
 
 ```python
 from anta.models import AntaTest, AntaCommand, AntaTemplate
@@ -193,21 +197,23 @@ class <YourTestName>(AntaTest):
     ]
 ```
 
-!!! tip "Command revision and version"
-    * Most of EOS commands return a JSON structure according to a model (some commands may not be modeled hence the necessity to use `text` outformat sometimes.
-    * The model can change across time (adding feature, ... ) and when the model is changed in a non backward-compatible way, the **revision** number is bumped. The initial model starts with **revision** 1.
-    * A **revision** applies to a particular CLI command whereas a **version** is global to an eAPI call. The **version** is internally translated to a specific **revision** for each CLI command in the RPC call. The currently supported **version** values  are `1` and `latest`.
-    * A **revision takes precedence over a version** (e.g. if a command is run with version="latest" and revision=1, the first revision of the model is returned)
-    * By default, eAPI returns the first revision of each model to ensure that when upgrading, integrations with existing tools are not broken. This is done by using by default `version=1` in eAPI calls.
-
-    By default, ANTA uses `version="latest"` in AntaCommand, but when developing tests, the revision MUST be provided when the outformat of the command is `json`. As explained earlier, this is to ensure that the eAPI always returns the same output model and that the test remains always valid from the day it was created. For some commands, you may also want to run them with a different revision or version.
-
-    For instance, the `VerifyBFDPeersHealth` test leverages the first revision of `show bfd peers`:
-
-    ```
-    # revision 1 as later revision introduce additional nesting for type
-    commands = [AntaCommand(command="show bfd peers", revision=1)]
-    ```
+> [!TIP]
+> __Command revision and version__
+>
+> * Most of EOS commands return a JSON structure according to a model (some commands may not be modeled hence the necessity to use `text` outformat sometimes.
+> * The model can change across time (adding feature, ... ) and when the model is changed in a non backward-compatible way, the **revision** number is bumped. The initial model starts with **revision** 1.
+> * A **revision** applies to a particular CLI command whereas a **version** is global to an eAPI call. The **version** is internally translated to a specific **revision** for each CLI command in the RPC call. The currently supported **version** values  are `1` and `latest`.
+> * A **revision takes precedence over a version** (e.g. if a command is run with version="latest" and revision=1, the first revision of the model is returned)
+> * By default, eAPI returns the first revision of each model to ensure that when upgrading, integrations with existing tools are not broken. This is done by using by default `version=1` in eAPI calls.
+>
+> By default, ANTA uses `version="latest"` in AntaCommand, but when developing tests, the revision MUST be provided when the outformat of the command is `json`. As explained earlier, this is to ensure that the eAPI always returns the same output model and that the test remains always valid from the day it was created. For some commands, you may also want to run them with a different revision or version.
+>
+> For instance, the `VerifyBFDPeersHealth` test leverages the first revision of `show bfd peers`:
+>
+> ```python
+> # revision 1 as later revision introduce additional nesting for type
+> commands = [AntaCommand(command="show bfd peers", revision=1)]
+> ```
 
 ### Inputs definition
 
@@ -242,8 +248,8 @@ You can also leverage [anta.custom_types](../api/types.md) that provides reusabl
 
 Regarding required, optional and nullable fields, refer to this [documentation](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields) on how to define them.
 
-!!! note
-    All the `pydantic` features are supported. For instance you can define [validators](https://docs.pydantic.dev/latest/usage/validators/) for complex input validation.
+> [!NOTE]
+> All the `pydantic` features are supported. For instance you can define [validators](https://docs.pydantic.dev/latest/usage/validators/) for complex input validation.
 
 ### Template rendering
 
@@ -338,8 +344,8 @@ class VerifyTemperature(AntaTest):
 
 ## Access your custom tests in the test catalog
 
-!!! warning ""
-    This section is required only if you are not merging your development into ANTA. Otherwise, just follow [contribution guide](../contribution.md).
+> [!WARNING]
+> This section is required only if you are not merging your development into ANTA. Otherwise, just follow [contribution guide](../contribution.md).
 
 For that, you need to create your own Python package as described in this [hitchhiker's guide](https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/) to package Python code. We assume it is well known and we won't focus on this aspect. Thus, your package must be importable by ANTA hence available in the module search path `sys.path` (you can use `PYTHONPATH` for example).
 

--- a/docs/advanced_usages/custom-tests.md
+++ b/docs/advanced_usages/custom-tests.md
@@ -86,8 +86,7 @@ Full AntaTest API documentation is available in the [API documentation section](
 > **Logger object**
 >
 > ANTA already provides comprehensive logging at every steps of a test execution. The [AntaTest](../api/models.md#anta.models.AntaTest) class also provides a `logger` attribute that is a Python logger specific to the test instance. See [Python documentation](https://docs.python.org/3/library/logging.html) for more information.
-
-> [!NOTE]
+>
 > **AntaDevice object**
 >
 > Even if `device` is not a private attribute, you should not need to access this object in your code.

--- a/docs/advanced_usages/custom-tests.md
+++ b/docs/advanced_usages/custom-tests.md
@@ -15,7 +15,7 @@ A test is a Python class where a test function is defined and will be run by the
 
 ANTA provides an abstract class [AntaTest](../api/models.md#anta.models.AntaTest). This class does the heavy lifting and provide the logic to define, collect and test data. The code below is an example of a simple test in ANTA, which is an [AntaTest](../api/models.md#anta.models.AntaTest) subclass:
 
-```python
+````python
 from anta.models import AntaTest, AntaCommand
 from anta.decorators import skip_on_platforms
 
@@ -49,7 +49,7 @@ class VerifyTemperature(AntaTest):
             self.result.is_success()
         else:
             self.result.is_failure(f"Device temperature exceeds acceptable limits. Current system status: '{temperature_status}'")
-```
+````
 
 [AntaTest](../api/models.md#anta.models.AntaTest) also provide more advanced capabilities like [AntaCommand](../api/models.md#anta.models.AntaCommand) templating using the [AntaTemplate](../api/models.md#anta.models.AntaTemplate) class or test inputs definition and validation using [AntaTest.Input](../api/models.md#anta.models.AntaTest.Input) [pydantic](https://docs.pydantic.dev/latest/) model. This will be discussed in the sections below.
 
@@ -83,13 +83,14 @@ Full AntaTest API documentation is available in the [API documentation section](
         heading_level: 10
 
 > [!NOTE]
-> **Logger object**
 >
-> ANTA already provides comprehensive logging at every steps of a test execution. The [AntaTest](../api/models.md#anta.models.AntaTest) class also provides a `logger` attribute that is a Python logger specific to the test instance. See [Python documentation](https://docs.python.org/3/library/logging.html) for more information.
+> - **Logger object**
 >
-> **AntaDevice object**
+>     ANTA already provides comprehensive logging at every steps of a test execution. The [AntaTest](../api/models.md#anta.models.AntaTest) class also provides a `logger` attribute that is a Python logger specific to the test instance. See [Python documentation](https://docs.python.org/3/library/logging.html) for more information.
 >
-> Even if `device` is not a private attribute, you should not need to access this object in your code.
+> - **AntaDevice object**
+>
+>     Even if `device` is not a private attribute, you should not need to access this object in your code.
 
 ### Test Inputs
 

--- a/docs/cli/debug.md
+++ b/docs/cli/debug.md
@@ -61,6 +61,7 @@ Options:
   --help                    Show this message and exit.
 ```
 
+> [!TIP]
 > `username`, `password`, `enable-password`, `enable`, `timeout` and `insecure` values are the same for all devices
 
 ### Example
@@ -162,8 +163,8 @@ Run templated command 'show vlan {vlan_id}' with {'vlan_id': '10'} on DC1-LEAF1A
 
 ### Example of multiple arguments
 
-!!! warning
-    If multiple arguments of the same key are provided, only the last argument value will be kept in the template parameters.
+> [!WARNING]
+> If multiple arguments of the same key are provided, only the last argument value will be kept in the template parameters.
 
 ```bash
 anta -log DEBUG debug run-template --template "ping {dst} source {src}" dst "8.8.8.8" src Loopback0 --device DC1-SPINE1    

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -64,6 +64,7 @@ Options:
   --help                  Show this message and exit.
 ```
 
+> [!TIP]
 > `username`, `password`, `enable-password`, `enable`, `timeout` and `insecure` values are the same for all devices
 
 ### Example
@@ -242,6 +243,7 @@ Options:
   --help                  Show this message and exit.
 ```
 
+> [!TIP]
 > `username`, `password`, `enable-password`, `enable`, `timeout` and `insecure` values are the same for all devices
 
 When executed, this command fetches tech-support files and downloads them locally into a device-specific subfolder within the designated folder. You can specify the output folder with the `--output` option.
@@ -250,15 +252,17 @@ ANTA uses SCP to download files from devices and will not trust unknown SSH host
 
 The configuration `aaa authorization exec default` must be present on devices to be able to use SCP.
 
-!!! warning Deprecation
-    ANTA can automatically configure `aaa authorization exec default local` using the `anta exec collect-tech-support --configure` option but this option is deprecated and will be removed in ANTA 2.0.0.
+> [!CAUTION]
+> __Deprecation__
+>
+> ANTA can automatically configure `aaa authorization exec default local` using the `anta exec collect-tech-support --configure` option but this option is deprecated and will be removed in ANTA 2.0.0.
 
 If you require specific AAA configuration for `aaa authorization exec default`, like `aaa authorization exec default none` or `aaa authorization exec default group tacacs+`, you will need to configure it manually.
 
 The `--latest` option allows retrieval of a specific number of the most recent tech-support files.
 
-!!! warning
-    By default **all** the tech-support files present on the devices are retrieved.
+> [!WARNING]
+> By default **all** the tech-support files present on the devices are retrieved.
 
 ### Example
 

--- a/docs/cli/exec.md
+++ b/docs/cli/exec.md
@@ -253,7 +253,7 @@ ANTA uses SCP to download files from devices and will not trust unknown SSH host
 The configuration `aaa authorization exec default` must be present on devices to be able to use SCP.
 
 > [!CAUTION]
-> __Deprecation__
+> **Deprecation**
 >
 > ANTA can automatically configure `aaa authorization exec default local` using the `anta exec collect-tech-support --configure` option but this option is deprecated and will be removed in ANTA 2.0.0.
 

--- a/docs/cli/get-inventory-information.md
+++ b/docs/cli/get-inventory-information.md
@@ -52,8 +52,8 @@ Options:
   --help                         Show this message and exit.
 ```
 
-!!! tip
-    By default, `anta get inventory` only provides information that doesn't rely on a device connection. If you are interested in obtaining connection-dependent details, like the hardware model, use the `--connected` option.
+> [!TIP]
+> By default, `anta get inventory` only provides information that doesn't rely on a device connection. If you are interested in obtaining connection-dependent details, like the hardware model, use the `--connected` option.
 
 ### Example
 

--- a/docs/cli/get-tests.md
+++ b/docs/cli/get-tests.md
@@ -26,8 +26,8 @@ Options:
   --help         Show this message and exit.
 ```
 
-!!! tip
-    By default, `anta get tests` will retrieve all tests available in ANTA.
+> [!TIP]
+> By default, `anta get tests` will retrieve all tests available in ANTA.
 
 ### Examples
 
@@ -91,9 +91,8 @@ anta.tests.aaa:
       vrf: MGMT
 ```
 
-!!! tip
-
-    You can filter tests by providing a prefix - ANTA will return all tests that start with your specified string.
+> [!TIP]
+> You can filter tests by providing a prefix - ANTA will return all tests that start with your specified string.
 
 ```yaml title="anta get tests --test VerifyTacacs"
 anta.tests.aaa:

--- a/docs/cli/inv-from-ansible.md
+++ b/docs/cli/inv-from-ansible.md
@@ -31,7 +31,7 @@ Options:
   --help                    Show this message and exit.
 ```
 
-> [!WARNING]warning
+> [!WARNING]
 >
 > - `anta get from-ansible` does not support inline vaulted variables, comment them out to generate your inventory.
 >

--- a/docs/cli/inv-from-ansible.md
+++ b/docs/cli/inv-from-ansible.md
@@ -31,12 +31,12 @@ Options:
   --help                    Show this message and exit.
 ```
 
-!!! warning "Warnings"
-
-    * `anta get from-ansible` does not support inline vaulted variables, comment them out to generate your inventory.
-    If the vaulted variable is necessary to build the inventory (e.g. `ansible_host`), it needs to be unvaulted for `from-ansible` command to work."
-
-    * The current implementation only considers devices directly attached to a specific Ansible group and does not support inheritance when using the `--ansible-group` option.
+> [!WARNING]warning
+> * `anta get from-ansible` does not support inline vaulted variables, comment them out to generate your inventory.
+>
+> * If the vaulted variable is necessary to build the inventory (e.g. `ansible_host`), it needs to be unvaulted for `from-ansible` command to work."
+>
+> * The current implementation only considers devices directly attached to a specific Ansible group and does not support inheritance when using the `--ansible-group` option.
 
 By default, if user does not provide `--output` file, anta will save output to configured anta inventory (`anta --inventory`). If the output file has content, anta will ask user to overwrite when running in interactive console. This mechanism can be controlled by triggers in case of CI usage: `--overwrite` to force anta to overwrite file. If not set, anta will exit
 

--- a/docs/cli/inv-from-ansible.md
+++ b/docs/cli/inv-from-ansible.md
@@ -32,11 +32,12 @@ Options:
 ```
 
 > [!WARNING]warning
-> * `anta get from-ansible` does not support inline vaulted variables, comment them out to generate your inventory.
 >
-> * If the vaulted variable is necessary to build the inventory (e.g. `ansible_host`), it needs to be unvaulted for `from-ansible` command to work."
+> - `anta get from-ansible` does not support inline vaulted variables, comment them out to generate your inventory.
 >
-> * The current implementation only considers devices directly attached to a specific Ansible group and does not support inheritance when using the `--ansible-group` option.
+> - If the vaulted variable is necessary to build the inventory (e.g. `ansible_host`), it needs to be unvaulted for `from-ansible` command to work."
+>
+> - The current implementation only considers devices directly attached to a specific Ansible group and does not support inheritance when using the `--ansible-group` option.
 
 By default, if user does not provide `--output` file, anta will save output to configured anta inventory (`anta --inventory`). If the output file has content, anta will ask user to overwrite when running in interactive console. This mechanism can be controlled by triggers in case of CI usage: `--overwrite` to force anta to overwrite file. If not set, anta will exit
 

--- a/docs/cli/inv-from-cvp.md
+++ b/docs/cli/inv-from-cvp.md
@@ -52,8 +52,8 @@ anta_inventory:
     - pod2
 ```
 
-!!! warning
-    The current implementation only considers devices directly attached to a specific container when using the `--cvp-container` option.
+> [!WARNING]
+> The current implementation only considers devices directly attached to a specific container when using the `--cvp-container` option.
 
 ## Creating an inventory from multiple containers
 

--- a/docs/cli/nrfu.md
+++ b/docs/cli/nrfu.md
@@ -26,7 +26,7 @@ ANTA provides a set of commands for performing NRFU tests on devices. These comm
 
 All commands under the `anta nrfu` namespace require a catalog yaml file specified with the `--catalog` option and a device inventory file specified with the `--inventory` option.
 
-!!! info
+> [!TIP]
     Issuing the command `anta nrfu` will run `anta nrfu table` without any option.
 
 ### Tag management

--- a/docs/cli/nrfu.md
+++ b/docs/cli/nrfu.md
@@ -27,7 +27,7 @@ ANTA provides a set of commands for performing NRFU tests on devices. These comm
 All commands under the `anta nrfu` namespace require a catalog yaml file specified with the `--catalog` option and a device inventory file specified with the `--inventory` option.
 
 > [!TIP]
-    Issuing the command `anta nrfu` will run `anta nrfu table` without any option.
+> Issuing the command `anta nrfu` will run `anta nrfu table` without any option.
 
 ### Tag management
 

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -45,9 +45,10 @@ Then, run the CLI without options:
 anta nrfu
 ```
 
-!!! note
-    All environment variables may not be needed for every commands.
-    Refer to `<command> --help` for the comprehensive environment variables names.
+> [!NOTE]
+> All environment variables may not be needed for every commands.
+>
+> Refer to `<command> --help` for the comprehensive environment variables names.
 
 Below are the environment variables usable with the `anta nrfu` command:
 
@@ -63,8 +64,8 @@ Below are the environment variables usable with the `anta nrfu` command:
 | ANTA_ENABLE | Whether it is necessary to go to enable mode on devices. |  No  |
 | ANTA_ENABLE_PASSWORD | The optional enable password, when this variable is set, ANTA_ENABLE or `--enable` is required. |  No  |
 
-!!! info
-    Caching can be disabled with the global parameter `--disable-cache`. For more details about how caching is implemented in ANTA, please refer to [Caching in ANTA](../advanced_usages/caching.md).
+> [!NOTE]
+> Caching can be disabled with the global parameter `--disable-cache`. For more details about how caching is implemented in ANTA, please refer to [Caching in ANTA](../advanced_usages/caching.md).
 
 ## ANTA Exit Codes
 

--- a/docs/cli/tag-management.md
+++ b/docs/cli/tag-management.md
@@ -92,10 +92,11 @@ anta.tests.interfaces:
         tags: ['spine']
 ```
 
+> [!TIP]
 > A tag used to filter a test can also be a device name
 
-> [!TIP]
-> **Use different input values for a specific test**
+> [!NOTE]
+> __Use different input values for a specific test__
 >
 > Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
 

--- a/docs/cli/tag-management.md
+++ b/docs/cli/tag-management.md
@@ -95,7 +95,7 @@ anta.tests.interfaces:
 > A tag used to filter a test can also be a device name
 
 > [!TIP]
-> __Use different input values for a specific test__
+> **Use different input values for a specific test**
 >
 > Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
 

--- a/docs/cli/tag-management.md
+++ b/docs/cli/tag-management.md
@@ -94,8 +94,10 @@ anta.tests.interfaces:
 
 > A tag used to filter a test can also be a device name
 
-!!! tip "Use different input values for a specific test"
-    Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
+> [!TIP]
+> __Use different input values for a specific test__
+>
+> Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
 
 ## Using tags
 

--- a/docs/cli/tag-management.md
+++ b/docs/cli/tag-management.md
@@ -96,7 +96,7 @@ anta.tests.interfaces:
 > A tag used to filter a test can also be a device name
 
 > [!NOTE]
-> __Use different input values for a specific test__
+> **Use different input values for a specific test**
 >
 > Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
 

--- a/docs/cli/tag-management.md
+++ b/docs/cli/tag-management.md
@@ -93,9 +93,10 @@ anta.tests.interfaces:
 ```
 
 > [!TIP]
-> A tag used to filter a test can also be a device name
 >
-> Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
+> - A tag used to filter a test can also be a device name
+>
+> - **Use different input values for a specific test**: Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
 
 ## Using tags
 

--- a/docs/cli/tag-management.md
+++ b/docs/cli/tag-management.md
@@ -94,9 +94,6 @@ anta.tests.interfaces:
 
 > [!TIP]
 > A tag used to filter a test can also be a device name
-
-> [!NOTE]
-> **Use different input values for a specific test**
 >
 > Leverage tags to define different input values for a specific test. See the `VerifyUptime` example above.
 

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -86,9 +86,9 @@ Success: no issues found in 82 source files
 
 > NOTE: Typing is configured quite strictly, do not hesitate to reach out if you have any questions, struggles, nightmares.
 
-## Unit tests
+## Unit tests with Pytest
 
-To keep high quality code, we require to provide a Pytest for every tests implemented in ANTA.
+To keep high quality code, we require to provide a __Pytest__ for every tests implemented in ANTA.
 
 All submodule should have its own pytest section under `tests/units/anta_tests/<submodule-name>.py`.
 

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -88,7 +88,7 @@ Success: no issues found in 82 source files
 
 ## Unit tests with Pytest
 
-To keep high quality code, we require to provide a __Pytest__ for every tests implemented in ANTA.
+To keep high quality code, we require to provide a **Pytest** for every tests implemented in ANTA.
 
 All submodule should have its own pytest section under `tests/units/anta_tests/<submodule-name>.py`.
 

--- a/docs/requirements-and-installation.md
+++ b/docs/requirements-and-installation.md
@@ -25,9 +25,8 @@ The ANTA package and the cli require some packages that are not part of the Pyth
 pip install anta
 ```
 
-!!! Warning
-
-    * This command alone **will not** install the ANTA CLI requirements.
+> [!WARNING]
+> This command alone **will not** install the ANTA CLI requirements.
 
 ### Install ANTA CLI as an application with `pipx`
 
@@ -37,9 +36,8 @@ pip install anta
 pipx install anta[cli]
 ```
 
-!!! Info
-
-    Please take the time to read through the installation instructions of `pipx` before getting started.
+> [!INFO]
+> Please take the time to read through the installation instructions of `pipx` before getting started.
 
 ### Install CLI from Pypi server
 
@@ -80,8 +78,8 @@ which anta
 /home/tom/.pyenv/shims/anta
 ```
 
-!!! warning
-    Before running the `anta --version` command, please be aware that some users have reported issues related to the `urllib3` package. If you encounter an error at this step, please refer to our [FAQ](faq.md) page for guidance on resolving it.
+> [!WARNING]
+> Before running the `anta --version` command, please be aware that some users have reported issues related to the `urllib3` package. If you encounter an error at this step, please refer to our [FAQ](faq.md) page for guidance on resolving it.
 
 ```bash
 # Check ANTA version

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,9 +33,8 @@ To help document the issue in Github, it is important to capture some logs so th
 
 ANTA provides very verbose logs when using the `DEBUG` level.  When using DEBUG log level with a log file, the DEBUG logging level is not sent to stdout, but only to the file.
 
-!!! danger
-
-    On real deployments, do not use DEBUG logging level without setting a log file at the same time.
+> [!CAUTION]
+> On real deployments, do not use DEBUG logging level without setting a log file at the same time.
 
 To save the logs to a file called `anta.log`, use the following flags:
 
@@ -46,11 +45,10 @@ anta -l DEBUG –log-file anta.log <ANTA_COMMAND>
 
 See `anta --help` for more information.  These have to precede the `nrfu` cmd.
 
-!!! tip
-
-    Remember that in ANTA, each level of command has its own options and they can only be set at this level.
-    so the `-l` and `--log-file` MUST be between `anta` and the `ANTA_COMMAND`.
-    similarly, all the `nrfu` options MUST be set between the `nrfu` and the `ANTA_NRFU_SUBCOMMAND` (`json`, `text`, `table` or `tpl-report`).
+> [!TIP]
+> Remember that in ANTA, each level of command has its own options and they can only be set at this level.
+> so the `-l` and `--log-file` MUST be between `anta` and the `ANTA_COMMAND`.
+> similarly, all the `nrfu` options MUST be set between the `nrfu` and the `ANTA_NRFU_SUBCOMMAND` (`json`, `text`, `table` or `tpl-report`).
 
 As an example, for the `nrfu` command, it would look like:
 
@@ -60,9 +58,8 @@ anta -l DEBUG --log-file anta.log nrfu --enable --username username --password a
 
 ### `ANTA_DEBUG` environment variable
 
-!!! warning
-
-     Do not use this if you do not know why. This produces a lot of logs and can create confusion if you do not know what to look for.
+> [!WARNING]
+> Do not use this if you do not know why. This produces a lot of logs and can create confusion if you do not know what to look for.
 
 The environment variable `ANTA_DEBUG=true` enable ANTA Debug Mode.
 

--- a/docs/usage-inventory-catalog.md
+++ b/docs/usage-inventory-catalog.md
@@ -47,8 +47,8 @@ The inventory file must start with the `anta_inventory` key then define one or m
 
 A full description of the inventory model is available in [API documentation](api/inventory.models.input.md)
 
-!!! info
-    Caching can be disabled per device, network or range by setting the `disable_cache` key to `True` in the inventory file. For more details about how caching is implemented in ANTA, please refer to [Caching in ANTA](advanced_usages/caching.md).
+> [!INFO]
+> Caching can be disabled per device, network or range by setting the `disable_cache` key to `True` in the inventory file. For more details about how caching is implemented in ANTA, please refer to [Caching in ANTA](advanced_usages/caching.md).
 
 ### Example
 
@@ -199,8 +199,8 @@ anta.tests.system:
         tags: ['leaf']
 ```
 
-!!! info
-    When using the CLI, you can filter the NRFU execution using tags. Refer to [this section](cli/tag-management.md) of the CLI documentation.
+> [!INFO]
+> When using the CLI, you can filter the NRFU execution using tags. Refer to [this section](cli/tag-management.md) of the CLI documentation.
 
 ### Tests available in ANTA
 
@@ -277,8 +277,10 @@ custom.tests.system:
     type: ['cEOS-LAB']
 ```
 
-!!! tip "How to create custom tests"
-    To create your custom tests, you should refer to this [documentation](advanced_usages/custom-tests.md)
+> [!TIP]
+> __How to create custom tests__
+>
+> To create your custom tests, you should refer to this [documentation](advanced_usages/custom-tests.md)
 
 ### Customize test description and categories
 
@@ -317,5 +319,5 @@ The following script reads all the files in `intended/test_catalogs/` with names
 --8<-- "merge_catalogs.py"
 ```
 
-!!! warning
-    The `AntaCatalog.merge()` method is deprecated and will be removed in ANTA v2.0. Please use the `AntaCatalog.merge_catalogs()` class method instead.
+> [!WARNING]
+> The `AntaCatalog.merge()` method is deprecated and will be removed in ANTA v2.0. Please use the `AntaCatalog.merge_catalogs()` class method instead.

--- a/docs/usage-inventory-catalog.md
+++ b/docs/usage-inventory-catalog.md
@@ -278,7 +278,7 @@ custom.tests.system:
 ```
 
 > [!TIP]
-> __How to create custom tests__
+> **How to create custom tests**
 >
 > To create your custom tests, you should refer to this [documentation](advanced_usages/custom-tests.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ watch:
   - anta
 
 plugins:
+  - gh-admonitions
   - mkdocstrings:
       default_handler: python
       custom_templates: docs/templates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ doc = [
   "mkdocstrings[python]>=0.26.0",
   "mkdocstrings-python>=1.11.0",
   "black>=24.10.0",
-  "mkdocs-github-admonitions-plugin"
+  "mkdocs-github-admonitions-plugin>=0.0.3"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,8 @@ doc = [
   "mkdocs-material>=9.5.34",
   "mkdocstrings[python]>=0.26.0",
   "mkdocstrings-python>=1.11.0",
-  "black>=24.10.0"
+  "black>=24.10.0",
+  "mkdocs-github-admonitions-plugin"
 ]
 
 [project.urls]


### PR DESCRIPTION
# Description

<!-- PR description !-->

Add support to convert Github Admonitions to basic mkdocs admonitions using [`PGijsbers/admonitions`](https://github.com/PGijsbers/admonitions). This conversion helps to get nice document in both worlds: Github and Mkdocs.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
