### PR TITLE
refactor(anta.tests): Nicer result failure messages for Logging and security test module

### DIFF
--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -192,7 +192,7 @@ class VerifyLoggingHosts(AntaTest):
         if not not_configured:
             self.result.is_success()
         else:
-            self.result.is_failure(f"Syslog servers {not_configured} are not configured in VRF {self.inputs.vrf}")
+            self.result.is_failure(f"Syslog servers {', '.join(not_configured)} are not configured in VRF {self.inputs.vrf}")
 
 
 class VerifyLoggingLogsGeneration(AntaTest):

--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -96,7 +96,7 @@ class VerifySSHIPv4Acl(AntaTest):
         not_configured_acl = [acl["name"] for acl in ipv4_acl_list if self.inputs.vrf not in acl["configuredVrfs"] or self.inputs.vrf not in acl["activeVrfs"]]
 
         if not_configured_acl:
-            self.result.is_failure(f"SSH IPv4 ACL(s) not configured or active in vrf {self.inputs.vrf}: {not_configured_acl}")
+            self.result.is_failure(f"SSH IPv4 ACL(s) not configured or active in vrf {self.inputs.vrf}: {', '.join(not_configured_acl)}")
         else:
             self.result.is_success()
 
@@ -144,7 +144,7 @@ class VerifySSHIPv6Acl(AntaTest):
         not_configured_acl = [acl["name"] for acl in ipv6_acl_list if self.inputs.vrf not in acl["configuredVrfs"] or self.inputs.vrf not in acl["activeVrfs"]]
 
         if not_configured_acl:
-            self.result.is_failure(f"SSH IPv6 ACL(s) not configured or active in vrf {self.inputs.vrf}: {not_configured_acl}")
+            self.result.is_failure(f"SSH IPv6 ACL(s) not configured or active in vrf {self.inputs.vrf}: {', '.join(not_configured_acl)}")
         else:
             self.result.is_success()
 
