### PR TITLE
test: idempotency of setup logger

### DIFF
--- a/anta/logger.py
+++ b/anta/logger.py
@@ -72,7 +72,7 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
     # Add RichHandler for stdout if not already present
     maybe_add_rich_handler = True
     if root.hasHandlers():
-        maybe_add_rich_handler = any(handler.get_name() == "ANTA_RICH_HANDLER" for handler in root.handlers)
+        maybe_add_rich_handler = all(handler.get_name() != "ANTA_RICH_HANDLER" for handler in root.handlers)
 
     if maybe_add_rich_handler:
         rich_handler = RichHandler(markup=True, rich_tracebacks=True, tracebacks_show_locals=False)

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -102,7 +102,7 @@ def _get_rich_handler(logger_instance: logging.Logger) -> logging.Handler | None
 
 def _maybe_add_rich_handler(loglevel: int, logger_instance: logging.Logger) -> None:
     """Add RichHandler for stdout if not already present."""
-    if _get_rich_handler is not None:
+    if _get_rich_handler(logger_instance) is not None:
         # Nothing to do.
         return
 

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -88,6 +88,10 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
 
 def _get_file_handler(logger_instance: logging.Logger, file: Path) -> logging.FileHandler | None:
     """Return the FileHandler if present."""
+    for handler in logger_instance.handlers:
+        if isinstance(handler, logging.FileHandler):
+            print(handler.baseFilename)  # noqa: T201
+
     return (
         next((handler for handler in logger_instance.handlers if isinstance(handler, logging.FileHandler) and handler.baseFilename == str(file)), None)
         if logger_instance.hasHandlers()

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -72,7 +72,7 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
     # Add RichHandler for stdout if not already present
     _maybe_add_rich_handler(loglevel, root)
 
-    # Add FileHandler if file is provided and same File Handler is not already present
+    # Add FileHandler if file is provided and same FileHandler is not already present
     if file and not _get_file_handler(root, file):
         file_handler = logging.FileHandler(file)
         formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -9,14 +9,12 @@ import logging
 import traceback
 from datetime import timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Literal
+from pathlib import Path
+from typing import Literal
 
 from rich.logging import RichHandler
 
 from anta import __DEBUG__
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +70,7 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
     # Add RichHandler for stdout if not already present
     _maybe_add_rich_handler(loglevel, root)
 
-    # Add FileHandler if file is provided and same FileHandler is not already present
+    # Add FileHandler if file is provided and same File Handler is not already present
     if file and not _get_file_handler(root, file):
         file_handler = logging.FileHandler(file)
         formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -88,9 +86,12 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
 
 def _get_file_handler(logger_instance: logging.Logger, file: Path) -> logging.FileHandler | None:
     """Return the FileHandler if present."""
+    # ruff: noqa: T201
     for handler in logger_instance.handlers:
         if isinstance(handler, logging.FileHandler):
-            print(handler.baseFilename)  # noqa: T201
+            print(handler.baseFilename)
+            print(Path(handler.baseFilename))
+        print(file)
 
     return (
         next((handler for handler in logger_instance.handlers if isinstance(handler, logging.FileHandler) and handler.baseFilename == str(file)), None)

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -87,7 +87,14 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
 def _get_file_handler(logger_instance: logging.Logger, file: Path) -> logging.FileHandler | None:
     """Return the FileHandler if present."""
     return (
-        next((handler for handler in logger_instance.handlers if isinstance(handler, logging.FileHandler) and Path(handler.baseFilename) == file), None)
+        next(
+            (
+                handler
+                for handler in logger_instance.handlers
+                if isinstance(handler, logging.FileHandler) and str(Path(handler.baseFilename).resolve()) == str(file.resolve())
+            ),
+            None,
+        )
         if logger_instance.hasHandlers()
         else None
     )

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -69,7 +69,12 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
         # httpx as well
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
-    # Add RichHandler for stdout
+    # Add RichHandler for stdout if not already present
+    if root.hasHandlers(): 
+        logger.handlers = []
+
+    root.
+
     rich_handler = RichHandler(markup=True, rich_tracebacks=True, tracebacks_show_locals=False)
     # Show Python module in stdout at DEBUG level
     fmt_string = "[grey58]\\[%(name)s][/grey58] %(message)s" if loglevel == logging.DEBUG else "%(message)s"

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -70,7 +70,7 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
         logging.getLogger("httpx").setLevel(logging.WARNING)
 
     # Add RichHandler for stdout if not already present
-    if root.hasHandlers(): 
+    if root.hasHandlers():
         logger.handlers = []
 
     root.

--- a/anta/logger.py
+++ b/anta/logger.py
@@ -86,15 +86,8 @@ def setup_logging(level: LogLevel = Log.INFO, file: Path | None = None) -> None:
 
 def _get_file_handler(logger_instance: logging.Logger, file: Path) -> logging.FileHandler | None:
     """Return the FileHandler if present."""
-    # ruff: noqa: T201
-    for handler in logger_instance.handlers:
-        if isinstance(handler, logging.FileHandler):
-            print(handler.baseFilename)
-            print(Path(handler.baseFilename))
-        print(file)
-
     return (
-        next((handler for handler in logger_instance.handlers if isinstance(handler, logging.FileHandler) and handler.baseFilename == str(file)), None)
+        next((handler for handler in logger_instance.handlers if isinstance(handler, logging.FileHandler) and Path(handler.baseFilename) == file), None)
         if logger_instance.hasHandlers()
         else None
     )

--- a/tests/units/test_logger.py
+++ b/tests/units/test_logger.py
@@ -6,15 +6,12 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from anta.logger import Log, LogLevel, _get_file_handler, _get_rich_handler, anta_log_exception, exc_to_str, setup_logging, tb_to_str
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.mark.parametrize(
@@ -22,8 +19,8 @@ if TYPE_CHECKING:
     [
         pytest.param(Log.INFO, None, False, id="INFO no file"),
         pytest.param(Log.DEBUG, None, False, id="DEBUG no file"),
-        pytest.param(Log.INFO, "/tmp/file.log", False, id="INFO file"),
-        pytest.param(Log.DEBUG, "/tmp/file.log", False, id="DEBUG file"),
+        pytest.param(Log.INFO, Path("/tmp/file.log"), False, id="INFO file"),
+        pytest.param(Log.DEBUG, Path("/tmp/file.log"), False, id="DEBUG file"),
         pytest.param(Log.INFO, None, True, id="INFO no file __DEBUG__ set"),
         pytest.param(Log.DEBUG, None, True, id="INFO no file __DEBUG__ set"),
     ],

--- a/tests/units/test_logger.py
+++ b/tests/units/test_logger.py
@@ -6,11 +6,57 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
-from anta.logger import anta_log_exception, exc_to_str, tb_to_str
+from anta.logger import Log, LogLevel, _get_file_handler, _get_rich_handler, anta_log_exception, exc_to_str, setup_logging, tb_to_str
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    ("level", "path", "debug_value"),
+    [
+        pytest.param(Log.INFO, None, False, id="INFO no file"),
+        pytest.param(Log.DEBUG, None, False, id="DEBUG no file"),
+        pytest.param(Log.INFO, "/tmp/file.log", False, id="INFO file"),
+        pytest.param(Log.DEBUG, "/tmp/file.log", False, id="DEBUG file"),
+        pytest.param(Log.INFO, None, True, id="INFO no file __DEBUG__ set"),
+        pytest.param(Log.DEBUG, None, True, id="INFO no file __DEBUG__ set"),
+    ],
+)
+def test_setup_logging(level: LogLevel, path: Path | None, debug_value: bool) -> None:
+    """Test setup_logging."""
+    # Clean up any logger on root
+    root = logging.getLogger()
+    if root.hasHandlers():
+        root.handlers = []
+
+    with patch("anta.logger.__DEBUG__", new=debug_value):
+        setup_logging(level, path)
+
+    rich_handler = _get_rich_handler(root)
+    assert rich_handler is not None
+
+    # When __DEBUG__ is True, the log level is overwritten to DEBUG
+    if debug_value:
+        assert root.level == logging.DEBUG
+        if path is not None:
+            assert rich_handler.level == logging.INFO
+
+    if path is not None:
+        assert _get_file_handler(root, path) is not None
+        expected_handlers = 2
+    else:
+        expected_handlers = 1
+    assert len(root.handlers) == expected_handlers
+
+    # Check idempotency
+    setup_logging(level, path)
+    assert len(root.handlers) == expected_handlers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Great news everyone - it is now MUCH faster to run the tests.. Locally it means 9s vs 74s for my machine.

The issue was that we were adding too many RichHandler when calling CliRunner multiple times...

**NOTE:** Logging need some more love.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
