### PR TITLE
refactor(anta.tests): Nicer result failure messages STP and System test module 

### DIFF
--- a/anta/input_models/system.py
+++ b/anta/input_models/system.py
@@ -28,4 +28,4 @@ class NTPServer(BaseModel):
 
     def __str__(self) -> str:
         """Representation of the NTPServer model."""
-        return f"{self.server_address} (Preferred: {self.preferred}, Stratum: {self.stratum})"
+        return f"{self.server_address} Preferred: {self.preferred} Stratum: {self.stratum}"

--- a/anta/input_models/system.py
+++ b/anta/input_models/system.py
@@ -28,4 +28,4 @@ class NTPServer(BaseModel):
 
     def __str__(self) -> str:
         """Representation of the NTPServer model."""
-        return f"{self.server_address} Preferred: {self.preferred} Stratum: {self.stratum}"
+        return f"NTP Server: {self.server_address} Preferred: {self.preferred} Stratum: {self.stratum}"

--- a/anta/tests/stp.py
+++ b/anta/tests/stp.py
@@ -63,9 +63,9 @@ class VerifySTPMode(AntaTest):
                     f"spanningTreeVlanInstances.{vlan_id}.spanningTreeVlanInstance.protocol",
                 )
             ):
-                self.result.is_failure(f"VLAN: {vlan_id} STP mode: {self.inputs.mode} - Not configured")
+                self.result.is_failure(f"VLAN {vlan_id} STP mode: {self.inputs.mode} - Not configured")
             elif stp_mode != self.inputs.mode:
-                self.result.is_failure(f"VLAN: {vlan_id} - Incorrect STP mode - Expected: {self.inputs.mode} Actual: {stp_mode}")
+                self.result.is_failure(f"VLAN {vlan_id} - Incorrect STP mode - Expected: {self.inputs.mode} Actual: {stp_mode}")
 
 
 class VerifySTPBlockedPorts(AntaTest):
@@ -172,7 +172,7 @@ class VerifySTPForwardingPorts(AntaTest):
         for command in self.instance_commands:
             vlan_id = command.params.vlan
             if not (topologies := get_value(command.json_output, "topologies")):
-                self.result.is_failure(f"VLAN: {vlan_id} - STP instance is not configured")
+                self.result.is_failure(f"VLAN {vlan_id} - STP instance is not configured")
                 continue
             for value in topologies.values():
                 if vlan_id and int(vlan_id) in value["vlans"]:
@@ -182,7 +182,7 @@ class VerifySTPForwardingPorts(AntaTest):
 
             if interfaces_state:
                 for interface, state in interfaces_state:
-                    self.result.is_failure(f"VLAN: {vlan_id} Interface: {interface} - Invalid state - Expected: forwarding Actual: {state}")
+                    self.result.is_failure(f"VLAN {vlan_id} Interface: {interface} - Invalid state - Expected: forwarding Actual: {state}")
 
 
 class VerifySTPRootPriority(AntaTest):
@@ -236,10 +236,10 @@ class VerifySTPRootPriority(AntaTest):
         check_instances = [f"{prefix}{instance_id}" for instance_id in self.inputs.instances] if self.inputs.instances else command_output["instances"].keys()
         for instance in check_instances:
             if not (instance_details := get_value(command_output, f"instances.{instance}")):
-                self.result.is_failure(f"Instance: {instance} - Not found")
+                self.result.is_failure(f"Instance: {instance} - Not configured")
                 continue
             if (priority := get_value(instance_details, "rootBridge.priority")) != self.inputs.priority:
-                self.result.is_failure(f"Instance: {instance} - Incorrect STP root priority - Expected: {self.inputs.priority} Actual: {priority}")
+                self.result.is_failure(f"STP Instance: {instance} - Incorrect root priority - Expected: {self.inputs.priority} Actual: {priority}")
 
 
 class VerifyStpTopologyChanges(AntaTest):

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -190,7 +190,7 @@ class VerifyCPUUtilization(AntaTest):
         command_output = self.instance_commands[0].json_output
         command_output_data = command_output["cpuInfo"]["%Cpu(s)"]["idle"]
         if command_output_data < CPU_IDLE_THRESHOLD:
-            self.result.is_failure(f"Device has reported a high CPU utilization -  Expected: {CPU_IDLE_THRESHOLD}% Actual: {100 - command_output_data}%")
+            self.result.is_failure(f"Device has reported a high CPU utilization -  Expected: < 75% Actual: {100 - command_output_data}%")
 
 
 class VerifyMemoryUtilization(AntaTest):
@@ -219,7 +219,7 @@ class VerifyMemoryUtilization(AntaTest):
         command_output = self.instance_commands[0].json_output
         memory_usage = command_output["memFree"] / command_output["memTotal"]
         if memory_usage < MEMORY_THRESHOLD:
-            self.result.is_failure(f"Device has reported a high memory usage - Expected: {MEMORY_THRESHOLD}% Actual: {(1 - memory_usage) * 100:.2f}%")
+            self.result.is_failure(f"Device has reported a high memory usage - Expected: < 75% Actual: {(1 - memory_usage) * 100:.2f}%")
 
 
 class VerifyFileSystemUtilization(AntaTest):
@@ -278,7 +278,7 @@ class VerifyNTP(AntaTest):
             self.result.is_success()
         else:
             data = command_output.split("\n")[0]
-            self.result.is_failure(f"Device not synchronized with configured NTP server(s) - Actual: {data}")
+            self.result.is_failure(f"NTP status mismatch - Expected: synchronised Actual: {data}")
 
 
 class VerifyNTPAssociations(AntaTest):

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -133,7 +133,7 @@ class VerifyCoredump(AntaTest):
         if not core_files:
             self.result.is_success()
         else:
-            self.result.is_failure(f"Core dump(s) have been found: {core_files}")
+            self.result.is_failure(f"Core dump(s) have been found: {', '.join(core_files)}")
 
 
 class VerifyAgentLogs(AntaTest):
@@ -284,7 +284,7 @@ class VerifyNTP(AntaTest):
             self.result.is_success()
         else:
             data = command_output.split("\n")[0]
-            self.result.is_failure(f"The device is not synchronized with the configured NTP server(s): '{data}'")
+            self.result.is_failure(f"The device is not synchronized with the configured NTP server(s) - Actual: {data}")
 
 
 class VerifyNTPAssociations(AntaTest):

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -24,7 +24,7 @@ DISK_SPACE_THRESHOLD = 75
 
 
 class VerifyUptime(AntaTest):
-    """Verifies if the device uptime is higher than the provided minimum uptime value.
+    """Verifies the device uptime.
 
     Expected Results
     ----------------
@@ -40,7 +40,6 @@ class VerifyUptime(AntaTest):
     ```
     """
 
-    description = "Verifies the device uptime."
     categories: ClassVar[list[str]] = ["system"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show uptime", revision=1)]
 
@@ -53,11 +52,10 @@ class VerifyUptime(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyUptime."""
+        self.result.is_success()
         command_output = self.instance_commands[0].json_output
-        if command_output["upTime"] > self.inputs.minimum:
-            self.result.is_success()
-        else:
-            self.result.is_failure(f"Device uptime is {command_output['upTime']} seconds")
+        if command_output["upTime"] < self.inputs.minimum:
+            self.result.is_failure(f"Device uptime is incorrect - Expected: {self.inputs.minimum} Actual: {command_output['upTime']} seconds")
 
 
 class VerifyReloadCause(AntaTest):
@@ -96,11 +94,11 @@ class VerifyReloadCause(AntaTest):
         ]:
             self.result.is_success()
         else:
-            self.result.is_failure(f"Reload cause is: '{command_output_data}'")
+            self.result.is_failure(f"Reload cause is: {command_output_data}")
 
 
 class VerifyCoredump(AntaTest):
-    """Verifies if there are core dump files in the /var/core directory.
+    """Verifies there are no core dump files.
 
     Expected Results
     ----------------
@@ -119,7 +117,6 @@ class VerifyCoredump(AntaTest):
     ```
     """
 
-    description = "Verifies there are no core dump files."
     categories: ClassVar[list[str]] = ["system"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show system coredump", revision=1)]
 
@@ -189,12 +186,11 @@ class VerifyCPUUtilization(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyCPUUtilization."""
+        self.result.is_success()
         command_output = self.instance_commands[0].json_output
         command_output_data = command_output["cpuInfo"]["%Cpu(s)"]["idle"]