@@ -224,7 +224,6 @@ class VerifyAPIHttpsSSL(AntaTest):
     ```
     """
 
-    description = "Verifies if the eAPI has a valid SSL profile."
     categories: ClassVar[list[str]] = ["security"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show management api http-commands", revision=1)]
 
@@ -242,10 +241,10 @@ class VerifyAPIHttpsSSL(AntaTest):
             if command_output["sslProfile"]["name"] == self.inputs.profile and command_output["sslProfile"]["state"] == "valid":
                 self.result.is_success()
             else:
-                self.result.is_failure(f"eAPI HTTPS server SSL profile ({self.inputs.profile}) is misconfigured or invalid")
+                self.result.is_failure(f"eAPI HTTPS server SSL profile: {self.inputs.profile} is misconfigured or invalid")
 
         except KeyError:
-            self.result.is_failure(f"eAPI HTTPS server SSL profile ({self.inputs.profile}) is not configured")
+            self.result.is_failure(f"eAPI HTTPS server SSL profile: {self.inputs.profile} is not configured")
 
 
 class VerifyAPIIPv4Acl(AntaTest):
@@ -290,7 +289,7 @@ class VerifyAPIIPv4Acl(AntaTest):
         not_configured_acl = [acl["name"] for acl in ipv4_acl_list if self.inputs.vrf not in acl["configuredVrfs"] or self.inputs.vrf not in acl["activeVrfs"]]
 
         if not_configured_acl:
-            self.result.is_failure(f"eAPI IPv4 ACL(s) not configured or active in vrf {self.inputs.vrf}: {not_configured_acl}")
+            self.result.is_failure(f"eAPI IPv4 ACL(s) not configured or active in vrf {self.inputs.vrf}: {', '.join(not_configured_acl)}")
         else:
             self.result.is_success()
 
@@ -338,7 +337,7 @@ class VerifyAPIIPv6Acl(AntaTest):
         not_configured_acl = [acl["name"] for acl in ipv6_acl_list if self.inputs.vrf not in acl["configuredVrfs"] or self.inputs.vrf not in acl["activeVrfs"]]
 
         if not_configured_acl:
-            self.result.is_failure(f"eAPI IPv6 ACL(s) not configured or active in vrf {self.inputs.vrf}: {not_configured_acl}")
+            self.result.is_failure(f"eAPI IPv6 ACL(s) not configured or active in vrf {self.inputs.vrf}: {', '.join(not_configured_acl)}")
         else:
             self.result.is_success()
 

--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -241,10 +241,10 @@ class VerifyAPIHttpsSSL(AntaTest):
             if command_output["sslProfile"]["name"] == self.inputs.profile and command_output["sslProfile"]["state"] == "valid":
                 self.result.is_success()
             else:
-                self.result.is_failure(f"eAPI HTTPS server SSL profile: {self.inputs.profile} is misconfigured or invalid")
+                self.result.is_failure(f"eAPI HTTPS server SSL profile {self.inputs.profile} is misconfigured or invalid")
 
         except KeyError:
-            self.result.is_failure(f"eAPI HTTPS server SSL profile: {self.inputs.profile} is not configured")
+            self.result.is_failure(f"eAPI HTTPS server SSL profile {self.inputs.profile} is not configured")
 
 
 class VerifyAPIIPv4Acl(AntaTest):

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -664,7 +664,7 @@ anta.tests.security:
   - VerifyAPIHttpStatus:
       # Verifies if eAPI HTTP server is disabled globally.
   - VerifyAPIHttpsSSL:
-      # Verifies if the eAPI has a valid SSL profile.
+      # Verifies if eAPI HTTPS server SSL profile is configured and valid.
       profile: default
   - VerifyAPIIPv4Acl:
       # Verifies if eAPI has the right number IPv4 ACL(s) configured for a specified VRF.

--- a/tests/units/anta_tests/test_logging.py
+++ b/tests/units/anta_tests/test_logging.py
@@ -142,7 +142,7 @@ DATA: list[dict[str, Any]] = [
                 """,
         ],
         "inputs": {"hosts": ["10.22.10.92", "10.22.10.93", "10.22.10.94"], "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["Syslog servers ['10.22.10.93', '10.22.10.94'] are not configured in VRF MGMT"]},
+        "expected": {"result": "failure", "messages": ["Syslog servers 10.22.10.93, 10.22.10.94 are not configured in VRF MGMT"]},
     },
     {
         "name": "failure-vrf",
@@ -157,7 +157,7 @@ DATA: list[dict[str, Any]] = [
                 """,
         ],
         "inputs": {"hosts": ["10.22.10.92", "10.22.10.93", "10.22.10.94"], "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["Syslog servers ['10.22.10.93', '10.22.10.94'] are not configured in VRF MGMT"]},
+        "expected": {"result": "failure", "messages": ["Syslog servers 10.22.10.93, 10.22.10.94 are not configured in VRF MGMT"]},
     },
     {
         "name": "success",

--- a/tests/units/anta_tests/test_security.py
+++ b/tests/units/anta_tests/test_security.py
@@ -90,7 +90,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySSHIPv4Acl,
         "eos_data": [{"ipAclList": {"aclList": [{"type": "Ip4Acl", "name": "ACL_IPV4_SSH", "configuredVrfs": ["default"], "activeVrfs": ["default"]}]}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["SSH IPv4 ACL(s) not configured or active in vrf MGMT: ['ACL_IPV4_SSH']"]},
+        "expected": {"result": "failure", "messages": ["SSH IPv4 ACL(s) not configured or active in vrf MGMT: ACL_IPV4_SSH"]},
     },
     {
         "name": "success",
@@ -111,7 +111,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySSHIPv6Acl,
         "eos_data": [{"ipv6AclList": {"aclList": [{"type": "Ip6Acl", "name": "ACL_IPV6_SSH", "configuredVrfs": ["default"], "activeVrfs": ["default"]}]}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["SSH IPv6 ACL(s) not configured or active in vrf MGMT: ['ACL_IPV6_SSH']"]},
+        "expected": {"result": "failure", "messages": ["SSH IPv6 ACL(s) not configured or active in vrf MGMT: ACL_IPV6_SSH"]},
     },
     {
         "name": "success",
@@ -192,7 +192,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"profile": "API_SSL_Profile"},
-        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile (API_SSL_Profile) is not configured"]},
+        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile: API_SSL_Profile is not configured"]},
     },
     {
         "name": "failure-misconfigured-invalid",
@@ -209,7 +209,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"profile": "API_SSL_Profile"},
-        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile (API_SSL_Profile) is misconfigured or invalid"]},
+        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile: API_SSL_Profile is misconfigured or invalid"]},
     },
     {
         "name": "success",
@@ -230,7 +230,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyAPIIPv4Acl,
         "eos_data": [{"ipAclList": {"aclList": [{"type": "Ip4Acl", "name": "ACL_IPV4_API", "configuredVrfs": ["default"], "activeVrfs": ["default"]}]}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["eAPI IPv4 ACL(s) not configured or active in vrf MGMT: ['ACL_IPV4_API']"]},
+        "expected": {"result": "failure", "messages": ["eAPI IPv4 ACL(s) not configured or active in vrf MGMT: ACL_IPV4_API"]},
     },
     {
         "name": "success",
@@ -251,7 +251,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyAPIIPv6Acl,
         "eos_data": [{"ipv6AclList": {"aclList": [{"type": "Ip6Acl", "name": "ACL_IPV6_API", "configuredVrfs": ["default"], "activeVrfs": ["default"]}]}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["eAPI IPv6 ACL(s) not configured or active in vrf MGMT: ['ACL_IPV6_API']"]},
+        "expected": {"result": "failure", "messages": ["eAPI IPv6 ACL(s) not configured or active in vrf MGMT: ACL_IPV6_API"]},
     },
     {
         "name": "success",

--- a/tests/units/anta_tests/test_security.py
+++ b/tests/units/anta_tests/test_security.py
@@ -192,7 +192,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"profile": "API_SSL_Profile"},
-        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile: API_SSL_Profile is not configured"]},
+        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile API_SSL_Profile is not configured"]},
     },
     {
         "name": "failure-misconfigured-invalid",
@@ -209,7 +209,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"profile": "API_SSL_Profile"},
-        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile: API_SSL_Profile is misconfigured or invalid"]},
+        "expected": {"result": "failure", "messages": ["eAPI HTTPS server SSL profile API_SSL_Profile is misconfigured or invalid"]},
     },
     {
         "name": "success",


### PR DESCRIPTION
# Description

Updated failure messages for following tests
1. test_logging.py
    1. VerifyLoggingHosts
    
2. test_security.py
    1. VerifySSHIPv4Acl
    2. VerifySSHIPv6Acl
    3. VerifyAPIHttpsSSL
    4. VerifyAPIIPv4Acl 
   5. VerifyAPIIPv6Acl    
   
Fixes # (issue id) #587

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have updated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
