### PR TITLE
fix(anta.tests): AntaTest.Input subclasses using common input models should have validators for their required fields.

### DIFF
--- a/anta/input_models/routing/bgp.py
+++ b/anta/input_models/routing/bgp.py
@@ -224,8 +224,8 @@ class BgpRoute(BaseModel):
     """The IPv4 network address."""
     vrf: str = "default"
     """Optional VRF for the BGP peer. Defaults to `default`."""
-    paths: list[BgpRoutePath] | None = None
-    """A list of paths for the BGP route. Required field in the `VerifyBGPRouteOrigin` test."""
+    paths: list[BgpRoutePath]
+    """A list of paths for the BGP route."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the BgpRoute for reporting.

--- a/anta/input_models/routing/generic.py
+++ b/anta/input_models/routing/generic.py
@@ -17,11 +17,11 @@ class IPv4Routes(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     prefix: IPv4Network
-    """The IPV4 network to validate the route type."""
+    """IPv4 prefix in CIDR notation."""
     vrf: str = "default"
     """VRF context. Defaults to `default` VRF."""
     route_type: IPv4RouteType | None = None
-    """List of IPV4 Route type to validate the valid rout type. Required field in the `VerifyIPv4RouteType` test."""
+    """Expected route type. Required field in the `VerifyIPv4RouteType` test."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the IPv4RouteType for reporting."""

--- a/anta/input_models/routing/generic.py
+++ b/anta/input_models/routing/generic.py
@@ -20,8 +20,8 @@ class IPv4Routes(BaseModel):
     """The IPV4 network to validate the route type."""
     vrf: str = "default"
     """VRF context. Defaults to `default` VRF."""
-    route_type: IPv4RouteType
-    """List of IPV4 Route type to validate the valid rout type."""
+    route_type: IPv4RouteType | None = None
+    """List of IPV4 Route type to validate the valid rout type. Required field in the `VerifyIPv4RouteType` test."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the IPv4RouteType for reporting."""

--- a/anta/tests/routing/generic.py
+++ b/anta/tests/routing/generic.py
@@ -11,7 +11,7 @@ from functools import cache
 from ipaddress import IPv4Address, IPv4Interface
 from typing import TYPE_CHECKING, ClassVar, Literal
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 
 from anta.custom_types import PositiveInteger
 from anta.input_models.routing.generic import IPv4Routes
@@ -189,9 +189,10 @@ class VerifyIPv4RouteType(AntaTest):
     """Verifies the route-type of the IPv4 prefixes.
 
     This test performs the following checks for each IPv4 route:
-        1. Verifies that the specified VRF is configured.
-        2. Verifies that the specified IPv4 route is exists in the configuration.
-        3. Verifies that the the specified IPv4 route is of the expected type.
+
+      1. Verifies that the specified VRF is configured.
+      2. Verifies that the specified IPv4 route is exists in the configuration.
+      3. Verifies that the the specified IPv4 route is of the expected type.
 
     Expected Results
     ----------------
@@ -230,6 +231,17 @@ class VerifyIPv4RouteType(AntaTest):
         """Input model for the VerifyIPv4RouteType test."""
 
         routes_entries: list[IPv4Routes]
+        """List of IPv4 route(s)."""
+
+        @field_validator("routes_entries")
+        @classmethod
+        def validate_routes_entries(cls, routes_entries: list[IPv4Routes]) -> list[IPv4Routes]:
+            """Validate that 'route_type' field is provided in each BGP route entry."""
+            for entry in routes_entries:
+                if entry.route_type is None:
+                    msg = f"{entry} 'route_type' field missing in the input"
+                    raise ValueError(msg)
+            return routes_entries
 
     @AntaTest.anta_test
     def test(self) -> None:

--- a/tests/units/input_models/routing/test_generic.py
+++ b/tests/units/input_models/routing/test_generic.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023-2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Tests for anta.input_models.routing.generic.py."""
+
+# pylint: disable=C0302
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+from anta.tests.routing.generic import VerifyIPv4RouteType
+
+if TYPE_CHECKING:
+    from anta.input_models.routing.generic import IPv4Routes
+
+
+class TestVerifyIPv4RouteTypeInput:
+    """Test anta.tests.routing.bgp.VerifyIPv4RouteType.Input."""
+
+    @pytest.mark.parametrize(
+        ("routes_entries"),
+        [
+            pytest.param([{"prefix": "192.168.0.0/24", "vrf": "default", "route_type": "eBGP"}], id="valid"),
+        ],
+    )
+    def test_valid(self, routes_entries: list[IPv4Routes]) -> None:
+        """Test VerifyIPv4RouteType.Input valid inputs."""
+        VerifyIPv4RouteType.Input(routes_entries=routes_entries)
+
+    @pytest.mark.parametrize(
+        ("routes_entries"),
+        [
+            pytest.param([{"prefix": "192.168.0.0/24", "vrf": "default"}], id="invalid"),
+        ],
+    )
+    def test_invalid(self, routes_entries: list[IPv4Routes]) -> None:
+        """Test VerifyIPv4RouteType.Input invalid inputs."""
+        with pytest.raises(ValidationError):
+            VerifyIPv4RouteType.Input(routes_entries=routes_entries)