-        if command_output_data > CPU_IDLE_THRESHOLD:
-            self.result.is_success()
-        else:
-            self.result.is_failure(f"Device has reported a high CPU utilization: {100 - command_output_data}%")
+        if command_output_data < CPU_IDLE_THRESHOLD:
+            self.result.is_failure(f"Device has reported a high CPU utilization -  Expected: {CPU_IDLE_THRESHOLD}% Actual: {100 - command_output_data}%")
 
 
 class VerifyMemoryUtilization(AntaTest):
@@ -219,12 +215,11 @@ class VerifyMemoryUtilization(AntaTest):
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyMemoryUtilization."""
+        self.result.is_success()
         command_output = self.instance_commands[0].json_output
         memory_usage = command_output["memFree"] / command_output["memTotal"]
-        if memory_usage > MEMORY_THRESHOLD:
-            self.result.is_success()
-        else:
-            self.result.is_failure(f"Device has reported a high memory usage: {(1 - memory_usage) * 100:.2f}%")
+        if memory_usage < MEMORY_THRESHOLD:
+            self.result.is_failure(f"Device has reported a high memory usage - Expected: {MEMORY_THRESHOLD}% Actual: {(1 - memory_usage) * 100:.2f}%")
 
 
 class VerifyFileSystemUtilization(AntaTest):
@@ -253,7 +248,7 @@ class VerifyFileSystemUtilization(AntaTest):
         self.result.is_success()
         for line in command_output.split("\n")[1:]:
             if "loop" not in line and len(line) > 0 and (percentage := int(line.split()[4].replace("%", ""))) > DISK_SPACE_THRESHOLD:
-                self.result.is_failure(f"Mount point {line} is higher than 75%: reported {percentage}%")
+                self.result.is_failure(f"Mount point: {line} - Higher disk space utilization - Expected: {DISK_SPACE_THRESHOLD}% Actual: {percentage}%")
 
 
 class VerifyNTP(AntaTest):
@@ -272,7 +267,6 @@ class VerifyNTP(AntaTest):
     ```
     """
 
