### PR TITLE
fix(anta.tests): VerifyEVPNType2Route test fails for locally originated MAC/IP addresses

### DIFF
--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -885,6 +885,7 @@ class VerifyEVPNType2Route(AntaTest):
                     route_type = path.get("routeType", {})
                     if route_type.get("active") and route_type.get("valid"):
                         has_active_path = True
+                        break
             if not has_active_path:
                 bad_evpn_routes.extend(list(evpn_routes))
 

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -877,16 +877,16 @@ class VerifyEVPNType2Route(AntaTest):
             if not evpn_routes:
                 no_evpn_routes.append((address, vni))
                 continue
-            # Verify that each EVPN route has at least one valid and active path
-            for route, route_data in evpn_routes.items():
-                has_active_path = False
-                for path in route_data["evpnRoutePaths"]:
-                    if path["routeType"]["valid"] is True and path["routeType"]["active"] is True:
-                        # At least one path is valid and active, no need to check the other paths
+
+            # Verify that at least one EVPN route has at least one active/valid path across all learned routes from all RDs combined
+            has_active_path = False
+            for route_data in evpn_routes.values():
+                for path in route_data.get("evpnRoutePaths", []):
+                    route_type = path.get("routeType", {})
+                    if route_type.get("active") and route_type.get("valid"):
                         has_active_path = True
-                        break
-                if not has_active_path:
-                    bad_evpn_routes.append(route)
+            if not has_active_path:
+                bad_evpn_routes.extend(list(evpn_routes))
 
         if no_evpn_routes:
             self.result.is_failure(f"The following VXLAN endpoint do not have any EVPN Type-2 route: {no_evpn_routes}")

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -2815,8 +2815,8 @@ DATA: list[dict[str, Any]] = [
                         "evpnRoutePaths": [
                             {
                                 "routeType": {
-                                    "active": True,
-                                    "valid": True,
+                                    "active": False,
+                                    "valid": False,
                                 },
                             },
                         ]
@@ -3039,7 +3039,7 @@ DATA: list[dict[str, Any]] = [
         },
     },
     {
-        "name": "failure-multiple-routes-multiple-paths-not-active",
+        "name": "success-multiple-path-and-have-one-active/valid",
         "test": VerifyEVPNType2Route,
         "eos_data": [
             {
@@ -3084,10 +3084,7 @@ DATA: list[dict[str, Any]] = [
         ],
         "inputs": {"vxlan_endpoints": [{"address": "192.168.20.102", "vni": 10020}]},
         "expected": {
-            "result": "failure",
-            "messages": [
-                "The following EVPN Type-2 routes do not have at least one valid and active path: ['RD: 10.1.0.6:500 mac-ip 10020 aac1.ab4e.bec2 192.168.20.102']"
-            ],
+            "result": "success",
         },
     },
     {


### PR DESCRIPTION
# Description

Updated the test to at least one EVPN route has at least one active/valid path across all learned routes from all RDs combined

Fixes #950 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
