### PR TITLE
refactor(anta.tests): Nicer result failure messages PTP, software test module

### DIFF
--- a/anta/tests/ptp.py
+++ b/anta/tests/ptp.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class VerifyPtpModeStatus(AntaTest):
-    """Verifies that the device is configured as a Precision Time Protocol (PTP) Boundary Clock (BC).
+    """Verifies that the device is configured as a PTP Boundary Clock.
 
     Expected Results
     ----------------
@@ -47,13 +47,13 @@ class VerifyPtpModeStatus(AntaTest):
             return
 
         if ptp_mode != "ptpBoundaryClock":
-            self.result.is_failure(f"The device is not configured as a PTP Boundary Clock - Actual: {ptp_mode}")
+            self.result.is_failure(f"Not configured as a PTP Boundary Clock - Actual: {ptp_mode}")
         else:
             self.result.is_success()
 
 
 class VerifyPtpGMStatus(AntaTest):
-    """Verifies that the device is locked to a valid Precision Time Protocol (PTP) Grandmaster (GM).
+    """Verifies that the device is locked to a valid PTP Grandmaster.
 
     To test PTP failover, re-run the test with a secondary GMID configured.
 
@@ -100,7 +100,7 @@ class VerifyPtpGMStatus(AntaTest):
 
 
 class VerifyPtpLockStatus(AntaTest):
-    """Verifies that the device was locked to the upstream Precision Time Protocol (PTP) Grandmaster (GM) in the last minute.
+    """Verifies that the device was locked to the upstream PTP GM in the last minute.
 
     Expected Results
     ----------------
@@ -133,13 +133,13 @@ class VerifyPtpLockStatus(AntaTest):
         time_difference = ptp_clock_summary["currentPtpSystemTime"] - ptp_clock_summary["lastSyncTime"]
 
         if time_difference >= threshold:
-            self.result.is_failure(f"The device lock is more than {threshold}s old - Actual: {time_difference}s")
+            self.result.is_failure(f"Lock is more than {threshold}s old - Actual: {time_difference}s")
         else:
             self.result.is_success()
 
 
 class VerifyPtpOffset(AntaTest):
-    """Verifies that the Precision Time Protocol (PTP) timing offset is within +/- 1000ns from the master clock.
+    """Verifies that the PTP timing offset is within +/- 1000ns from the master clock.
 
     Expected Results
     ----------------
@@ -175,13 +175,11 @@ class VerifyPtpOffset(AntaTest):
                 offset_interfaces.setdefault(interface["intf"], []).append(interface["offsetFromMaster"])
 
         for interface, data in offset_interfaces.items():
-            self.result.is_failure(
-                f"Interface: {interface} - The device timing offset from master is greater than +/- {threshold}ns: Actual: {', '.join(map(str, data))}"
-            )
+            self.result.is_failure(f"Interface: {interface} - Timing offset from master is greater than +/- {threshold}ns: Actual: {', '.join(map(str, data))}")
 
 
 class VerifyPtpPortModeStatus(AntaTest):
-    """Verifies that all interfaces are in a valid Precision Time Protocol (PTP) state.
+    """Verifies the PTP interfaces state.
 
     The interfaces can be in one of the following state: Master, Slave, Passive, or Disabled.
 

--- a/anta/tests/software.py
+++ b/anta/tests/software.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class VerifyEOSVersion(AntaTest):
-    """Verifies that the device is running one of the allowed EOS version.
+    """Verifies the EOS version of the device.
 
     Expected Results
     ----------------
@@ -49,11 +49,11 @@ class VerifyEOSVersion(AntaTest):
         command_output = self.instance_commands[0].json_output
         self.result.is_success()
         if command_output["version"] not in self.inputs.versions:
-            self.result.is_failure(f"Device version mismatch - Actual: {command_output['version']} not in Expected: {', '.join(self.inputs.versions)}")
+            self.result.is_failure(f"EOS version mismatch - Actual: {command_output['version']} not in Expected: {', '.join(self.inputs.versions)}")
 
 
 class VerifyTerminAttrVersion(AntaTest):
-    """Verifies that he device is running one of the allowed TerminAttr version.
+    """Verifies the TerminAttr version of the device.
 
     Expected Results
     ----------------
@@ -87,7 +87,7 @@ class VerifyTerminAttrVersion(AntaTest):
         self.result.is_success()
         command_output_data = command_output["details"]["packages"]["TerminAttr-core"]["version"]
         if command_output_data not in self.inputs.versions:
