### PR TITLE
refactor(anta.tests): Nicer result failure messages Service and SNMP test module 

### DIFF
--- a/anta/input_models/services.py
+++ b/anta/input_models/services.py
@@ -32,7 +32,7 @@ class DnsServer(BaseModel):
         --------
         Server 10.0.0.1 (VRF: default, Priority: 1)
         """
-        return f"Server {self.server_address} (VRF: {self.vrf}, Priority: {self.priority})"
+        return f"Server {self.server_address} VRF: {self.vrf} Priority: {self.priority}"
 
 
 class ErrdisableRecovery(BaseModel):

--- a/anta/tests/services.py
+++ b/anta/tests/services.py
@@ -46,7 +46,7 @@ class VerifyHostname(AntaTest):
         hostname = self.instance_commands[0].json_output["hostname"]
 
         if hostname != self.inputs.hostname:
-            self.result.is_failure(f"Expected `{self.inputs.hostname}` as the hostname, but found `{hostname}` instead.")
+            self.result.is_failure(f"Incorrect Hostname - Expected: {self.inputs.hostname} Actual: {hostname}")
         else:
             self.result.is_success()
 

--- a/tests/units/anta_tests/test_services.py
+++ b/tests/units/anta_tests/test_services.py
@@ -25,7 +25,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"hostname": "s1-spine1"},
         "expected": {
             "result": "failure",
-            "messages": ["Expected `s1-spine1` as the hostname, but found `s1-spine2` instead."],
+            "messages": ["Incorrect Hostname - Expected: s1-spine1 Actual: s1-spine2"],
         },
     },
     {
@@ -88,7 +88,7 @@ DATA: list[dict[str, Any]] = [
         },
         "expected": {
             "result": "failure",
-            "messages": ["Server 10.14.0.10 (VRF: default, Priority: 0) - Not configured", "Server 10.14.0.21 (VRF: MGMT, Priority: 1) - Not configured"],
+            "messages": ["Server 10.14.0.10 VRF: default Priority: 0 - Not configured", "Server 10.14.0.21 VRF: MGMT Priority: 1 - Not configured"],
         },
     },
     {
@@ -109,9 +109,9 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Server 10.14.0.1 (VRF: CS, Priority: 0) - Incorrect priority - Priority: 1",
-                "Server 10.14.0.11 (VRF: default, Priority: 0) - Not configured",
-                "Server 10.14.0.110 (VRF: MGMT, Priority: 0) - Not configured",
+                "Server 10.14.0.1 VRF: CS Priority: 0 - Incorrect priority - Priority: 1",
+                "Server 10.14.0.11 VRF: default Priority: 0 - Not configured",
+                "Server 10.14.0.110 VRF: MGMT Priority: 0 - Not configured",
             ],
         },
     },

--- a/tests/units/anta_tests/test_snmp.py
+++ b/tests/units/anta_tests/test_snmp.py
@@ -36,14 +36,14 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySnmpStatus,
         "eos_data": [{"vrfs": {"snmpVrfs": ["default"]}, "enabled": True}],
         "inputs": {"vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["SNMP agent disabled in vrf MGMT"]},
+        "expected": {"result": "failure", "messages": ["VRF: MGMT - SNMP agent disabled"]},
     },
     {
         "name": "failure-disabled",
         "test": VerifySnmpStatus,
         "eos_data": [{"vrfs": {"snmpVrfs": ["default"]}, "enabled": False}],
         "inputs": {"vrf": "default"},
-        "expected": {"result": "failure", "messages": ["SNMP agent disabled in vrf default"]},
+        "expected": {"result": "failure", "messages": ["VRF: default - SNMP agent disabled"]},
     },
     {
         "name": "success",
@@ -57,14 +57,14 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySnmpIPv4Acl,
         "eos_data": [{"ipAclList": {"aclList": []}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["Expected 1 SNMP IPv4 ACL(s) in vrf MGMT but got 0"]},
+        "expected": {"result": "failure", "messages": ["VRF: MGMT - Incorrect SNMP IPv4 ACL(s) - Expected: 1 Actual: 0"]},
     },
     {
         "name": "failure-wrong-vrf",
         "test": VerifySnmpIPv4Acl,
         "eos_data": [{"ipAclList": {"aclList": [{"type": "Ip4Acl", "name": "ACL_IPV4_SNMP", "configuredVrfs": ["default"], "activeVrfs": ["default"]}]}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["SNMP IPv4 ACL(s) not configured or active in vrf MGMT: ['ACL_IPV4_SNMP']"]},
+        "expected": {"result": "failure", "messages": ["VRF: MGMT - Following SNMP IPv4 ACL(s) not configured or active: ACL_IPV4_SNMP"]},
     },
     {
         "name": "success",
@@ -78,14 +78,14 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySnmpIPv6Acl,
         "eos_data": [{"ipv6AclList": {"aclList": []}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["Expected 1 SNMP IPv6 ACL(s) in vrf MGMT but got 0"]},
+        "expected": {"result": "failure", "messages": ["VRF: MGMT - Incorrect SNMP IPv6 ACL(s) - Expected: 1 Actual: 0"]},
     },
     {
         "name": "failure-wrong-vrf",
         "test": VerifySnmpIPv6Acl,
         "eos_data": [{"ipv6AclList": {"aclList": [{"type": "Ip6Acl", "name": "ACL_IPV6_SNMP", "configuredVrfs": ["default"], "activeVrfs": ["default"]}]}}],
         "inputs": {"number": 1, "vrf": "MGMT"},
-        "expected": {"result": "failure", "messages": ["SNMP IPv6 ACL(s) not configured or active in vrf MGMT: ['ACL_IPV6_SNMP']"]},
+        "expected": {"result": "failure", "messages": ["VRF: MGMT - Following SNMP IPv6 ACL(s) not configured or active: ACL_IPV6_SNMP"]},
     },
     {
         "name": "success",
@@ -109,7 +109,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"location": "New York"},
         "expected": {
             "result": "failure",
-            "messages": ["Expected `New York` as the location, but found `Europe` instead."],
+            "messages": ["Incorrect SNMP location - Expected: New York Actual: Europe"],
         },
     },
     {
@@ -148,7 +148,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"contact": "Bob@example.com"},
         "expected": {
             "result": "failure",
-            "messages": ["Expected `Bob@example.com` as the contact, but found `Jon@example.com` instead."],
+            "messages": ["Incorrect SNMP contact - Expected: Bob@example.com Actual: Jon@example.com"],
         },
     },
     {
@@ -227,7 +227,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {},
         "expected": {
             "result": "failure",
-            "messages": ["The following SNMP PDU counters are not found or have zero PDU counters:\n{'inGetPdus': 0, 'inSetPdus': 0}"],
+            "messages": ["The following SNMP PDU counters are not found or have zero PDU counters: inGetPdus, inSetPdus"],
         },
     },
     {
@@ -245,7 +245,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"pdus": ["inGetPdus", "outTrapPdus"]},
         "expected": {
             "result": "failure",
-            "messages": ["The following SNMP PDU counters are not found or have zero PDU counters:\n{'inGetPdus': 'Not Found', 'outTrapPdus': 'Not Found'}"],
+            "messages": ["The following SNMP PDU counters are not found or have zero PDU counters: inGetPdus, outTrapPdus"],
         },
     },
     {
@@ -319,9 +319,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {},
         "expected": {
             "result": "failure",
-            "messages": [
-                "The following SNMP error counters are not found or have non-zero error counters:\n{'inVersionErrs': 1, 'inParseErrs': 2, 'outBadValueErrs': 2}"
-            ],
+            "messages": ["The following SNMP error counters are not found or have non-zero error counters: inParseErrs, inVersionErrs, outBadValueErrs"],
         },
     },
     {


### PR DESCRIPTION
Nicer result failure messages for following test module.
      1.  Service
      2.  SNMP

Fixes #587

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
