### PR TITLE
refactor(anta.tests): Nicer result failure messages MLAG test module 

### DIFF
--- a/anta/tests/mlag.py
+++ b/anta/tests/mlag.py
@@ -48,11 +48,11 @@ class VerifyMlagStatus(AntaTest):
             self.result.is_skipped("MLAG is disabled")
             return
 
-        # Verifies the localIntfStatus
-        if (neg_status := command_output["negStatus"]) != "connected":
-            self.result.is_failure(f"MLAG Negotiation status mismatch - Expected: connected Actual: {neg_status}")
-
         # Verifies the negotiation status
+        if (neg_status := command_output["negStatus"]) != "connected":
+            self.result.is_failure(f"MLAG negotiation status mismatch - Expected: connected Actual: {neg_status}")
+
+        # Verifies the local interface interface status
         if (intf_state := command_output["localIntfStatus"]) != "up":
             self.result.is_failure(f"Operational state of the MLAG local interface is not correct - Expected: up Actual: {intf_state}")
 
@@ -183,11 +183,11 @@ class VerifyMlagReloadDelay(AntaTest):
 
         # Verifies the reloadDelay
         if (reload_delay := get_value(command_output, "reloadDelay")) != self.inputs.reload_delay:
-            self.result.is_failure(f"MLAG reload delay mismatch - Expected: {self.inputs.reload_delay}s Actual: {reload_delay}s")
+            self.result.is_failure(f"MLAG reload-delay mismatch - Expected: {self.inputs.reload_delay}s Actual: {reload_delay}s")
 
         # Verifies the reloadDelayNonMlag
         if (non_mlag_reload_delay := get_value(command_output, "reloadDelayNonMlag")) != self.inputs.reload_delay_non_mlag:
-            self.result.is_failure(f"Delay for non MLAG ports mismatch - Expected: {self.inputs.reload_delay_non_mlag}s Actual: {non_mlag_reload_delay}s")
+            self.result.is_failure(f"Delay for non-MLAG ports mismatch - Expected: {self.inputs.reload_delay_non_mlag}s Actual: {non_mlag_reload_delay}s")
 
 
 class VerifyMlagDualPrimary(AntaTest):
@@ -310,4 +310,4 @@ class VerifyMlagPrimaryPriority(AntaTest):
 
         # Check primary priority
         if primary_priority != self.inputs.primary_priority:
-            self.result.is_failure(f"The primary priority mismatch - Expected: {self.inputs.primary_priority} Actual: {primary_priority}")
+            self.result.is_failure(f"MLAG primary priority mismatch - Expected: {self.inputs.primary_priority} Actual: {primary_priority}")

--- a/anta/tests/mlag.py
+++ b/anta/tests/mlag.py
@@ -49,16 +49,16 @@ class VerifyMlagStatus(AntaTest):
             return
 
         # Verifies the localIntfStatus
-        if command_output.get("negStatus") != "connected":
-            self.result.is_failure("MLAG Negotiation status is not connected")
+        if (neg_status := command_output["negStatus"]) != "connected":
+            self.result.is_failure(f"MLAG Negotiation status mismatch - Expected: connected Actual: {neg_status}")
 
         # Verifies the negotiation status
-        if command_output.get("localIntfStatus") != "up":
-            self.result.is_failure("Operational state of the MLAG local interface is not up")
+        if (intf_state := command_output["localIntfStatus"]) != "up":
+            self.result.is_failure(f"Operational state of the MLAG local interface is not correct - Expected: up Actual: {intf_state}")
 
         # Verifies the peerLinkStatus
-        if command_output.get("peerLinkStatus") != "up":
-            self.result.is_failure("Operational state of the MLAG peer link is not up")
+        if (peer_link_state := command_output["peerLinkStatus"]) != "up":
+            self.result.is_failure(f"Operational state of the MLAG peer link is not correct - Expected: up Actual: {peer_link_state}")
 
 
 class VerifyMlagInterfaces(AntaTest):

--- a/tests/units/anta_tests/test_mlag.py
+++ b/tests/units/anta_tests/test_mlag.py
@@ -32,11 +32,11 @@ DATA: list[dict[str, Any]] = [
     {
         "name": "failure-negotian-status",
         "test": VerifyMlagStatus,
-        "eos_data": [{"state": "active", "peerLinkStatus": "up", "localIntfStatus": "up"}],
+        "eos_data": [{"state": "active", "negStatus": "connecting", "peerLinkStatus": "up", "localIntfStatus": "up"}],
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["MLAG Negotiation status is not connected"],
+            "messages": ["MLAG Negotiation status mismatch - Expected: connected Actual: connecting"],
         },
     },
     {
@@ -46,7 +46,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["Operational state of the MLAG local interface is not up"],
+            "messages": ["Operational state of the MLAG local interface is not correct - Expected: up Actual: down"],
         },
     },
     {
@@ -56,7 +56,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["Operational state of the MLAG peer link is not up"],
+            "messages": ["Operational state of the MLAG peer link is not correct - Expected: up Actual: down"],
         },
     },
     {

--- a/tests/units/anta_tests/test_mlag.py
+++ b/tests/units/anta_tests/test_mlag.py
@@ -30,13 +30,13 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "skipped", "messages": ["MLAG is disabled"]},
     },
     {
-        "name": "failure-negotian-status",
+        "name": "failure-negotiation-status",
         "test": VerifyMlagStatus,
         "eos_data": [{"state": "active", "negStatus": "connecting", "peerLinkStatus": "up", "localIntfStatus": "up"}],
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["MLAG Negotiation status mismatch - Expected: connected Actual: connecting"],
+            "messages": ["MLAG negotiation status mismatch - Expected: connected Actual: connecting"],
         },
     },
     {
@@ -189,7 +189,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"reload_delay": 300, "reload_delay_non_mlag": 330},
         "expected": {
             "result": "failure",
-            "messages": ["MLAG reload delay mismatch - Expected: 300s Actual: 400s", "Delay for non MLAG ports mismatch - Expected: 330s Actual: 430s"],
+            "messages": ["MLAG reload-delay mismatch - Expected: 300s Actual: 400s", "Delay for non-MLAG ports mismatch - Expected: 330s Actual: 430s"],
         },
     },
     {
@@ -344,7 +344,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"primary_priority": 1},
         "expected": {
             "result": "failure",
-            "messages": ["The device is not set as MLAG primary.", "The primary priority mismatch - Expected: 1 Actual: 32767"],
+            "messages": ["The device is not set as MLAG primary.", "MLAG primary priority mismatch - Expected: 1 Actual: 32767"],
         },
     },
 ]


### PR DESCRIPTION
# Description

Nicer result failure messages MLAG test module 

Fixes #587 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
