### PR TITLE
feat(anta): NetBox as an inventory source

### DIFF
--- a/anta/cli/get/__init__.py
+++ b/anta/cli/get/__init__.py
@@ -15,6 +15,7 @@ def get() -> None:
 
 get.add_command(commands.from_cvp)
 get.add_command(commands.from_ansible)
+get.add_command(commands.from_netbox)
 get.add_command(commands.inventory)
 get.add_command(commands.tags)
 get.add_command(commands.tests)

--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -22,7 +22,7 @@ from anta.cli.console import console
 from anta.cli.get.utils import inventory_output_options
 from anta.cli.utils import ExitCode, inventory_options
 
-from .utils import create_inventory_from_ansible, create_inventory_from_cvp, explore_package, get_cv_token
+from .utils import create_inventory_from_ansible, create_inventory_from_cvp, create_inventory_from_netbox, explore_package, get_cv_token
 
 if TYPE_CHECKING:
     from anta.inventory import AntaInventory
@@ -100,6 +100,29 @@ def from_ansible(ctx: click.Context, output: Path, ansible_group: str, ansible_i
             inventory=ansible_inventory,
             output=output,
             ansible_group=ansible_group,
+        )
+    except ValueError as e:
+        logger.error(str(e))
+        ctx.exit(ExitCode.USAGE_ERROR)
+
+@click.command
+@click.pass_context
+@inventory_output_options
+@click.option("--nb-instance", "-nbi", help="Name of NetBox instance", type=str, required=True)
+@click.option("--nb-token", "-nbt", help="NetBox Token", type=str, required=True)
+@click.option("--nb-platform", "-nbt", help="NetBox device platform", type=str, default="Arista EOS", required=True)
+@click.option("--nb-token", "-nbt", help="NetBox Token", type=str, required=True)
+@click.option("--nb-verify", "-nbf", help="NetBox Verify", type=bool, default=False, required=False)
+def from_netbox(ctx: click.Context, nb_instance: str, output: Path, nb_token: str, nb_platform: str, nb_verify: bool=False) -> None:
+    """Build ANTA inventory from a NetBox instance."""
+    logger.info("Building inventory from netbox instance file '%s'", nb_instance)
+    try:
+        create_inventory_from_netbox(
+            nb_instance=nb_instance,
+            output=output,
+            token=nb_token,
+            platform=nb_platform,
+            verify=nb_verify
         )
     except ValueError as e:
         logger.error(str(e))

