### PR TITLE
refactor(anta.tests): Nicer result failure messages generic routing module

### DIFF
--- a/anta/tests/routing/generic.py
+++ b/anta/tests/routing/generic.py
@@ -112,7 +112,7 @@ class VerifyRoutingTableSize(AntaTest):
         if self.inputs.minimum <= total_routes <= self.inputs.maximum:
             self.result.is_success()
         else:
-            self.result.is_failure(f"routing-table has {total_routes} routes and not between min `{self.inputs.minimum}` and maximum `{self.inputs.maximum}`")
+            self.result.is_failure(f"Routing table has {total_routes} routes, outside the range of {self.inputs.minimum} to {self.inputs.maximum}")
 
 
 class VerifyRoutingTableEntry(AntaTest):

--- a/anta/tests/routing/generic.py
+++ b/anta/tests/routing/generic.py
@@ -112,7 +112,7 @@ class VerifyRoutingTableSize(AntaTest):
         if self.inputs.minimum <= total_routes <= self.inputs.maximum:
             self.result.is_success()
         else:
-            self.result.is_failure(f"routing-table has {total_routes} routes and not between min ({self.inputs.minimum}) and maximum ({self.inputs.maximum})")
+            self.result.is_failure(f"routing-table has {total_routes} routes and not between min `{self.inputs.minimum}` and maximum `{self.inputs.maximum}`")
 
 
 class VerifyRoutingTableEntry(AntaTest):
@@ -182,7 +182,7 @@ class VerifyRoutingTableEntry(AntaTest):
         if not missing_routes:
             self.result.is_success()
         else:
-            self.result.is_failure(f"The following route(s) are missing from the routing table of VRF {self.inputs.vrf}: {missing_routes}")
+            self.result.is_failure(f"The following route(s) are missing from the routing table of VRF {self.inputs.vrf}: {', '.join(missing_routes)}")
 
 
 class VerifyIPv4RouteType(AntaTest):

--- a/tests/units/anta_tests/routing/test_generic.py
+++ b/tests/units/anta_tests/routing/test_generic.py
@@ -68,7 +68,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"minimum": 42, "maximum": 666},
-        "expected": {"result": "failure", "messages": ["routing-table has 1000 routes and not between min `42` and maximum `666`"]},
+        "expected": {"result": "failure", "messages": ["Routing table contains 1000 routes, outside the range of 42 to 666"]},
     },
     {
         "name": "success",

--- a/tests/units/anta_tests/routing/test_generic.py
+++ b/tests/units/anta_tests/routing/test_generic.py
@@ -68,7 +68,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"minimum": 42, "maximum": 666},
-        "expected": {"result": "failure", "messages": ["Routing table contains 1000 routes, outside the range of 42 to 666"]},
+        "expected": {"result": "failure", "messages": ["Routing table has 1000 routes, outside the range of 42 to 666"]},
     },
     {
         "name": "success",

--- a/tests/units/anta_tests/routing/test_generic.py
+++ b/tests/units/anta_tests/routing/test_generic.py
@@ -68,7 +68,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"minimum": 42, "maximum": 666},
-        "expected": {"result": "failure", "messages": ["routing-table has 1000 routes and not between min (42) and maximum (666)"]},
+        "expected": {"result": "failure", "messages": ["routing-table has 1000 routes and not between min `42` and maximum `666`"]},
     },
     {
         "name": "success",
@@ -204,9 +204,20 @@ DATA: list[dict[str, Any]] = [
                     },
                 },
             },
+            {
+                "vrfs": {
+                    "default": {
+                        "routingDisabled": False,
+                        "allRoutesProgrammedHardware": True,
+                        "allRoutesProgrammedKernel": True,
+                        "defaultRouteState": "notSet",
+                        "routes": {},
+                    },
+                },
+            },
         ],
-        "inputs": {"vrf": "default", "routes": ["10.1.0.1", "10.1.0.2"]},
-        "expected": {"result": "failure", "messages": ["The following route(s) are missing from the routing table of VRF default: ['10.1.0.1']"]},
+        "inputs": {"vrf": "default", "routes": ["10.1.0.1", "10.1.0.2", "10.1.0.3"]},
+        "expected": {"result": "failure", "messages": ["The following route(s) are missing from the routing table of VRF default: 10.1.0.1, 10.1.0.3"]},
     },
     {
         "name": "failure-wrong-route",
@@ -260,7 +271,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"vrf": "default", "routes": ["10.1.0.1", "10.1.0.2"]},
-        "expected": {"result": "failure", "messages": ["The following route(s) are missing from the routing table of VRF default: ['10.1.0.2']"]},
+        "expected": {"result": "failure", "messages": ["The following route(s) are missing from the routing table of VRF default: 10.1.0.2"]},
     },
     {
         "name": "failure-wrong-route-collect-all",
@@ -302,7 +313,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"vrf": "default", "routes": ["10.1.0.1", "10.1.0.2"], "collect": "all"},
-        "expected": {"result": "failure", "messages": ["The following route(s) are missing from the routing table of VRF default: ['10.1.0.2']"]},
+        "expected": {"result": "failure", "messages": ["The following route(s) are missing from the routing table of VRF default: 10.1.0.2"]},
     },
     {
         "name": "success-valid-route-type",


### PR DESCRIPTION
# Description

Updated failure messages for following tests
1. VerifyRoutingTableSize
2. VerifyRoutingTableEntry

Fixes #587 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
