### PR TITLE
refactor(anta.tests): Nicer result failure messages AVT, field_notice test module 

### DIFF
--- a/anta/input_models/avt.py
+++ b/anta/input_models/avt.py
@@ -33,4 +33,4 @@ class AVTPath(BaseModel):
         AVT CONTROL-PLANE-PROFILE VRF: default (Destination: 10.101.255.2, Next-hop: 10.101.255.1)
 
         """
-        return f"AVT: {self.avt_name}, VRF: {self.vrf}, Destination: {self.destination}, Next-hop: {self.next_hop}"
+        return f"AVT: {self.avt_name} VRF: {self.vrf} Destination: {self.destination} Next-hop: {self.next_hop}"

--- a/anta/input_models/avt.py
+++ b/anta/input_models/avt.py
@@ -33,4 +33,4 @@ class AVTPath(BaseModel):
         AVT CONTROL-PLANE-PROFILE VRF: default (Destination: 10.101.255.2, Next-hop: 10.101.255.1)
 
         """
-        return f"AVT {self.avt_name} VRF: {self.vrf} (Destination: {self.destination}, Next-hop: {self.next_hop})"
+        return f"AVT: {self.avt_name}, VRF: {self.vrf}, Destination: {self.destination}, Next-hop: {self.next_hop}"

--- a/anta/tests/avt.py
+++ b/anta/tests/avt.py
@@ -148,7 +148,7 @@ class VerifyAVTSpecificPath(AntaTest):
             # If no matching path found, mark the test as failed
             if not path_found:
                 if avt_path.path_type and not path_type_found:
-                    self.result.is_failure(f"{avt_path}, Path Type: {avt_path.path_type} - Path not found")
+                    self.result.is_failure(f"{avt_path} Path Type: {avt_path.path_type} - Path not found")
                 else:
                     self.result.is_failure(f"{avt_path} - Path not found")
 

--- a/anta/tests/avt.py
+++ b/anta/tests/avt.py
@@ -148,7 +148,7 @@ class VerifyAVTSpecificPath(AntaTest):
             # If no matching path found, mark the test as failed
             if not path_found:
                 if avt_path.path_type and not path_type_found:
-                    self.result.is_failure(f"{avt_path} Path Type: {avt_path.path_type} - Path not found")
+                    self.result.is_failure(f"{avt_path}, Path Type: {avt_path.path_type} - Path not found")
                 else:
                     self.result.is_failure(f"{avt_path} - Path not found")
 
@@ -192,4 +192,4 @@ class VerifyAVTRole(AntaTest):
 
         # Check if the AVT role matches the expected role
         if self.inputs.role != command_output.get("role"):
-            self.result.is_failure(f"Expected AVT role as `{self.inputs.role}`, but found `{command_output.get('role')}` instead.")
+            self.result.is_failure(f"AVT role mismatch - Expected: {self.inputs.role}, Actual: {command_output.get('role')}")

--- a/anta/tests/field_notices.py
+++ b/anta/tests/field_notices.py
@@ -96,7 +96,7 @@ class VerifyFieldNotice44Resolution(AntaTest):
         for variant in variants:
             model = model.replace(variant, "")
         if model not in devices:
-            self.result.is_skipped("device is not impacted by FN044")
+            self.result.is_skipped("Device is not impacted by FN044")
             return
 
         for component in command_output["details"]["components"]:
@@ -117,7 +117,7 @@ class VerifyFieldNotice44Resolution(AntaTest):
             )
         )
         if incorrect_aboot_version:
-            self.result.is_failure(f"device is running incorrect version of aboot ({aboot_version})")
+            self.result.is_failure(f"Device is running incorrect version of aboot {aboot_version}")
 
 
 class VerifyFieldNotice72Resolution(AntaTest):

--- a/tests/units/anta_tests/test_avt.py
+++ b/tests/units/anta_tests/test_avt.py
@@ -444,7 +444,7 @@ DATA: list[dict[str, Any]] = [
         },
         "expected": {
             "result": "failure",
-            "messages": ["AVT MGMT-AVT-POLICY-DEFAULT VRF: default (Destination: 10.101.255.2, Next-hop: 10.101.255.1) - No AVT path configured"],
+            "messages": ["AVT: MGMT-AVT-POLICY-DEFAULT, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.1 - No AVT path configured"],
         },
     },
     {
@@ -507,8 +507,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AVT DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default (Destination: 10.101.255.2, Next-hop: 10.101.255.11) Path Type: multihop - Path not found",
-                "AVT DATA-AVT-POLICY-CONTROL-PLANE VRF: data (Destination: 10.101.255.1, Next-hop: 10.101.255.21) Path Type: direct - Path not found",
+                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.11, Path Type: multihop - Path not found",
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.21, Path Type: direct - Path not found",
             ],
         },
     },
