### PR TITLE
feat(anta): Added testcase to validate the STP disabled VLANs

### DIFF
--- a/anta/tests/stp.py
+++ b/anta/tests/stp.py
@@ -322,17 +322,14 @@ class VerifySTPDisabledVlans(AntaTest):
 
     Expected Results
     ----------------
-    *Success: The test will pass if all of the following conditions are met:
-
-      1. STP is properly configured on the device.
-      2. The specified VLAN(s) exist on the device.
-      3. STP is confirmed to be disabled for all the specified VLAN(s).
-
-    *Failure: The test will fail if any of the following condition is met:
-
-      1. STP is not configured on the device.
-      2. The specified VLAN(s) not exist on the device.
-      3. STP is confirmed to be enabled for any of the specified VLAN(s).
+    * Success: The test will pass if all of the following conditions are met:
+        - STP is properly configured on the device.
+        - The specified VLAN(s) exist on the device.
+        - STP is confirmed to be disabled for all the specified VLAN(s).
+    * Failure: The test will fail if any of the following condition is met:
+        - STP is not configured on the device.
+        - The specified VLAN(s) not exist on the device.
+        - STP is confirmed to be enabled for any of the specified VLAN(s).
 
     Examples
     --------

--- a/anta/tests/stp.py
+++ b/anta/tests/stp.py
@@ -317,7 +317,7 @@ class VerifySTPDisabledVlans(AntaTest):
     This test performs the following checks:
 
         1. Verifies that the STP is configured.
-        2. Verifies that the specified VLAN is exist on the device.
+        2. Verifies that the specified VLAN(s) exist on the device.
         3. Verifies that the STP is disabled for the specified VLAN(s).
 
     Expected Results
@@ -328,8 +328,8 @@ class VerifySTPDisabledVlans(AntaTest):
         - STP is confirmed to be disabled for all the specified VLAN(s).
     * Failure: The test will fail if any of the following condition is met:
         - STP is not configured on the device.
-        - The specified VLAN(s) not exist on the device.
-        - STP is confirmed to be enabled for any of the specified VLAN(s).
+        - The specified VLAN(s) do not exist on the device.
+        - STP is enabled for any of the specified VLAN(s).
 
     Examples
     --------
@@ -349,7 +349,7 @@ class VerifySTPDisabledVlans(AntaTest):
         """Input model for the VerifySTPDisabledVlans test."""
 
         vlans: list[Vlan]
-        """List of STP disabled VLAN(s)"""
+        """List of STP disabled VLAN(s)."""
 
     @AntaTest.anta_test
     def test(self) -> None:

--- a/anta/tests/stp.py
+++ b/anta/tests/stp.py
@@ -312,17 +312,27 @@ class VerifyStpTopologyChanges(AntaTest):
 
 
 class VerifySTPDisabledVlans(AntaTest):
-    """Verifies the STP disabled VLANs.
+    """Verifies the STP disabled VLAN(s).
 
     This test performs the following checks:
+
         1. Verifies that the STP is configured.
-        2. Verifies that the specified VLAN is present on the device.
-        3. Verifies that the STP is disabled for the specified VLANs.
+        2. Verifies that the specified VLAN is exist on the device.
+        3. Verifies that the STP is disabled for the specified VLAN(s).
 
     Expected Results
     ----------------
-    * Success: The test will pass if STP is disabled for the specified VLANs.
-    * Failure: The test will fail, if STP is enabled for the specified VLANs.
+    *Success: The test will pass if all of the following conditions are met:
+
+      1. STP is properly configured on the device.
+      2. The specified VLAN(s) exist on the device.
+      3. STP is confirmed to be disabled for all the specified VLAN(s).
+
+    *Failure: The test will fail if any of the following condition is met:
+
+      1. STP is not configured on the device.
+      2. The specified VLAN(s) not exist on the device.
+      3. STP is confirmed to be enabled for any of the specified VLAN(s).
 
     Examples
     --------
@@ -342,7 +352,7 @@ class VerifySTPDisabledVlans(AntaTest):
         """Input model for the VerifySTPDisabledVlans test."""
 
         vlans: list[Vlan]
-        """List of STP disabled VLANs"""
+        """List of STP disabled VLAN(s)"""
 
     @AntaTest.anta_test
     def test(self) -> None:
