### PR TITLE
fix(anta.tests): VerifyUnifiedForwardingTableMode test is now skipped on unsupported platforms

### DIFF
--- a/anta/constants.py
+++ b/anta/constants.py
@@ -47,8 +47,9 @@ KNOWN_EOS_ERRORS = [
 """List of known EOS errors that should set a test status to 'failure' with the error message."""
 
 UNSUPPORTED_PLATFORM_ERRORS = [
+    "not supported on this hardware platform",
     "Invalid input (at token 2: 'trident')",
 ]
-"""Error messages when using `show platform <family> <command>` on unsupported ASIC families.
-Will set the test status to 'skipped' with the unsupported command. More errors can be added
-for different platforms if tests require it."""
+"""Error messages indicating platform or hardware unsupported commands.
+Will set the test status to 'skipped'. Includes both general hardware
+platform errors and specific ASIC family limitations."""

--- a/anta/constants.py
+++ b/anta/constants.py
@@ -45,3 +45,10 @@ KNOWN_EOS_ERRORS = [
     r"No source interface .*",
 ]
 """List of known EOS errors that should set a test status to 'failure' with the error message."""
+
+UNSUPPORTED_PLATFORM_ERRORS = [
+    "Invalid input (at token 2: 'trident')",
+]
+"""Error messages when using `show platform <family> <command>` on unsupported ASIC families.
+Will set the test status to 'skipped' with the unsupported command. More errors can be added
+for different platforms if tests require it."""

--- a/anta/models.py
+++ b/anta/models.py
@@ -258,7 +258,7 @@ class AntaCommand(BaseModel):
 
             raise RuntimeError(msg)
 
-        return all(not any(error in e for error in UNSUPPORTED_PLATFORM_ERRORS) for e in self.errors)
+        return not any(any(error in e for error in UNSUPPORTED_PLATFORM_ERRORS) for e in self.errors)
 
     @property
     def returned_known_eos_error(self) -> bool:

--- a/anta/models.py
+++ b/anta/models.py
@@ -15,8 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, ValidationError, create_model
 
-from anta import GITHUB_SUGGESTION
-from anta.constants import KNOWN_EOS_ERRORS
+from anta.constants import KNOWN_EOS_ERRORS, UNSUPPORTED_PLATFORM_ERRORS
 from anta.custom_types import REGEXP_EOS_BLACKLIST_CMDS, Revision
 from anta.logger import anta_log_exception, exc_to_str
 from anta.result_manager.models import AntaTestStatus, TestResult
@@ -258,7 +257,11 @@ class AntaCommand(BaseModel):
             msg = f"Command '{self.command}' has not been collected and has not returned an error. Call AntaDevice.collect()."
 
             raise RuntimeError(msg)
-        return all("not supported on this hardware platform" not in e for e in self.errors)
+
+        return all(
+            "not supported on this hardware platform" not in e and not any(platform_error in e for platform_error in UNSUPPORTED_PLATFORM_ERRORS)
+            for e in self.errors
+        )
 
     @property
     def returned_known_eos_error(self) -> bool:
@@ -683,8 +686,6 @@ class AntaTest(ABC):
         cmds = self.failed_commands
         unsupported_commands = [f"'{c.command}' is not supported on {self.device.hw_model}" for c in cmds if not c.supported]
         if unsupported_commands:
-            msg = f"Test {self.name} has been skipped because it is not supported on {self.device.hw_model}: {GITHUB_SUGGESTION}"
-            self.logger.warning(msg)
             self.result.is_skipped("\n".join(unsupported_commands))
             return
         returned_known_eos_error = [f"'{c.command}' failed on {self.device.name}: {', '.join(c.errors)}" for c in cmds if c.returned_known_eos_error]

--- a/anta/models.py
+++ b/anta/models.py
@@ -258,10 +258,7 @@ class AntaCommand(BaseModel):
 
             raise RuntimeError(msg)
 
-        return all(
-            "not supported on this hardware platform" not in e and not any(platform_error in e for platform_error in UNSUPPORTED_PLATFORM_ERRORS)
-            for e in self.errors
-        )
+        return all(not any(error in e for error in UNSUPPORTED_PLATFORM_ERRORS) for e in self.errors)
 
     @property
     def returned_known_eos_error(self) -> bool:

--- a/anta/tests/profiles.py
+++ b/anta/tests/profiles.py
@@ -51,7 +51,7 @@ class VerifyUnifiedForwardingTableMode(AntaTest):
         if command_output["uftMode"] == str(self.inputs.mode):
             self.result.is_success()
         else:
-            self.result.is_failure(f"Device is not running correct UFT mode (expected: {self.inputs.mode} / running: {command_output['uftMode']})")
+            self.result.is_failure(f"Not running the correct UFT mode - Expected: {self.inputs.mode}, Actual: {command_output['uftMode']}")
 
 
 class VerifyTcamProfile(AntaTest):

--- a/tests/units/anta_tests/test_profiles.py
+++ b/tests/units/anta_tests/test_profiles.py
@@ -23,7 +23,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyUnifiedForwardingTableMode,
         "eos_data": [{"uftMode": "2", "urpfEnabled": False, "chipModel": "bcm56870", "l2TableSize": 163840, "l3TableSize": 147456, "lpmTableSize": 32768}],
         "inputs": {"mode": 3},
-        "expected": {"result": "failure", "messages": ["Device is not running correct UFT mode (expected: 3 / running: 2)"]},
+        "expected": {"result": "failure", "messages": ["Not running the correct UFT mode - Expected: 3, Actual: 2"]},
     },
     {
         "name": "success",


### PR DESCRIPTION
Fixes #607 

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