-    description = "Verifies if NTP is synchronised."
     categories: ClassVar[list[str]] = ["system"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ntp status", ofmt="text")]
 
@@ -284,7 +278,7 @@ class VerifyNTP(AntaTest):
             self.result.is_success()
         else:
             data = command_output.split("\n")[0]
-            self.result.is_failure(f"The device is not synchronized with the configured NTP server(s) - Actual: {data}")
+            self.result.is_failure(f"Device not synchronized with configured NTP server(s) - Actual: {data}")
 
 
 class VerifyNTPAssociations(AntaTest):

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -952,7 +952,7 @@ anta.tests.system:
   - VerifyMemoryUtilization:
       # Verifies whether the memory utilization is below 75%.
   - VerifyNTP:
-      # Verifies if NTP is synchronised.
+      # Verifies that the Network Time Protocol (NTP) is synchronized.
   - VerifyNTPAssociations:
       # Verifies the Network Time Protocol (NTP) associations.
       ntp_servers:

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -37,7 +37,7 @@ DATA: list[dict[str, Any]] = [
             {"spanningTreeVlanInstances": {}},
         ],
         "inputs": {"mode": "rstp", "vlans": [10, 20]},
-        "expected": {"result": "failure", "messages": ["STP mode 'rstp' not configured for the following VLAN(s): [10, 20]"]},
+        "expected": {"result": "failure", "messages": ["STP mode rstp not configured for the following VLAN(s): 10, 20"]},
     },
     {
         "name": "failure-wrong-mode",
@@ -47,7 +47,7 @@ DATA: list[dict[str, Any]] = [
             {"spanningTreeVlanInstances": {"20": {"spanningTreeVlanInstance": {"protocol": "mstp"}}}},
         ],
         "inputs": {"mode": "rstp", "vlans": [10, 20]},
-        "expected": {"result": "failure", "messages": ["Wrong STP mode configured for the following VLAN(s): [10, 20]"]},
+        "expected": {"result": "failure", "messages": ["Wrong STP mode configured for the following VLAN(s): 10, 20"]},
     },
     {
         "name": "failure-both",
@@ -59,7 +59,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"mode": "rstp", "vlans": [10, 20]},
         "expected": {
             "result": "failure",
-            "messages": ["STP mode 'rstp' not configured for the following VLAN(s): [10]", "Wrong STP mode configured for the following VLAN(s): [20]"],
+            "messages": ["STP mode rstp not configured for the following VLAN(s): 10", "Wrong STP mode configured for the following VLAN(s): 20"],
         },
     },
     {
@@ -74,7 +74,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySTPBlockedPorts,
         "eos_data": [{"spanningTreeInstances": {"MST0": {"spanningTreeBlockedPorts": ["Ethernet10"]}, "MST10": {"spanningTreeBlockedPorts": ["Ethernet10"]}}}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The following ports are blocked by STP: {'MST0': ['Ethernet10'], 'MST10': ['Ethernet10']}"]},
+        "expected": {"result": "failure", "messages": ["STP Instance: MST0 blocked ports are: Ethernet10", "STP Instance: MST10 blocked ports are: Ethernet10"]},
     },
     {
         "name": "success",
@@ -95,7 +95,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The following interfaces have STP BPDU packet errors: ['Ethernet10', 'Ethernet11']"]},
+        "expected": {"result": "failure", "messages": ["The following interfaces have STP BPDU packet errors: Ethernet10, Ethernet11"]},
     },
     {
         "name": "success",
@@ -134,7 +134,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySTPForwardingPorts,
         "eos_data": [{"unmappedVlans": [], "topologies": {}}, {"unmappedVlans": [], "topologies": {}}],
         "inputs": {"vlans": [10, 20]},
-        "expected": {"result": "failure", "messages": ["STP instance is not configured for the following VLAN(s): [10, 20]"]},
+        "expected": {"result": "failure", "messages": ["VLAN: 10 - STP instance is not configured", "VLAN: 20 - STP instance is not configured"]},
     },
     {
         "name": "failure",
@@ -152,7 +152,10 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"vlans": [10, 20]},
         "expected": {
             "result": "failure",
-            "messages": ["The following VLAN(s) have interface(s) that are not in a forwarding state: [{'VLAN 10': ['Ethernet10']}, {'VLAN 20': ['Ethernet10']}]"],
+            "messages": [
+                "VLAN: 10 - Following interface(s) that are not in a forwarding state: Ethernet10",
+                "VLAN: 20 - Following interface(s) that are not in a forwarding state: Ethernet10",
+            ],
         },
     },
     {
@@ -330,7 +333,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"priority": 32768, "instances": [10, 20, 30]},
-        "expected": {"result": "failure", "messages": ["The following instance(s) have the wrong STP root priority configured: ['VL20', 'VL30']"]},
+        "expected": {"result": "failure", "messages": ["The following instance(s) have the wrong STP root priority configured: VL20, VL30"]},
     },
     {
         "name": "success-mstp",
@@ -470,8 +473,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "The following STP topologies are not configured or number of changes not within the threshold:\n"
-                "{'topologies': {'Cist': {'Cpu': {'Number of changes': 15}, 'Port-Channel5': {'Number of changes': 15}}}}"
+                "Topology: Cist Interface: Cpu - Number of changes not within the threshold - Expected: 10 Actual: 15",
+                "Topology: Cist Interface: Port-Channel5 - Number of changes not within the threshold - Expected: 10 Actual: 15",
             ],
         },
     },

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -37,7 +37,7 @@ DATA: list[dict[str, Any]] = [
             {"spanningTreeVlanInstances": {}},
         ],
         "inputs": {"mode": "rstp", "vlans": [10, 20]},
