### PR TITLE
fix(anta): Add Semaphore to AsyncEOSDevice

### DIFF
--- a/anta/device.py
+++ b/anta/device.py
@@ -32,6 +32,10 @@ logger = logging.getLogger(__name__)
 # https://github.com/pyca/cryptography/issues/7236#issuecomment-1131908472
 CLIENT_KEYS = asyncssh.public_key.load_default_keypairs()
 
+# Limit concurrency to 100 requests (HTTPX default) to avoid high-concurrency performance issues
+# See: https://github.com/encode/httpx/issues/3215
+MAX_CONCURRENT_REQUESTS = 100
+
 
 class AntaCache:
     """Class to be used as cache.
@@ -296,6 +300,7 @@ class AntaDevice(ABC):
         raise NotImplementedError(msg)
 
 
+# pylint: disable=too-many-instance-attributes
 class AsyncEOSDevice(AntaDevice):
     """Implementation of AntaDevice for EOS using aio-eapi.
 
@@ -381,6 +386,7 @@ class AsyncEOSDevice(AntaDevice):
         self.enable = enable
         self._enable_password = enable_password
         self._session: asynceapi.Device = asynceapi.Device(host=host, port=port, username=username, password=password, proto=proto, timeout=timeout)
+        self._command_semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
         ssh_params: dict[str, Any] = {}
         if insecure:
             ssh_params["known_hosts"] = None