--- a/anta/cli/get/commands.py
+++ b/anta/cli/get/commands.py
@@ -105,25 +105,19 @@ def from_ansible(ctx: click.Context, output: Path, ansible_group: str, ansible_i
         logger.error(str(e))
         ctx.exit(ExitCode.USAGE_ERROR)
 
+
 @click.command
 @click.pass_context
 @inventory_output_options
-@click.option("--nb-instance", "-nbi", help="Name of NetBox instance", type=str, required=True)
-@click.option("--nb-token", "-nbt", help="NetBox Token", type=str, required=True)
+@click.option("--nb-instance", "-nbi", help="Name of the NetBox instance", type=str, required=True)
+@click.option("--nb-token", "-nbt", help="NetBox token", type=str, required=True)
 @click.option("--nb-platform", "-nbt", help="NetBox device platform", type=str, default="Arista EOS", required=True)
-@click.option("--nb-token", "-nbt", help="NetBox Token", type=str, required=True)
-@click.option("--nb-verify", "-nbf", help="NetBox Verify", type=bool, default=False, required=False)
-def from_netbox(ctx: click.Context, nb_instance: str, output: Path, nb_token: str, nb_platform: str, nb_verify: bool=False) -> None:
+@click.option("--nb-verify", "-nbf", help="NetBox verify SSL", type=bool, default=False, required=False)
+def from_netbox(ctx: click.Context, nb_instance: str, output: Path, nb_token: str, nb_platform: str, nb_verify: bool = False) -> None:
     """Build ANTA inventory from a NetBox instance."""
     logger.info("Building inventory from netbox instance file '%s'", nb_instance)
     try:
-        create_inventory_from_netbox(
-            nb_instance=nb_instance,
-            output=output,
-            token=nb_token,
-            platform=nb_platform,
-            verify=nb_verify
-        )
+        create_inventory_from_netbox(nb_instance=nb_instance, output=output, token=nb_token, platform=nb_platform, verify=nb_verify)
     except ValueError as e:
         logger.error(str(e))
         ctx.exit(ExitCode.USAGE_ERROR)

--- a/anta/cli/get/utils.py
+++ b/anta/cli/get/utils.py
@@ -215,7 +215,7 @@ def create_inventory_from_ansible(inventory: Path, output: Path, ansible_group: 
     write_inventory_to_file(ansible_hosts, output)
 
 
-def create_inventory_from_netbox(nb_instance: str, output: Path, token: str, platform: str = "Arista EOS", verify: bool=False) -> None:
+def create_inventory_from_netbox(nb_instance: str, output: Path, token: str, platform: str = "Arista EOS", verify: bool = False) -> None:
     """Fetch devices from NetBox filtered by a specific platform.
 
     Parameters
@@ -227,7 +227,7 @@ def create_inventory_from_netbox(nb_instance: str, output: Path, token: str, pla
     token
         The token used to authenticate to the NetBox instance.
     platform
-        The query of the platform to filter devices by.
+        The platform to filter devices by.
     verify
         Verify the SSL certification of the NetBox instance.
 

--- a/anta/cli/get/utils.py
+++ b/anta/cli/get/utils.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import functools
 import importlib
 import inspect
+import ipaddress
 import json
 import logging
 import pkgutil
@@ -212,6 +213,54 @@ def create_inventory_from_ansible(inventory: Path, output: Path, ansible_group: 
         raise ValueError(msg)
     ansible_hosts = deep_yaml_parsing(ansible_inventory)
     write_inventory_to_file(ansible_hosts, output)
+
+
+def create_inventory_from_netbox(nb_instance: str, output: Path, token: str, platform: str = "Arista EOS", verify: bool=False) -> None:
+    """Fetch devices from NetBox filtered by a specific platform.
+
+    Parameters
+    ----------
+    nb_instance
+        The NetBox API instance.
+    output
+        ANTA inventory file to generate.
+    token
+        The token used to authenticate to the NetBox instance.
+    platform
+        The query of the platform to filter devices by.
+    verify
+        Verify the SSL certification of the NetBox instance.
+
+    """
+    session = requests.session()
+    session.verify = verify
+    try:
+        import pynetbox
+    except ImportError as e:
+        logging.error(e)
+
+    try:
+        # Initialize NetBox API
+        nb = pynetbox.api(nb_instance, token=token)
+
+        # Platform name to filter
+        platform = nb.dcim.platforms.get(q=[platform])
+
+        devices = nb.dcim.devices.filter(platform=platform.slug)
+
+        inventory = []
+        for device in devices:
+            host_entry = {
+                "host": str(ipaddress.ip_interface(device.primary_ip).ip),
+                "name": device.name,
+                "tags": [tag.name for tag in device.tags],
+            }
+            inventory.append(host_entry)
+
+        write_inventory_to_file(inventory, output)
+
+    except Exception as e:
+        raise ValueError(e) from e
 
 
 def explore_package(module_name: str, test_name: str | None = None, *, short: bool = False, count: bool = False) -> int:

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,12 @@
+anta_inventory:
+  hosts:
+  - host: 192.168.100.50
+    name: dc1-leaf1
+    tags:
+    - Quebec
+    - Bravo
+    - Echo
+  - host: 192.168.100.51
+    name: dc1-leaf2
+    tags:
+    - Bravo


### PR DESCRIPTION
# Description

Initial implementation to get NetBox as an inventory source. This has a lot of areas where it could be improved (logging, syntax, naming) but I hope this initial PR can get the idea implemented.

Example using the public NetBox demo instance:

```shell
> anta get from-netbox -nbi https://demo.netbox.dev -nbt 1092017ee4dba8515d37a6b0ab104cc5978331c7 -o test.yml
[16:20:14] INFO     Building inventory from netbox instance file          commands.py:119
                    'https://demo.netbox.dev'                                            
[16:20:15] INFO     ANTA inventory file has been created: 'test.yml'         utils.py:130
 ~/git/anta  netbox-inv !2 ?1 ............................................... 3.11.6 py 
> 
```

```yaml
anta_inventory:
  hosts:
  - host: 192.168.100.50
    name: dc1-leaf1
    tags:
    - Quebec
    - Bravo
    - Echo
  - host: 192.168.100.51
    name: dc1-leaf2
    tags:
    - Bravo

```

Still TODO:
- [ ] Add tests
- [ ] How to set verify to False as a parameter and pass pre-checks
- [ ] Documentation
- [ ] Improved Typing

Fixes #257

# Checklist:

<!-- Delete not relevant items !-->

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)