-        "expected": {"result": "failure", "messages": ["VLAN: 10 STP mode: rstp - Not configured", "VLAN: 20 STP mode: rstp - Not configured"]},
+        "expected": {"result": "failure", "messages": ["VLAN 10 STP mode: rstp - Not configured", "VLAN 20 STP mode: rstp - Not configured"]},
     },
     {
         "name": "failure-wrong-mode",
@@ -49,7 +49,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"mode": "rstp", "vlans": [10, 20]},
         "expected": {
             "result": "failure",
-            "messages": ["VLAN: 10 - Incorrect STP mode - Expected: rstp Actual: mstp", "VLAN: 20 - Incorrect STP mode - Expected: rstp Actual: mstp"],
+            "messages": ["VLAN 10 - Incorrect STP mode - Expected: rstp Actual: mstp", "VLAN 20 - Incorrect STP mode - Expected: rstp Actual: mstp"],
         },
     },
     {
@@ -62,7 +62,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"mode": "rstp", "vlans": [10, 20]},
         "expected": {
             "result": "failure",
-            "messages": ["VLAN: 10 STP mode: rstp - Not configured", "VLAN: 20 - Incorrect STP mode - Expected: rstp Actual: mstp"],
+            "messages": ["VLAN 10 STP mode: rstp - Not configured", "VLAN 20 - Incorrect STP mode - Expected: rstp Actual: mstp"],
         },
     },
     {
@@ -163,7 +163,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifySTPForwardingPorts,
         "eos_data": [{"unmappedVlans": [], "topologies": {}}, {"unmappedVlans": [], "topologies": {}}],
         "inputs": {"vlans": [10, 20]},
-        "expected": {"result": "failure", "messages": ["VLAN: 10 - STP instance is not configured", "VLAN: 20 - STP instance is not configured"]},
+        "expected": {"result": "failure", "messages": ["VLAN 10 - STP instance is not configured", "VLAN 20 - STP instance is not configured"]},
     },
     {
         "name": "failure",
@@ -182,8 +182,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "VLAN: 10 Interface: Ethernet10 - Invalid state - Expected: forwarding Actual: discarding",
-                "VLAN: 20 Interface: Ethernet10 - Invalid state - Expected: forwarding Actual: discarding",
+                "VLAN 10 Interface: Ethernet10 - Invalid state - Expected: forwarding Actual: discarding",
+                "VLAN 20 Interface: Ethernet10 - Invalid state - Expected: forwarding Actual: discarding",
             ],
         },
     },
@@ -364,7 +364,7 @@ DATA: list[dict[str, Any]] = [
             }
         ],
         "inputs": {"priority": 32768, "instances": [11, 20]},