@@ -445,57 +451,61 @@ class AsyncEOSDevice(AntaDevice):
         collection_id
             An identifier used to build the eAPI request ID.
         """
-        commands: list[dict[str, str | int]] = []
-        if self.enable and self._enable_password is not None:
-            commands.append(
-                {
-                    "cmd": "enable",
-                    "input": str(self._enable_password),
-                },
-            )
-        elif self.enable:
-            # No password
-            commands.append({"cmd": "enable"})
-        commands += [{"cmd": command.command, "revision": command.revision}] if command.revision else [{"cmd": command.command}]
-        try:
-            response: list[dict[str, Any] | str] = await self._session.cli(
-                commands=commands,
-                ofmt=command.ofmt,
-                version=command.version,
-                req_id=f"ANTA-{collection_id}-{id(command)}" if collection_id else f"ANTA-{id(command)}",
-            )  # type: ignore[assignment] # multiple commands returns a list
-            # Do not keep response of 'enable' command
-            command.output = response[-1]
-        except asynceapi.EapiCommandError as e:
-            # This block catches exceptions related to EOS issuing an error.
-            self._log_eapi_command_error(command, e)
-        except TimeoutException as e:
-            # This block catches Timeout exceptions.
-            command.errors = [exc_to_str(e)]
-            timeouts = self._session.timeout.as_dict()
-            logger.error(
-                "%s occurred while sending a command to %s. Consider increasing the timeout.\nCurrent timeouts: Connect: %s | Read: %s | Write: %s | Pool: %s",
-                exc_to_str(e),
-                self.name,
-                timeouts["connect"],
-                timeouts["read"],
-                timeouts["write"],
-                timeouts["pool"],
-            )
-        except (ConnectError, OSError) as e:
-            # This block catches OSError and socket issues related exceptions.
-            command.errors = [exc_to_str(e)]
-            if (isinstance(exc := e.__cause__, httpcore.ConnectError) and isinstance(os_error := exc.__context__, OSError)) or isinstance(os_error := e, OSError):  # pylint: disable=no-member
-                if isinstance(os_error.__cause__, OSError):
-                    os_error = os_error.__cause__
-                logger.error("A local OS error occurred while connecting to %s: %s.", self.name, os_error)
-            else:
+        async with self._command_semaphore:
+            commands: list[dict[str, str | int]] = []
+            if self.enable and self._enable_password is not None:
+                commands.append(
+                    {
+                        "cmd": "enable",
+                        "input": str(self._enable_password),
+                    },
+                )
+            elif self.enable:
+                # No password
+                commands.append({"cmd": "enable"})
+            commands += [{"cmd": command.command, "revision": command.revision}] if command.revision else [{"cmd": command.command}]
+            try:
+                response: list[dict[str, Any] | str] = await self._session.cli(
+                    commands=commands,
+                    ofmt=command.ofmt,
+                    version=command.version,
+                    req_id=f"ANTA-{collection_id}-{id(command)}" if collection_id else f"ANTA-{id(command)}",
+                )  # type: ignore[assignment] # multiple commands returns a list
+                # Do not keep response of 'enable' command
+                command.output = response[-1]
+            except asynceapi.EapiCommandError as e:
+                # This block catches exceptions related to EOS issuing an error.
+                self._log_eapi_command_error(command, e)
+            except TimeoutException as e:
+                # This block catches Timeout exceptions.
+                command.errors = [exc_to_str(e)]
+                timeouts = self._session.timeout.as_dict()
+                logger.error(
+                    "%s occurred while sending a command to %s. Consider increasing the timeout.\nCurrent timeouts: Connect: %s | Read: %s | Write: %s | Pool: %s",
+                    exc_to_str(e),
+                    self.name,
+                    timeouts["connect"],
+                    timeouts["read"],
+                    timeouts["write"],
+                    timeouts["pool"],
+                )
+            except (ConnectError, OSError) as e:
+                # This block catches OSError and socket issues related exceptions.
+                command.errors = [exc_to_str(e)]
+                # pylint: disable=no-member
+                if (isinstance(exc := e.__cause__, httpcore.ConnectError) and isinstance(os_error := exc.__context__, OSError)) or isinstance(
+                    os_error := e, OSError
+                ):
+                    if isinstance(os_error.__cause__, OSError):
+                        os_error = os_error.__cause__
+                    logger.error("A local OS error occurred while connecting to %s: %s.", self.name, os_error)
+                else:
+                    anta_log_exception(e, f"An error occurred while issuing an eAPI request to {self.name}", logger)
+            except HTTPError as e:
+                # This block catches most of the httpx Exceptions and logs a general message.
+                command.errors = [exc_to_str(e)]
                 anta_log_exception(e, f"An error occurred while issuing an eAPI request to {self.name}", logger)
-        except HTTPError as e:
-            # This block catches most of the httpx Exceptions and logs a general message.
-            command.errors = [exc_to_str(e)]
-            anta_log_exception(e, f"An error occurred while issuing an eAPI request to {self.name}", logger)
-        logger.debug("%s: %s", self.name, command)
+            logger.debug("%s: %s", self.name, command)
 
     def _log_eapi_command_error(self, command: AntaCommand, e: asynceapi.EapiCommandError) -> None:
         """Appropriately log the eapi command error."""


### PR DESCRIPTION
# Description

Add a Semaphore of 100 per device to avoid sending too many commands/requests to HTTPX. HTTPX has a default max_connections of 100 so we respect that to avoid high-concurrency performance issues.

Related to:

https://github.com/encode/httpx/issues/3215
https://github.com/encode/httpcore/pull/928
https://github.com/encode/httpcore/pull/929

Benchmarks on i7-12800H, 32GB RAM, 1048576 file descriptors

**With Semaphore**:
```
2025-02-13 17:28:22,109 - INFO - Running benchmarks with 64 commands and max_connections=100
2025-02-13 17:28:22,110 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:28:22,110 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:28:23,602 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 1.492405 seconds
2025-02-13 17:28:23,602 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:28:23,603 - INFO - Running benchmarks with 640 commands and max_connections=100
2025-02-13 17:28:23,603 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:28:23,603 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:28:27,111 - INFO - Process Resource Usage - CPU: 20.00%, Memory: 0.16%
2025-02-13 17:28:32,112 - INFO - Process Resource Usage - CPU: 16.60%, Memory: 0.18%
2025-02-13 17:28:37,113 - INFO - Process Resource Usage - CPU: 17.40%, Memory: 0.19%
2025-02-13 17:28:38,123 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 14.519754 seconds
2025-02-13 17:28:38,123 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:28:38,127 - INFO - Running benchmarks with 1600 commands and max_connections=100
2025-02-13 17:28:38,127 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:28:38,127 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:28:42,114 - INFO - Process Resource Usage - CPU: 20.20%, Memory: 0.20%
2025-02-13 17:28:47,116 - INFO - Process Resource Usage - CPU: 18.00%, Memory: 0.20%
2025-02-13 17:28:52,117 - INFO - Process Resource Usage - CPU: 18.00%, Memory: 0.21%
2025-02-13 17:28:57,118 - INFO - Process Resource Usage - CPU: 17.40%, Memory: 0.23%
2025-02-13 17:29:02,119 - INFO - Process Resource Usage - CPU: 16.20%, Memory: 0.24%
2025-02-13 17:29:07,120 - INFO - Process Resource Usage - CPU: 17.40%, Memory: 0.26%
2025-02-13 17:29:12,123 - INFO - Process Resource Usage - CPU: 18.00%, Memory: 0.27%
2025-02-13 17:29:14,493 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 36.365215 seconds
2025-02-13 17:29:14,493 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:29:14,501 - INFO - Running benchmarks with 3200 commands and max_connections=100
2025-02-13 17:29:14,502 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:29:14,502 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:29:17,125 - INFO - Process Resource Usage - CPU: 20.20%, Memory: 0.27%
2025-02-13 17:29:22,126 - INFO - Process Resource Usage - CPU: 18.20%, Memory: 0.27%
2025-02-13 17:29:27,128 - INFO - Process Resource Usage - CPU: 18.20%, Memory: 0.27%
2025-02-13 17:29:32,129 - INFO - Process Resource Usage - CPU: 16.40%, Memory: 0.27%
2025-02-13 17:29:37,132 - INFO - Process Resource Usage - CPU: 17.00%, Memory: 0.27%
2025-02-13 17:29:42,133 - INFO - Process Resource Usage - CPU: 18.60%, Memory: 0.27%
2025-02-13 17:29:47,134 - INFO - Process Resource Usage - CPU: 17.60%, Memory: 0.28%
2025-02-13 17:29:52,135 - INFO - Process Resource Usage - CPU: 18.20%, Memory: 0.29%
2025-02-13 17:29:57,138 - INFO - Process Resource Usage - CPU: 17.60%, Memory: 0.30%
2025-02-13 17:30:02,140 - INFO - Process Resource Usage - CPU: 17.80%, Memory: 0.32%
2025-02-13 17:30:07,142 - INFO - Process Resource Usage - CPU: 17.60%, Memory: 0.33%
2025-02-13 17:30:12,143 - INFO - Process Resource Usage - CPU: 17.60%, Memory: 0.34%
2025-02-13 17:30:17,145 - INFO - Process Resource Usage - CPU: 18.40%, Memory: 0.36%
2025-02-13 17:30:22,147 - INFO - Process Resource Usage - CPU: 17.60%, Memory: 0.37%
2025-02-13 17:30:25,249 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 70.746333 seconds
2025-02-13 17:30:25,249 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:30:25,269 - INFO - Benchmark Results:
2025-02-13 17:30:25,269 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 64
2025-02-13 17:30:25,269 - INFO -   Batch size 1 took 1.492405 seconds
2025-02-13 17:30:25,269 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 640
2025-02-13 17:30:25,269 - INFO -   Batch size 1 took 14.519754 seconds
2025-02-13 17:30:25,269 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 1600
2025-02-13 17:30:25,269 - INFO -   Batch size 1 took 36.365215 seconds
2025-02-13 17:30:25,269 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 3200
2025-02-13 17:30:25,269 - INFO -   Batch size 1 took 70.746333 seconds
2025-02-13 17:30:25,269 - INFO - Resource usage logger task cancelled.
```

**Without Semaphore**:
```
2025-02-13 17:31:38,543 - INFO - Running benchmarks with 64 commands and max_connections=100
2025-02-13 17:31:38,544 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:31:38,544 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:31:39,948 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 1.404417 seconds
2025-02-13 17:31:39,948 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:31:39,949 - INFO - Running benchmarks with 640 commands and max_connections=100
2025-02-13 17:31:39,949 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:31:39,949 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:31:43,567 - INFO - Process Resource Usage - CPU: 77.40%, Memory: 0.18%
2025-02-13 17:31:48,576 - INFO - Process Resource Usage - CPU: 100.00%, Memory: 0.19%
2025-02-13 17:31:53,576 - INFO - Process Resource Usage - CPU: 95.40%, Memory: 0.20%
2025-02-13 17:31:56,802 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 16.853240 seconds
2025-02-13 17:31:56,802 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:31:56,807 - INFO - Running benchmarks with 1600 commands and max_connections=100
2025-02-13 17:31:56,807 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:31:56,807 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:32:17,716 - INFO - Process Resource Usage - CPU: 89.40%, Memory: 0.22%
2025-02-13 17:32:22,881 - INFO - Process Resource Usage - CPU: 99.50%, Memory: 0.23%
2025-02-13 17:32:27,897 - INFO - Process Resource Usage - CPU: 99.90%, Memory: 0.24%
2025-02-13 17:32:32,998 - INFO - Process Resource Usage - CPU: 99.80%, Memory: 0.24%
2025-02-13 17:32:38,005 - INFO - Process Resource Usage - CPU: 99.90%, Memory: 0.26%
2025-02-13 17:32:43,061 - INFO - Process Resource Usage - CPU: 99.70%, Memory: 0.27%
2025-02-13 17:32:48,064 - INFO - Process Resource Usage - CPU: 99.90%, Memory: 0.28%
2025-02-13 17:32:52,257 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 55.450154 seconds
2025-02-13 17:32:52,257 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:32:52,270 - INFO - Running benchmarks with 3200 commands and max_connections=100
2025-02-13 17:32:52,270 - INFO - <172.20.20.111>: Starting benchmarks...
2025-02-13 17:32:52,270 - INFO - <172.20.20.111>: Benchmarking with batch size 1
2025-02-13 17:34:21,817 - INFO - Process Resource Usage - CPU: 97.70%, Memory: 0.29%
2025-02-13 17:34:26,827 - INFO - Process Resource Usage - CPU: 99.00%, Memory: 0.30%
2025-02-13 17:34:31,874 - INFO - Process Resource Usage - CPU: 99.90%, Memory: 0.31%
2025-02-13 17:34:36,932 - INFO - Process Resource Usage - CPU: 99.80%, Memory: 0.32%
2025-02-13 17:34:42,112 - INFO - Process Resource Usage - CPU: 100.20%, Memory: 0.34%
2025-02-13 17:34:47,146 - INFO - Process Resource Usage - CPU: 99.90%, Memory: 0.35%
2025-02-13 17:34:52,175 - INFO - Process Resource Usage - CPU: 99.80%, Memory: 0.36%
2025-02-13 17:34:57,261 - INFO - Process Resource Usage - CPU: 100.10%, Memory: 0.37%
2025-02-13 17:35:02,349 - INFO - Process Resource Usage - CPU: 100.00%, Memory: 0.37%
2025-02-13 17:35:07,368 - INFO - Process Resource Usage - CPU: 99.80%, Memory: 0.39%
2025-02-13 17:35:12,445 - INFO - Process Resource Usage - CPU: 100.10%, Memory: 0.40%
2025-02-13 17:35:17,475 - INFO - Process Resource Usage - CPU: 99.80%, Memory: 0.41%
2025-02-13 17:35:22,505 - INFO - Process Resource Usage - CPU: 100.20%, Memory: 0.41%
2025-02-13 17:35:27,512 - INFO - Process Resource Usage - CPU: 99.70%, Memory: 0.42%
2025-02-13 17:35:32,034 - INFO - <172.20.20.111>: Completed benchmarking with batch size 1 in 159.763054 seconds
2025-02-13 17:35:32,034 - INFO - <172.20.20.111>: Completed benchmarks!
2025-02-13 17:35:32,060 - INFO - Benchmark Results:
2025-02-13 17:35:32,061 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 64
2025-02-13 17:35:32,061 - INFO -   Batch size 1 took 1.404417 seconds
2025-02-13 17:35:32,061 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 640
2025-02-13 17:35:32,061 - INFO -   Batch size 1 took 16.853240 seconds
2025-02-13 17:35:32,061 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 1600
2025-02-13 17:35:32,061 - INFO -   Batch size 1 took 55.450154 seconds
2025-02-13 17:35:32,061 - INFO - Device: 172.20.20.111, Max Connections: 100, Number of Commands: 3200
2025-02-13 17:35:32,061 - INFO -   Batch size 1 took 159.763054 seconds
2025-02-13 17:35:32,061 - INFO - Resource usage logger task cancelled.
```
# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