@@ -358,13 +368,11 @@ class VerifySTPDisabledVlans(AntaTest):
             return
 
         actual_vlans = list(stp_vlan_instances)
-        # Iterating on each VLAN mentioned in the inputs
+        # If the specified VLAN is not present on the device, STP is enabled for the VLAN(s), test fails.
         for vlan in self.inputs.vlans:
-            # If the specified VLAN is not present on the device, the test fails.
             if str(vlan) not in actual_vlans:
-                self.result.is_failure(f"VLAN: {vlan} is not found on the device")
+                self.result.is_failure(f"VLAN: {vlan} - Not configured")
                 continue
 
-            # If the STP is enabled for the specified VLANs, the test fails.
             if stp_vlan_instances.get(str(vlan)):
-                self.result.is_failure(f"VLAN: {vlan} STP is enabled")
+                self.result.is_failure(f"VLAN: {vlan} - STP is enabled")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -737,6 +737,11 @@ anta.tests.stp:
       # Verifies there is no STP blocked ports.
   - VerifySTPCounters:
       # Verifies there is no errors in STP BPDU packets.
+  - VerifySTPDisabledVlans:
+      # Verifies the STP disabled VLANs.
+      vlans:
+        - 6
+        - 4094
   - VerifySTPForwardingPorts:
       # Verifies that all interfaces are forwarding for a provided list of VLAN(s).
       vlans:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -738,7 +738,7 @@ anta.tests.stp:
   - VerifySTPCounters:
       # Verifies there is no errors in STP BPDU packets.
   - VerifySTPDisabledVlans:
-      # Verifies the STP disabled VLANs.
+      # Verifies the STP disabled VLAN(s).
       vlans:
         - 6
         - 4094

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -7,7 +7,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from anta.tests.stp import VerifySTPBlockedPorts, VerifySTPCounters, VerifySTPForwardingPorts, VerifySTPMode, VerifySTPRootPriority, VerifyStpTopologyChanges
+from anta.tests.stp import (
+    VerifySTPBlockedPorts,
+    VerifySTPCounters,
+    VerifySTPDisabledVlans,
+    VerifySTPForwardingPorts,
+    VerifySTPMode,
+    VerifySTPRootPriority,
+    VerifyStpTopologyChanges,
+)
 from tests.units.anta_tests import test
 
 DATA: list[dict[str, Any]] = [
@@ -485,5 +493,28 @@ DATA: list[dict[str, Any]] = [
         ],
         "inputs": {"threshold": 10},
         "expected": {"result": "failure", "messages": ["STP is not configured."]},
+    },
+    {
+        "name": "success-stp-disabled-vlans",
+        "test": VerifySTPDisabledVlans,
+        "eos_data": [{"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {}}, "6": {}, "4094": {}}}],
+        "inputs": {"vlans": ["6", "4094"]},
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-stp-not-configured",
+        "test": VerifySTPDisabledVlans,
+        "eos_data": [{"spanningTreeVlanInstances": {}}],
+        "inputs": {"vlans": ["6", "4094"]},
+        "expected": {"result": "failure", "messages": ["STP is not configured"]},
+    },
+    {
+        "name": "failure-stp-disabled-vlans-enabled",
+        "test": VerifySTPDisabledVlans,
+        "eos_data": [
+            {"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {}}, "6": {"spanningTreeVlanInstance": {}}, "4094": {"spanningTreeVlanInstance": {}}}}
+        ],
+        "inputs": {"vlans": ["6", "4094"]},
+        "expected": {"result": "failure", "messages": ["STP is enabled for the following VLANS: 6 4094"]},
     },
 ]

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -509,12 +509,21 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "failure", "messages": ["STP is not configured"]},
     },
     {
-        "name": "failure-stp-disabled-vlans-enabled",
+        "name": "failure-stp-disabled-vlans-not-found",
+        "test": VerifySTPDisabledVlans,
+        "eos_data": [
+            {"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {}}, "6": {"spanningTreeVlanInstance": {}}, "4094": {"spanningTreeVlanInstance": {}}}}
+        ],
+        "inputs": {"vlans": ["16", "4093"]},
+        "expected": {"result": "failure", "messages": ["VLAN: 16 is not found on the device", "VLAN: 4093 is not found on the device"]},
+    },
+    {
+        "name": "failure-stp-disabled-vlans",
         "test": VerifySTPDisabledVlans,
         "eos_data": [
             {"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {}}, "6": {"spanningTreeVlanInstance": {}}, "4094": {"spanningTreeVlanInstance": {}}}}
         ],
         "inputs": {"vlans": ["6", "4094"]},
-        "expected": {"result": "failure", "messages": ["STP is enabled for the following VLANS: 6 4094"]},
+        "expected": {"result": "failure", "messages": ["VLAN: 6 STP is enabled", "VLAN: 4094 STP is enabled"]},
     },
 ]

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -497,7 +497,7 @@ DATA: list[dict[str, Any]] = [
     {
         "name": "success-stp-disabled-vlans",
         "test": VerifySTPDisabledVlans,
-        "eos_data": [{"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {}}, "6": {}, "4094": {}}}],
+        "eos_data": [{"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {"priority": 32768}}}, "6": {}, "4094": {}}}],
         "inputs": {"vlans": ["6", "4094"]},
         "expected": {"result": "success"},
     },
@@ -512,18 +512,30 @@ DATA: list[dict[str, Any]] = [
         "name": "failure-stp-disabled-vlans-not-found",
         "test": VerifySTPDisabledVlans,
         "eos_data": [
-            {"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {}}, "6": {"spanningTreeVlanInstance": {}}, "4094": {"spanningTreeVlanInstance": {}}}}
+            {
+                "spanningTreeVlanInstances": {
+                    "1": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {}}},
+                    "6": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {}}},
+                    "4094": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {}}},
+                }
+            }
         ],
         "inputs": {"vlans": ["16", "4093"]},
-        "expected": {"result": "failure", "messages": ["VLAN: 16 is not found on the device", "VLAN: 4093 is not found on the device"]},
+        "expected": {"result": "failure", "messages": ["VLAN: 16 - Not configured", "VLAN: 4093 - Not configured"]},
     },
     {
         "name": "failure-stp-disabled-vlans",
         "test": VerifySTPDisabledVlans,
         "eos_data": [
-            {"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {}}, "6": {"spanningTreeVlanInstance": {}}, "4094": {"spanningTreeVlanInstance": {}}}}
+            {
+                "spanningTreeVlanInstances": {
+                    "1": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {}}},
+                    "6": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {}}},
+                    "4094": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {}}},
+                }
+            }
         ],
         "inputs": {"vlans": ["6", "4094"]},