-        "expected": {"result": "failure", "messages": ["Instance: VL11 - Not found", "Instance: VL20 - Not found"]},
+        "expected": {"result": "failure", "messages": ["Instance: VL11 - Not configured", "Instance: VL20 - Not configured"]},
     },
     {
         "name": "failure-wrong-priority",
@@ -409,8 +409,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Instance: VL20 - Incorrect STP root priority - Expected: 32768 Actual: 8196",
-                "Instance: VL30 - Incorrect STP root priority - Expected: 32768 Actual: 8196",
+                "STP Instance: VL20 - Incorrect root priority - Expected: 32768 Actual: 8196",
+                "STP Instance: VL30 - Incorrect root priority - Expected: 32768 Actual: 8196",
             ],
         },
     },

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -190,7 +190,7 @@ EntityManager::doBackoff waiting for remote sysdb version ...................ok
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device has reported a high CPU utilization -  Expected: 25% Actual: 75.2%"]},
+        "expected": {"result": "failure", "messages": ["Device has reported a high CPU utilization -  Expected: < 75% Actual: 75.2%"]},
     },
     {
         "name": "success",
@@ -222,7 +222,7 @@ EntityManager::doBackoff waiting for remote sysdb version ...................ok
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device has reported a high memory usage - Expected: 0.25% Actual: 95.56%"]},
+        "expected": {"result": "failure", "messages": ["Device has reported a high memory usage - Expected: < 75% Actual: 95.56%"]},
     },
     {
         "name": "success",
@@ -278,7 +278,7 @@ poll interval unknown
 """,
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device not synchronized with configured NTP server(s) - Actual: unsynchronised"]},
+        "expected": {"result": "failure", "messages": ["NTP status mismatch - Expected: synchronised Actual: unsynchronised"]},
     },
     {
         "name": "success",

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -33,7 +33,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyUptime,
         "eos_data": [{"upTime": 665.15, "loadAvg": [0.13, 0.12, 0.09], "users": 1, "currentTime": 1683186659.139859}],
         "inputs": {"minimum": 666},
-        "expected": {"result": "failure", "messages": ["Device uptime is 665.15 seconds"]},
+        "expected": {"result": "failure", "messages": ["Device uptime is incorrect - Expected: 666 Actual: 665.15 seconds"]},
     },
     {
         "name": "success-no-reload",
@@ -74,7 +74,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Reload cause is: 'Reload after crash.'"]},
+        "expected": {"result": "failure", "messages": ["Reload cause is: Reload after crash."]},
     },
     {
         "name": "success-without-minidump",
@@ -190,7 +190,7 @@ EntityManager::doBackoff waiting for remote sysdb version ...................ok
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device has reported a high CPU utilization: 75.2%"]},
+        "expected": {"result": "failure", "messages": ["Device has reported a high CPU utilization -  Expected: 25% Actual: 75.2%"]},
     },
     {
         "name": "success",
@@ -222,7 +222,7 @@ EntityManager::doBackoff waiting for remote sysdb version ...................ok
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device has reported a high memory usage: 95.56%"]},
+        "expected": {"result": "failure", "messages": ["Device has reported a high memory usage - Expected: 0.25% Actual: 95.56%"]},
     },
     {
         "name": "success",
@@ -253,8 +253,8 @@ none            294M   78M  217M  84% /.overlay
         "expected": {
             "result": "failure",
             "messages": [
-                "Mount point /dev/sda2       3.9G  988M  2.9G  84% /mnt/flash is higher than 75%: reported 84%",
-                "Mount point none            294M   78M  217M  84% /.overlay is higher than 75%: reported 84%",
+                "Mount point: /dev/sda2       3.9G  988M  2.9G  84% /mnt/flash - Higher disk space utilization - Expected: 75% Actual: 84%",
+                "Mount point: none            294M   78M  217M  84% /.overlay - Higher disk space utilization - Expected: 75% Actual: 84%",
             ],
         },
     },
@@ -278,7 +278,7 @@ poll interval unknown
 """,
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The device is not synchronized with the configured NTP server(s) - Actual: unsynchronised"]},
+        "expected": {"result": "failure", "messages": ["Device not synchronized with configured NTP server(s) - Actual: unsynchronised"]},
     },
     {
         "name": "success",
@@ -413,9 +413,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "1.1.1.1 Preferred: True Stratum: 1 - Bad association - Condition: candidate, Stratum: 2",
-                "2.2.2.2 Preferred: False Stratum: 2 - Bad association - Condition: sys.peer, Stratum: 2",
-                "3.3.3.3 Preferred: False Stratum: 2 - Bad association - Condition: sys.peer, Stratum: 3",
+                "NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Bad association - Condition: candidate, Stratum: 2",
+                "NTP Server: 2.2.2.2 Preferred: False Stratum: 2 - Bad association - Condition: sys.peer, Stratum: 2",
+                "NTP Server: 3.3.3.3 Preferred: False Stratum: 2 - Bad association - Condition: sys.peer, Stratum: 3",
             ],
         },
     },
