### PR TITLE
fix(anta.tests): BFD test module: AntaTest.Input subclasses using common input models should have validators for their required fields.

### DIFF
--- a/anta/tests/bfd.py
+++ b/anta/tests/bfd.py
@@ -159,7 +159,7 @@ class VerifyBFDPeersIntervals(AntaTest):
                 if peer.multiplier is None:
                     missing_fileds.append("multiplier")
                 if missing_fileds:
-                    msg = f"{peer}; {', '.join(missing_fileds)} field(s) are missing in the input."
+                    msg = f"{peer} {', '.join(missing_fileds)} field(s) are missing in the input."
                     raise ValueError(msg)
             return bfd_peers
 
@@ -334,7 +334,7 @@ class VerifyBFDPeersRegProtocols(AntaTest):
             """Validate that 'protocols' field is provided in each BFD peer."""
             for peer in bfd_peers:
                 if peer.protocols is None:
-                    msg = f"{peer}; 'protocols' field missing in the input"
+                    msg = f"{peer} 'protocols' field missing in the input."
                     raise ValueError(msg)
             return bfd_peers
 

--- a/anta/tests/bfd.py
+++ b/anta/tests/bfd.py
@@ -148,17 +148,18 @@ class VerifyBFDPeersIntervals(AntaTest):
 
         @field_validator("bfd_peers")
         @classmethod
-        def validate_snmp_user(cls, bfd_peers: list[T]) -> list[T]:
-            """Validate that 'tx_interval', 'rx_interval' or 'multiplier' field is provided in each BFD peer."""
+        def validate_bfd_peers(cls, bfd_peers: list[T]) -> list[T]:
+            """Validate that 'tx_interval', 'rx_interval' and 'multiplier' fields are provided in each BFD peer."""
             for peer in bfd_peers:
+                missing_fileds = []
                 if peer.tx_interval is None:
-                    msg = f"{peer}; 'tx_interval' field missing in the input"
-                    raise ValueError(msg)
+                    missing_fileds.append("tx_interval")
                 if peer.rx_interval is None:
-                    msg = f"{peer}; 'rx_interval' field missing in the input"
-                    raise ValueError(msg)
+                    missing_fileds.append("rx_interval")
                 if peer.multiplier is None:
-                    msg = f"{peer}; 'multiplier' field missing in the input"
+                    missing_fileds.append("multiplier")
+                if missing_fileds:
+                    msg = f"{peer}; {', '.join(missing_fileds)} field(s) are missing in the input."
                     raise ValueError(msg)
             return bfd_peers
 
@@ -329,7 +330,7 @@ class VerifyBFDPeersRegProtocols(AntaTest):
 
         @field_validator("bfd_peers")
         @classmethod
-        def validate_snmp_user(cls, bfd_peers: list[T]) -> list[T]:
+        def validate_bfd_peers(cls, bfd_peers: list[T]) -> list[T]:
             """Validate that 'protocols' field is provided in each BFD peer."""
             for peer in bfd_peers:
                 if peer.protocols is None:

--- a/tests/units/input_models/test_bfd.py
+++ b/tests/units/input_models/test_bfd.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023-2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Tests for anta.input_models.bfd.py."""
+
+# pylint: disable=C0302
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+from anta.tests.bfd import VerifyBFDPeersIntervals, VerifyBFDPeersRegProtocols
+
+if TYPE_CHECKING:
+    from anta.input_models.bfd import BFDPeer
+
+
+class TestVerifyBFDPeersIntervalsInput:
+    """Test anta.tests.bfd.VerifyBFDPeersIntervals.Input."""
+
+    @pytest.mark.parametrize(
+        ("bfd_peers"),
+        [
+            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "tx_interval": 1200, "rx_interval": 1200, "multiplier": 3}], id="valid"),
+        ],
+    )
+    def test_valid(self, bfd_peers: list[BFDPeer]) -> None:
+        """Test VerifyBFDPeersIntervals.Input valid inputs."""
+        VerifyBFDPeersIntervals.Input(bfd_peers=bfd_peers)
+
+    @pytest.mark.parametrize(
+        ("bfd_peers"),
+        [
+            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "tx_interval": 1200}], id="invalid-tx-interval"),
+            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "rx_interval": 1200}], id="invalid-rx-interval"),
+            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "multiplier": 3}], id="invalid-multiplier"),
+        ],
+    )
+    def test_invalid(self, bfd_peers: list[BFDPeer]) -> None:
+        """Test VerifyBFDPeersIntervals.Input invalid inputs."""
+        with pytest.raises(ValidationError):
+            VerifyBFDPeersIntervals.Input(bfd_peers=bfd_peers)
+
+
+class TestVerifyBFDPeersRegProtocolsInput:
+    """Test anta.tests.bfd.VerifyBFDPeersRegProtocols.Input."""
+
+    @pytest.mark.parametrize(
+        ("bfd_peers"),
+        [
+            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "protocols": ["bgp"]}], id="valid"),
+        ],
+    )
+    def test_valid(self, bfd_peers: list[BFDPeer]) -> None:
+        """Test VerifyBFDPeersRegProtocols.Input valid inputs."""
+        VerifyBFDPeersRegProtocols.Input(bfd_peers=bfd_peers)
+
+    @pytest.mark.parametrize(
+        ("bfd_peers"),
+        [
+            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default"}], id="invalid"),
+        ],
+    )
+    def test_invalid(self, bfd_peers: list[BFDPeer]) -> None:
+        """Test VerifyBFDPeersRegProtocols.Input invalid inputs."""
+        with pytest.raises(ValidationError):
+            VerifyBFDPeersRegProtocols.Input(bfd_peers=bfd_peers)

--- a/tests/units/input_models/test_bfd.py
+++ b/tests/units/input_models/test_bfd.py
@@ -3,7 +3,6 @@
 # that can be found in the LICENSE file.
 """Tests for anta.input_models.bfd.py."""
 
-# pylint: disable=C0302
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/units/input_models/test_bfd.py
+++ b/tests/units/input_models/test_bfd.py
@@ -35,7 +35,7 @@ class TestVerifyBFDPeersIntervalsInput:
         [
             pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "tx_interval": 1200}], id="invalid-tx-interval"),
             pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "rx_interval": 1200}], id="invalid-rx-interval"),
-            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "multiplier": 3}], id="invalid-multiplier"),
+            pytest.param([{"peer_address": "10.0.0.1", "vrf": "default", "tx_interval": 1200, "rx_interval": 1200}], id="invalid-multiplier"),
         ],
     )
     def test_invalid(self, bfd_peers: list[BFDPeer]) -> None:


### PR DESCRIPTION
# Description

BFD test module: AntaTest.Input subclasses using common input models should have validators for their required fields.

Fixes #997 

# Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