--- a/tests/units/input_models/routing/test_generic.py
+++ b/tests/units/input_models/routing/test_generic.py
@@ -3,7 +3,6 @@
 # that can be found in the LICENSE file.
 """Tests for anta.input_models.routing.generic.py."""
 
-# pylint: disable=C0302
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from pydantic import ValidationError
 
 from anta.input_models.interfaces import InterfaceState
+from anta.tests.interfaces import VerifyInterfacesStatus, VerifyLACPInterfacesStatus
 
 if TYPE_CHECKING:
     from anta.custom_types import Interface, PortChannelInterface
@@ -31,3 +33,53 @@ class TestInterfaceState:
     def test_valid__str__(self, name: Interface, portchannel: PortChannelInterface | None, expected: str) -> None:
         """Test InterfaceState __str__."""
         assert str(InterfaceState(name=name, portchannel=portchannel)) == expected
+
+
+class TestVerifyInterfacesStatusInput:
+    """Test anta.tests.interfaces.VerifyInterfacesStatus.Input."""
+
+    @pytest.mark.parametrize(
+        ("interfaces"),
+        [
+            pytest.param([{"name": "Ethernet1", "status": "up"}], id="valid"),
+        ],
+    )
+    def test_valid(self, interfaces: list[InterfaceState]) -> None:
+        """Test VerifyInterfacesStatus.Input valid inputs."""
+        VerifyInterfacesStatus.Input(interfaces=interfaces)
+
+    @pytest.mark.parametrize(
+        ("interfaces"),
+        [
+            pytest.param([{"name": "Ethernet1"}], id="invalid"),
+        ],
+    )
+    def test_invalid(self, interfaces: list[InterfaceState]) -> None:
+        """Test VerifyInterfacesStatus.Input invalid inputs."""
+        with pytest.raises(ValidationError):
+            VerifyInterfacesStatus.Input(interfaces=interfaces)
+
+
+class TestVerifyLACPInterfacesStatusInput:
+    """Test anta.tests.interfaces.VerifyLACPInterfacesStatus.Input."""
+
+    @pytest.mark.parametrize(
+        ("interfaces"),
+        [
+            pytest.param([{"name": "Ethernet1", "portchannel": "Port-Channel100"}], id="valid"),
+        ],
+    )
+    def test_valid(self, interfaces: list[InterfaceState]) -> None:
+        """Test VerifyLACPInterfacesStatus.Input valid inputs."""
+        VerifyLACPInterfacesStatus.Input(interfaces=interfaces)
+
+    @pytest.mark.parametrize(
+        ("interfaces"),
+        [
+            pytest.param([{"name": "Ethernet1"}], id="invalid"),
+        ],
+    )
+    def test_invalid(self, interfaces: list[InterfaceState]) -> None:
+        """Test VerifyLACPInterfacesStatus.Input invalid inputs."""
+        with pytest.raises(ValidationError):
+            VerifyLACPInterfacesStatus.Input(interfaces=interfaces)


### PR DESCRIPTION
# Description

AntaTest.Input subclasses using common input models should have validators for their required fields.

### Changes

- input_models/bgp : `route_type` marked as required key and no reuse.
- tests/interfaces.py : Added validators for `status` field in VerifyInterfacesStatus test
- tests/interfaces.py : Added validators for `portchannel ` field in VerifyLACPInterfacesStatus test
- tests/routing/generic.py : Added validators for `route_type ` field in VerifyIPv4RouteType test


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