-            self.result.is_failure(f"Device TerminAttr version mismatch - Actual: {command_output_data} not in Expected: {', '.join(self.inputs.versions)}")
+            self.result.is_failure(f"TerminAttr version mismatch - Actual: {command_output_data} not in Expected: {', '.join(self.inputs.versions)}")
 
 
 class VerifyEOSExtensions(AntaTest):

--- a/anta/tests/software.py
+++ b/anta/tests/software.py
@@ -34,7 +34,6 @@ class VerifyEOSVersion(AntaTest):
     ```
     """
 
-    description = "Verifies the EOS version of the device."
     categories: ClassVar[list[str]] = ["software"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version", revision=1)]
 
@@ -48,10 +47,9 @@ class VerifyEOSVersion(AntaTest):
     def test(self) -> None:
         """Main test function for VerifyEOSVersion."""
         command_output = self.instance_commands[0].json_output
-        if command_output["version"] in self.inputs.versions:
-            self.result.is_success()
-        else:
-            self.result.is_failure(f'device is running version "{command_output["version"]}" not in expected versions: {self.inputs.versions}')
+        self.result.is_success()
+        if command_output["version"] not in self.inputs.versions:
+            self.result.is_failure(f"Device version mismatch - Actual: {command_output['version']} not in Expected: {', '.join(self.inputs.versions)}")
 
 
 class VerifyTerminAttrVersion(AntaTest):
@@ -73,7 +71,6 @@ class VerifyTerminAttrVersion(AntaTest):
     ```
     """
 
-    description = "Verifies the TerminAttr version of the device."
     categories: ClassVar[list[str]] = ["software"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version detail", revision=1)]
 
@@ -87,11 +84,10 @@ class VerifyTerminAttrVersion(AntaTest):
     def test(self) -> None:
         """Main test function for VerifyTerminAttrVersion."""
         command_output = self.instance_commands[0].json_output
+        self.result.is_success()
         command_output_data = command_output["details"]["packages"]["TerminAttr-core"]["version"]
-        if command_output_data in self.inputs.versions:
-            self.result.is_success()
-        else:
-            self.result.is_failure(f"device is running TerminAttr version {command_output_data} and is not in the allowed list: {self.inputs.versions}")
+        if command_output_data not in self.inputs.versions:
+            self.result.is_failure(f"Device TerminAttr version mismatch - Actual: {command_output_data} not in Expected: {', '.join(self.inputs.versions)}")
 
 
 class VerifyEOSExtensions(AntaTest):
@@ -120,6 +116,7 @@ class VerifyEOSExtensions(AntaTest):
     def test(self) -> None:
         """Main test function for VerifyEOSExtensions."""
         boot_extensions = []
+        self.result.is_success()
         show_extensions_command_output = self.instance_commands[0].json_output
         show_boot_extensions_command_output = self.instance_commands[1].json_output
         installed_extensions = [
@@ -131,7 +128,7 @@ class VerifyEOSExtensions(AntaTest):
                 boot_extensions.append(formatted_extension)
         installed_extensions.sort()
         boot_extensions.sort()
-        if installed_extensions == boot_extensions:
-            self.result.is_success()
-        else:
-            self.result.is_failure(f"Missing EOS extensions: installed {installed_extensions} / configured: {boot_extensions}")
+        if installed_extensions != boot_extensions:
+            str_installed_extensions = ", ".join(installed_extensions) if installed_extensions else "Not found"
+            str_boot_extensions = ", ".join(boot_extensions) if boot_extensions else "Not found"
+            self.result.is_failure(f"Installed and Boot extensions mismatch - Installed: {str_installed_extensions}, Configured: {str_boot_extensions}")

--- a/anta/tests/software.py
+++ b/anta/tests/software.py
@@ -131,4 +131,4 @@ class VerifyEOSExtensions(AntaTest):
         if installed_extensions != boot_extensions:
             str_installed_extensions = ", ".join(installed_extensions) if installed_extensions else "Not found"
             str_boot_extensions = ", ".join(boot_extensions) if boot_extensions else "Not found"
-            self.result.is_failure(f"Installed and Boot extensions mismatch - Installed: {str_installed_extensions}, Configured: {str_boot_extensions}")
+            self.result.is_failure(f"EOS extensions mismatch - Installed: {str_installed_extensions}, Configured: {str_boot_extensions}")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -365,16 +365,16 @@ anta.tests.profiles:
       mode: 3
 anta.tests.ptp:
   - VerifyPtpGMStatus:
-      # Verifies that the device is locked to a valid Precision Time Protocol (PTP) Grandmaster (GM).
+      # Verifies that the device is locked to a valid PTP Grandmaster.
       gmid: 0xec:46:70:ff:fe:00:ff:a9
   - VerifyPtpLockStatus:
-      # Verifies that the device was locked to the upstream Precision Time Protocol (PTP) Grandmaster (GM) in the last minute.
+      # Verifies that the device was locked to the upstream PTP GM in the last minute.
   - VerifyPtpModeStatus:
-      # Verifies that the device is configured as a Precision Time Protocol (PTP) Boundary Clock (BC).
+      # Verifies that the device is configured as a PTP Boundary Clock.
   - VerifyPtpOffset:
-      # Verifies that the Precision Time Protocol (PTP) timing offset is within +/- 1000ns from the master clock.
+      # Verifies that the PTP timing offset is within +/- 1000ns from the master clock.
   - VerifyPtpPortModeStatus:
-      # Verifies that all interfaces are in a valid Precision Time Protocol (PTP) state.
+      # Verifies the PTP interfaces state.
 anta.tests.routing.bgp:
   - VerifyBGPAdvCommunities:
       # Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s).
@@ -860,12 +860,12 @@ anta.tests.software:
   - VerifyEOSExtensions:
       # Verifies that all EOS extensions installed on the device are enabled for boot persistence.
   - VerifyEOSVersion:
-      # Verifies that the device is running one of the allowed EOS version.
+      # Verifies the EOS version of the device.
       versions:
         - 4.25.4M
         - 4.26.1F
   - VerifyTerminAttrVersion:
-      # Verifies that he device is running one of the allowed TerminAttr version.
+      # Verifies the TerminAttr version of the device.
       versions:
         - v1.13.6
         - v1.8.0

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -365,16 +365,16 @@ anta.tests.profiles:
       mode: 3
 anta.tests.ptp:
   - VerifyPtpGMStatus:
-      # Verifies that the device is locked to a valid PTP Grandmaster.
+      # Verifies that the device is locked to a valid Precision Time Protocol (PTP) Grandmaster (GM).
       gmid: 0xec:46:70:ff:fe:00:ff:a9
   - VerifyPtpLockStatus:
-      # Verifies that the device was locked to the upstream PTP GM in the last minute.
+      # Verifies that the device was locked to the upstream Precision Time Protocol (PTP) Grandmaster (GM) in the last minute.
   - VerifyPtpModeStatus:
-      # Verifies that the device is configured as a PTP Boundary Clock.
+      # Verifies that the device is configured as a Precision Time Protocol (PTP) Boundary Clock (BC).
   - VerifyPtpOffset:
-      # Verifies that the PTP timing offset is within +/- 1000ns from the master clock.
+      # Verifies that the Precision Time Protocol (PTP) timing offset is within +/- 1000ns from the master clock.
   - VerifyPtpPortModeStatus:
-      # Verifies the PTP interfaces state.
+      # Verifies that all interfaces are in a valid Precision Time Protocol (PTP) state.
 anta.tests.routing.bgp:
   - VerifyBGPAdvCommunities:
       # Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s).
@@ -860,12 +860,12 @@ anta.tests.software:
   - VerifyEOSExtensions:
       # Verifies that all EOS extensions installed on the device are enabled for boot persistence.
   - VerifyEOSVersion:
-      # Verifies the EOS version of the device.
+      # Verifies that the device is running one of the allowed EOS version.
       versions:
         - 4.25.4M
         - 4.26.1F
   - VerifyTerminAttrVersion:
-      # Verifies the TerminAttr version of the device.
+      # Verifies that he device is running one of the allowed TerminAttr version.
       versions:
         - v1.13.6
         - v1.8.0

--- a/tests/units/anta_tests/test_ptp.py
+++ b/tests/units/anta_tests/test_ptp.py
@@ -39,7 +39,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyPtpModeStatus,
         "eos_data": [{"ptpMode": "ptpDisabled", "ptpIntfSummaries": {}}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The device is not configured as a PTP Boundary Clock: 'ptpDisabled'"]},
+        "expected": {"result": "failure", "messages": ["The device is not configured as a PTP Boundary Clock - Actual: ptpDisabled"]},
     },
     {
         "name": "skipped",
@@ -158,7 +158,7 @@ DATA: list[dict[str, Any]] = [
             }
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The device lock is more than 60s old: 157s"]},
+        "expected": {"result": "failure", "messages": ["The device lock is more than 60s old - Actual: 157s"]},
     },
     {
         "name": "skipped",
@@ -236,7 +236,9 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": [("The device timing offset from master is greater than +/- 1000ns: {'Ethernet27/1': [1200, -1300]}")],
+            "messages": [
+                "Interface: Ethernet27/1 - The device timing offset from master is greater than +/- 1000ns: Actual: 1200, -1300",
+            ],
         },
     },
     {
@@ -335,6 +337,6 @@ DATA: list[dict[str, Any]] = [
             }
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The following interface(s) are not in a valid PTP state: '['Ethernet53', 'Ethernet1']'"]},
+        "expected": {"result": "failure", "messages": ["The following interface(s) are not in a valid PTP state: Ethernet53, Ethernet1"]},
     },
 ]

--- a/tests/units/anta_tests/test_ptp.py
+++ b/tests/units/anta_tests/test_ptp.py
@@ -39,7 +39,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyPtpModeStatus,
         "eos_data": [{"ptpMode": "ptpDisabled", "ptpIntfSummaries": {}}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The device is not configured as a PTP Boundary Clock - Actual: ptpDisabled"]},
+        "expected": {"result": "failure", "messages": ["Not configured as a PTP Boundary Clock - Actual: ptpDisabled"]},
     },
     {
         "name": "skipped",
@@ -158,7 +158,7 @@ DATA: list[dict[str, Any]] = [
             }
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The device lock is more than 60s old - Actual: 157s"]},
+        "expected": {"result": "failure", "messages": ["Lock is more than 60s old - Actual: 157s"]},
     },
     {
         "name": "skipped",
@@ -237,7 +237,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Interface: Ethernet27/1 - The device timing offset from master is greater than +/- 1000ns: Actual: 1200, -1300",
+                "Interface: Ethernet27/1 - Timing offset from master is greater than +/- 1000ns: Actual: 1200, -1300",
             ],
         },
     },

--- a/tests/units/anta_tests/test_software.py
+++ b/tests/units/anta_tests/test_software.py
@@ -35,7 +35,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"versions": ["4.27.1F"]},
-        "expected": {"result": "failure", "messages": ["device is running version \"4.27.0F\" not in expected versions: ['4.27.1F']"]},
+        "expected": {"result": "failure", "messages": ["Device version mismatch - Actual: 4.27.0F not in Expected: 4.27.1F"]},
     },
     {
         "name": "success",
@@ -77,7 +77,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"versions": ["v1.17.1", "v1.18.1"]},
-        "expected": {"result": "failure", "messages": ["device is running TerminAttr version v1.17.0 and is not in the allowed list: ['v1.17.1', 'v1.18.1']"]},
+        "expected": {"result": "failure", "messages": ["Device TerminAttr version mismatch - Actual: v1.17.0 not in Expected: v1.17.1, v1.18.1"]},
     },
     # TODO: add a test with a real extension?
     {
@@ -108,6 +108,6 @@ DATA: list[dict[str, Any]] = [
             {"extensions": ["dummy"]},
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Missing EOS extensions: installed [] / configured: ['dummy']"]},
+        "expected": {"result": "failure", "messages": ["Installed and Boot extensions mismatch - Installed: Not found, Configured: dummy"]},
     },
 ]

--- a/tests/units/anta_tests/test_software.py
+++ b/tests/units/anta_tests/test_software.py
@@ -79,7 +79,6 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"versions": ["v1.17.1", "v1.18.1"]},
         "expected": {"result": "failure", "messages": ["TerminAttr version mismatch - Actual: v1.17.0 not in Expected: v1.17.1, v1.18.1"]},
     },
-    # TODO: add a test with a real extension?
     {
         "name": "success-no-extensions",
         "test": VerifyEOSExtensions,
@@ -91,11 +90,30 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
-        "name": "success-empty-extension",
+        "name": "success-extensions",
         "test": VerifyEOSExtensions,
         "eos_data": [
-            {"extensions": {}, "extensionStoredDir": "flash:", "warnings": ["No extensions are available"]},
-            {"extensions": [""]},
+            {
+                "extensions": {
+                    "AristaCloudGateway-1.0.1-1.swix": {
+                        "version": "1.0.1",
+                        "release": "1",
+                        "presence": "present",
+                        "status": "installed",
+                        "boot": True,
+                        "numPackages": 1,
+                        "error": False,
+                        "vendor": "",
+                        "summary": "Arista Cloud Connect",
+                        "installedSize": 60532424,
+                        "packages": {"AristaCloudGateway-1.0.1-1.x86_64.rpm": {"version": "1.0.1", "release": "1"}},
+                        "description": "An extension for Arista Cloud Connect gateway",
+                        "affectedAgents": [],
+                        "agentsToRestart": [],
+                    },
+                }
+            },
+            {"extensions": ["AristaCloudGateway-1.0.1-1.swix"]},
         ],
         "inputs": None,
         "expected": {"result": "success"},
@@ -104,10 +122,80 @@ DATA: list[dict[str, Any]] = [
         "name": "failure",
         "test": VerifyEOSExtensions,
         "eos_data": [
-            {"extensions": {}, "extensionStoredDir": "flash:", "warnings": ["No extensions are available"]},
-            {"extensions": ["dummy"]},
+            {
+                "extensions": {
+                    "AristaCloudGateway-1.0.1-1.swix": {
+                        "version": "1.0.1",
+                        "release": "1",
+                        "presence": "present",
+                        "status": "installed",
+                        "boot": False,
+                        "numPackages": 1,
+                        "error": False,
+                        "vendor": "",
+                        "summary": "Arista Cloud Connect",
+                        "installedSize": 60532424,
+                        "packages": {"AristaCloudGateway-1.0.1-1.x86_64.rpm": {"version": "1.0.1", "release": "1"}},
+                        "description": "An extension for Arista Cloud Connect gateway",
+                        "affectedAgents": [],
+                        "agentsToRestart": [],
+                    },
+                }
+            },
+            {"extensions": []},
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Installed and Boot extensions mismatch - Installed: Not found, Configured: dummy"]},
+        "expected": {"result": "failure", "messages": ["EOS extensions mismatch - Installed: AristaCloudGateway-1.0.1-1.swix, Configured: Not found"]},
+    },
+    {
+        "name": "failure-multiple-extensions",
+        "test": VerifyEOSExtensions,
+        "eos_data": [
+            {
+                "extensions": {
+                    "AristaCloudGateway-1.0.1-1.swix": {
+                        "version": "1.0.1",
+                        "release": "1",
+                        "presence": "present",
+                        "status": "installed",
+                        "boot": False,
+                        "numPackages": 1,
+                        "error": False,
+                        "vendor": "",
+                        "summary": "Arista Cloud Connect",
+                        "installedSize": 60532424,
+                        "packages": {"AristaCloudGateway-1.0.1-1.x86_64.rpm": {"version": "1.0.1", "release": "1"}},
+                        "description": "An extension for Arista Cloud Connect gateway",
+                        "affectedAgents": [],
+                        "agentsToRestart": [],
+                    },
+                    "EOS-4.33.0F-NDRSensor.swix": {
+                        "version": "4.33.0",
+                        "release": "39050855.4330F",
+                        "presence": "present",
+                        "status": "notInstalled",
+                        "boot": True,
+                        "numPackages": 9,
+                        "error": False,
+                        "statusDetail": "No RPMs are compatible with current EOS version.",
+                        "vendor": "",
+                        "summary": "NDR sensor",
+                        "installedSize": 0,
+                        "packages": {},
+                        "description": "NDR sensor provides libraries to generate flow activity records using DPI\nmetadata and IPFIX flow records.",
+                        "affectedAgents": [],
+                        "agentsToRestart": [],
+                    },
+                }
+            },
+            {"extensions": ["AristaCloudGateway-1.0.1-1.swix", "EOS-4.33.0F-NDRSensor.swix"]},
+        ],
+        "inputs": None,
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "EOS extensions mismatch - Installed: AristaCloudGateway-1.0.1-1.swix, Configured: AristaCloudGateway-1.0.1-1.swix, EOS-4.33.0F-NDRSensor.swix"
+            ],
+        },
     },
 ]

--- a/tests/units/anta_tests/test_software.py
+++ b/tests/units/anta_tests/test_software.py
@@ -35,7 +35,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"versions": ["4.27.1F"]},
-        "expected": {"result": "failure", "messages": ["Device version mismatch - Actual: 4.27.0F not in Expected: 4.27.1F"]},
+        "expected": {"result": "failure", "messages": ["EOS version mismatch - Actual: 4.27.0F not in Expected: 4.27.1F"]},
     },
     {
         "name": "success",
@@ -77,7 +77,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"versions": ["v1.17.1", "v1.18.1"]},
-        "expected": {"result": "failure", "messages": ["Device TerminAttr version mismatch - Actual: v1.17.0 not in Expected: v1.17.1, v1.18.1"]},
+        "expected": {"result": "failure", "messages": ["TerminAttr version mismatch - Actual: v1.17.0 not in Expected: v1.17.1, v1.18.1"]},
     },
     # TODO: add a test with a real extension?
     {


### PR DESCRIPTION
Nicer result failure messages for following test module.
     1 . PTP
     2.  Software
  
**Note:** Test with unit test only, as this testcases are skipped on ATD lab
Fixes https://github.com/aristanetworks/anta/issues/587

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