@@ -571,8 +571,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AVT DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default (Destination: 10.101.255.2, Next-hop: 10.101.255.11) - Path not found",
-                "AVT DATA-AVT-POLICY-CONTROL-PLANE VRF: data (Destination: 10.101.255.1, Next-hop: 10.101.255.21) - Path not found",
+                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.11 - Path not found",
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.21 - Path not found",
             ],
         },
     },
@@ -646,11 +646,11 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AVT DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default (Destination: 10.101.255.2, Next-hop: 10.101.255.1) - "
+                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.1 - "
                 "Incorrect path multihop:3 - Valid: False, Active: True",
-                "AVT DATA-AVT-POLICY-CONTROL-PLANE VRF: data (Destination: 10.101.255.1, Next-hop: 10.101.255.1) - "
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.1 - "
                 "Incorrect path direct:10 - Valid: False, Active: True",
-                "AVT DATA-AVT-POLICY-CONTROL-PLANE VRF: data (Destination: 10.101.255.1, Next-hop: 10.101.255.1) - "
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.1 - "
                 "Incorrect path direct:9 - Valid: True, Active: False",
             ],
         },
@@ -667,6 +667,6 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyAVTRole,
         "eos_data": [{"role": "transit"}],
         "inputs": {"role": "edge"},
-        "expected": {"result": "failure", "messages": ["Expected AVT role as `edge`, but found `transit` instead."]},
+        "expected": {"result": "failure", "messages": ["AVT role mismatch - Expected: edge, Actual: transit"]},
     },
 ]

--- a/tests/units/anta_tests/test_avt.py
+++ b/tests/units/anta_tests/test_avt.py
@@ -444,7 +444,7 @@ DATA: list[dict[str, Any]] = [
         },
         "expected": {
             "result": "failure",
-            "messages": ["AVT: MGMT-AVT-POLICY-DEFAULT, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.1 - No AVT path configured"],
+            "messages": ["AVT: MGMT-AVT-POLICY-DEFAULT VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 - No AVT path configured"],
         },
     },
     {
@@ -507,8 +507,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.11, Path Type: multihop - Path not found",
-                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.21, Path Type: direct - Path not found",
+                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.11 Path Type: multihop - Path not found",
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.21 Path Type: direct - Path not found",
             ],
         },
     },
@@ -571,8 +571,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.11 - Path not found",
-                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.21 - Path not found",
+                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.11 - Path not found",
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.21 - Path not found",
             ],
         },
     },
@@ -646,11 +646,11 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE, VRF: default, Destination: 10.101.255.2, Next-hop: 10.101.255.1 - "
+                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 - "
                 "Incorrect path multihop:3 - Valid: False, Active: True",
-                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.1 - "
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.1 - "
                 "Incorrect path direct:10 - Valid: False, Active: True",
-                "AVT: DATA-AVT-POLICY-CONTROL-PLANE, VRF: data, Destination: 10.101.255.1, Next-hop: 10.101.255.1 - "
+                "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.1 - "
                 "Incorrect path direct:9 - Valid: True, Active: False",
             ],
         },

--- a/tests/units/anta_tests/test_field_notices.py
+++ b/tests/units/anta_tests/test_field_notices.py
@@ -45,7 +45,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["device is running incorrect version of aboot (4.0.1)"],
+            "messages": ["Device is running incorrect version of aboot 4.0.1"],
         },
     },
     {
@@ -65,7 +65,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["device is running incorrect version of aboot (4.1.0)"],
+            "messages": ["Device is running incorrect version of aboot 4.1.0"],
         },
     },
     {
@@ -85,7 +85,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["device is running incorrect version of aboot (6.0.1)"],
+            "messages": ["Device is running incorrect version of aboot 6.0.1"],
         },
     },
     {
@@ -105,7 +105,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["device is running incorrect version of aboot (6.1.1)"],
+            "messages": ["Device is running incorrect version of aboot 6.1.1"],
         },
     },
     {
@@ -125,7 +125,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "skipped",
-            "messages": ["device is not impacted by FN044"],
+            "messages": ["Device is not impacted by FN044"],
         },
     },
     {


### PR DESCRIPTION
Nicer result failure messages  for following test module.
  1. AVT, 
  2. field_notice 

**Note:** Test with unit test only, as this testcases are skipped on ATD lab
Fixes #587 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