-        "expected": {"result": "failure", "messages": ["VLAN: 6 STP is enabled", "VLAN: 4094 STP is enabled"]},
+        "expected": {"result": "failure", "messages": ["VLAN: 6 - STP is enabled", "VLAN: 4094 - STP is enabled"]},
     },
 ]

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -495,7 +495,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "failure", "messages": ["STP is not configured."]},
     },
     {
-        "name": "success-stp-disabled-vlans",
+        "name": "success",
         "test": VerifySTPDisabledVlans,
         "eos_data": [{"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {"priority": 32768}}}, "6": {}, "4094": {}}}],
         "inputs": {"vlans": ["6", "4094"]},
@@ -509,7 +509,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "failure", "messages": ["STP is not configured"]},
     },
     {
-        "name": "failure-stp-disabled-vlans-not-found",
+        "name": "failure-vlans-not-found",
         "test": VerifySTPDisabledVlans,
         "eos_data": [
             {
@@ -524,7 +524,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "failure", "messages": ["VLAN: 16 - Not configured", "VLAN: 4093 - Not configured"]},
     },
     {
-        "name": "failure-stp-disabled-vlans",
+        "name": "failure-vlans-enabled",
         "test": VerifySTPDisabledVlans,
         "eos_data": [
             {


### PR DESCRIPTION
# Description
This test performs the following checks:
        1. Verifies that the STP is configured.
        2. Verifies that the specified VLAN is present on the device.
        3. Verifies that the STP is disabled for the specified VLANs.

    Expected Results
    ----------------
    * Success: The test will pass if STP is disabled for the specified VLANs.
    * Failure: The test will fail, if STP is enabled for the specified VLANs

Fixes  #862 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