@@ -463,7 +463,7 @@ poll interval unknown
         },
         "expected": {
             "result": "failure",
-            "messages": ["3.3.3.3 Preferred: False Stratum: 1 - Not configured"],
+            "messages": ["NTP Server: 3.3.3.3 Preferred: False Stratum: 1 - Not configured"],
         },
     },
     {
@@ -490,9 +490,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "1.1.1.1 Preferred: True Stratum: 1 - Bad association - Condition: candidate, Stratum: 1",
-                "2.2.2.2 Preferred: False Stratum: 1 - Not configured",
-                "3.3.3.3 Preferred: False Stratum: 1 - Not configured",
+                "NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Bad association - Condition: candidate, Stratum: 1",
+                "NTP Server: 2.2.2.2 Preferred: False Stratum: 1 - Not configured",
+                "NTP Server: 3.3.3.3 Preferred: False Stratum: 1 - Not configured",
             ],
         },
     },

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -95,14 +95,14 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyCoredump,
         "eos_data": [{"mode": "compressedDeferred", "coreFiles": ["core.2344.1584483862.Mlag.gz", "core.23101.1584483867.Mlag.gz"]}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Core dump(s) have been found: ['core.2344.1584483862.Mlag.gz', 'core.23101.1584483867.Mlag.gz']"]},
+        "expected": {"result": "failure", "messages": ["Core dump(s) have been found: core.2344.1584483862.Mlag.gz, core.23101.1584483867.Mlag.gz"]},
     },
     {
         "name": "failure-with-minidump",
         "test": VerifyCoredump,
         "eos_data": [{"mode": "compressedDeferred", "coreFiles": ["minidump", "core.2344.1584483862.Mlag.gz", "core.23101.1584483867.Mlag.gz"]}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Core dump(s) have been found: ['core.2344.1584483862.Mlag.gz', 'core.23101.1584483867.Mlag.gz']"]},
+        "expected": {"result": "failure", "messages": ["Core dump(s) have been found: core.2344.1584483862.Mlag.gz, core.23101.1584483867.Mlag.gz"]},
     },
     {
         "name": "success",
@@ -278,7 +278,7 @@ poll interval unknown
 """,
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["The device is not synchronized with the configured NTP server(s): 'unsynchronised'"]},
+        "expected": {"result": "failure", "messages": ["The device is not synchronized with the configured NTP server(s) - Actual: unsynchronised"]},
     },
     {
         "name": "success",
@@ -413,9 +413,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "1.1.1.1 (Preferred: True, Stratum: 1) - Bad association - Condition: candidate, Stratum: 2",
-                "2.2.2.2 (Preferred: False, Stratum: 2) - Bad association - Condition: sys.peer, Stratum: 2",
-                "3.3.3.3 (Preferred: False, Stratum: 2) - Bad association - Condition: sys.peer, Stratum: 3",
+                "1.1.1.1 Preferred: True Stratum: 1 - Bad association - Condition: candidate, Stratum: 2",
+                "2.2.2.2 Preferred: False Stratum: 2 - Bad association - Condition: sys.peer, Stratum: 2",
+                "3.3.3.3 Preferred: False Stratum: 2 - Bad association - Condition: sys.peer, Stratum: 3",
             ],
         },
     },
@@ -463,7 +463,7 @@ poll interval unknown
         },
         "expected": {
             "result": "failure",
-            "messages": ["3.3.3.3 (Preferred: False, Stratum: 1) - Not configured"],
+            "messages": ["3.3.3.3 Preferred: False Stratum: 1 - Not configured"],
         },
     },
     {
@@ -490,9 +490,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "1.1.1.1 (Preferred: True, Stratum: 1) - Bad association - Condition: candidate, Stratum: 1",
-                "2.2.2.2 (Preferred: False, Stratum: 1) - Not configured",
-                "3.3.3.3 (Preferred: False, Stratum: 1) - Not configured",
+                "1.1.1.1 Preferred: True Stratum: 1 - Bad association - Condition: candidate, Stratum: 1",
+                "2.2.2.2 Preferred: False Stratum: 1 - Not configured",
+                "3.3.3.3 Preferred: False Stratum: 1 - Not configured",
             ],
         },
     },


### PR DESCRIPTION
Nicer result failure messages for following test module.

  1. STP
  2. System


Fixes #587

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
