### PR TITLE
refactor(anta.tests): Nicer result failure messages hardware test module

### DIFF
--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -54,7 +54,7 @@ class VerifyTransceiversManufacturers(AntaTest):
         for interface, value in command_output["xcvrSlots"].items():
             if value["mfgName"] not in self.inputs.manufacturers:
                 self.result.is_failure(
-                    f"Interface: {interface} - Transceivers are from unapproved manufacturers - Expected: {', '.join(self.inputs.manufacturers)}"
+                    f"Interface: {interface} - Transceiver is from unapproved manufacturers - Expected: {', '.join(self.inputs.manufacturers)}"
                     f" Actual: {value['mfgName']}"
                 )
 
@@ -119,7 +119,7 @@ class VerifyTransceiversTemperature(AntaTest):
             if sensor["hwStatus"] != "ok":
                 self.result.is_failure(f"Sensor: {sensor['name']} - Invalid Hardware State - Expected: ok Actual: {sensor['hwStatus']}")
             if sensor["alertCount"] != 0:
-                self.result.is_failure(f"Sensor: {sensor['name']} - Non-zero alert-count - Actual: {sensor['alertCount']}")
+                self.result.is_failure(f"Sensor: {sensor['name']} - Non-zero alert counter - Actual: {sensor['alertCount']}")
 
 
 class VerifyEnvironmentSystemCooling(AntaTest):

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -86,7 +86,7 @@ class VerifyTemperature(AntaTest):
         command_output = self.instance_commands[0].json_output
         temperature_status = command_output.get("systemStatus", "")
         if temperature_status != "temperatureOk":
-            self.result.is_failure(f"Device temperature exceeds acceptable limits - Expected: {'temperatureOk'} Actual: {temperature_status}")
+            self.result.is_failure(f"Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: {temperature_status}")
 
 
 class VerifyTransceiversTemperature(AntaTest):
@@ -119,7 +119,7 @@ class VerifyTransceiversTemperature(AntaTest):
             if sensor["hwStatus"] != "ok":
                 self.result.is_failure(f"Sensor: {sensor['name']} - Invalid Hardware State - Expected: ok Actual: {sensor['hwStatus']}")
             if sensor["alertCount"] != 0:
-                self.result.is_failure(f"Sensor: {sensor['name']} - Alert count mismatch - Expected: 0 Actual: {sensor['alertCount']}")
+                self.result.is_failure(f"Sensor: {sensor['name']} - Non-zero alert-count - Actual: {sensor['alertCount']}")
 
 
 class VerifyEnvironmentSystemCooling(AntaTest):
@@ -190,7 +190,7 @@ class VerifyEnvironmentCooling(AntaTest):
             for fan in power_supply.get("fans", []):
                 if (state := fan["status"]) not in self.inputs.states:
                     self.result.is_failure(
-                        f"PowerSupply: {power_supply['label']} Fan: {fan['label']} - Invalid state - Expected: {', '.join(self.inputs.states)} Actual: {state}"
+                        f"Power Slot: {power_supply['label']} Fan: {fan['label']} - Invalid state - Expected: {', '.join(self.inputs.states)} Actual: {state}"
                     )
         # Then go through fan trays
         for fan_tray in command_output.get("fanTraySlots", []):
@@ -237,7 +237,7 @@ class VerifyEnvironmentPower(AntaTest):
         power_supplies = command_output.get("powerSupplies", "{}")
         for power_supply, value in dict(power_supplies).items():
             if (state := value["state"]) not in self.inputs.states:
-                self.result.is_failure(f"Power Supply: {power_supply} - Invalid power supplies state - Expected: {', '.join(self.inputs.states)} Actual: {state}")
+                self.result.is_failure(f"Power Slot: {power_supply} - Invalid power supplies state - Expected: {', '.join(self.inputs.states)} Actual: {state}")
 
 
 class VerifyAdverseDrops(AntaTest):
@@ -267,4 +267,4 @@ class VerifyAdverseDrops(AntaTest):
         command_output = self.instance_commands[0].json_output
         total_adverse_drop = command_output.get("totalAdverseDrops", "")
         if total_adverse_drop != 0:
-            self.result.is_failure(f"Invalid totalAdverseDrops counter - Expected: 0 Actual: {total_adverse_drop}")
+            self.result.is_failure(f"Non-zero totalAdverseDrops counter - Actual: {total_adverse_drop}")

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -117,7 +117,7 @@ class VerifyTransceiversTemperature(AntaTest):
         sensors = command_output.get("tempSensors", "")
         for sensor in sensors:
             if sensor["hwStatus"] != "ok":
-                self.result.is_failure(f"Sensor: {sensor['name']} - Invalid Hardware State - Expected: ok Actual: {sensor['hwStatus']}")
+                self.result.is_failure(f"Sensor: {sensor['name']} - Invalid hardware state - Expected: ok Actual: {sensor['hwStatus']}")
             if sensor["alertCount"] != 0:
                 self.result.is_failure(f"Sensor: {sensor['name']} - Non-zero alert counter - Actual: {sensor['alertCount']}")
 
@@ -149,7 +149,7 @@ class VerifyEnvironmentSystemCooling(AntaTest):
         sys_status = command_output.get("systemStatus", "")
         self.result.is_success()
         if sys_status != "coolingOk":
-            self.result.is_failure(f"Device system cooling is not OK - Actual: {sys_status}")
+            self.result.is_failure(f"Device system cooling status invalid - Expected: coolingOk Actual: {sys_status}")
 
 
 class VerifyEnvironmentCooling(AntaTest):
@@ -267,4 +267,4 @@ class VerifyAdverseDrops(AntaTest):
         command_output = self.instance_commands[0].json_output
         total_adverse_drop = command_output.get("totalAdverseDrops", "")
         if total_adverse_drop != 0:
-            self.result.is_failure(f"Non-zero totalAdverseDrops counter - Actual: {total_adverse_drop}")
+            self.result.is_failure(f"Non-zero total adverse drops counter - Actual: {total_adverse_drop}")

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -78,12 +78,12 @@ DATA: list[dict[str, Any]] = [
                 "ambientThreshold": 45,
                 "cardSlots": [],
                 "shutdownOnOverheat": "True",
-                "systemStatus": "temperatureKO",
+                "systemStatus": "temperatureCritical",
                 "recoveryModeOnOverheat": "recoveryModeNA",
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureKO"]},
+        "expected": {"result": "failure", "messages": ["Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureCritical"]},
     },
     {
         "name": "success",
@@ -178,7 +178,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["Sensor: DomTemperatureSensor54 - Alert count mismatch - Expected: 0 Actual: 1"],
+            "messages": ["Sensor: DomTemperatureSensor54 - Non-zero alert-count - Actual: 1"],
         },
     },
     {
@@ -245,6 +245,24 @@ DATA: list[dict[str, Any]] = [
                         "fans": [
                             {
                                 "status": "ok",
+                                "uptime": 1682498937.0240965,
+                                "maxSpeed": 23000,
+                                "lastSpeedStableChangeTime": 1682499033.0403435,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 33,
+                                "speedHwOverride": True,
+                                "speedStable": True,
+                                "label": "PowerSupply1/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "PowerSupply1",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
                                 "uptime": 1682498935.9121106,
                                 "maxSpeed": 23000,
                                 "lastSpeedStableChangeTime": 1682499092.4665174,
@@ -265,6 +283,24 @@ DATA: list[dict[str, Any]] = [
                         "fans": [
                             {
                                 "status": "ok",
+                                "uptime": 1682498923.9303148,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0139885,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 29,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "1/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "1",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
                                 "uptime": 1682498923.9304729,
                                 "maxSpeed": 17500,
                                 "lastSpeedStableChangeTime": 1682498939.9329433,
@@ -277,7 +313,43 @@ DATA: list[dict[str, Any]] = [
                         ],
                         "speed": 30,
                         "label": "2",
-                    }
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9383528,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140095,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "3/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "3",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9303904,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140295,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "4/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "4",
+                    },
                 ],
                 "minFanSpeed": 0,
                 "currentZones": 1,
@@ -301,6 +373,24 @@ DATA: list[dict[str, Any]] = [
                 "airflowDirection": "frontToBackAirflow",
                 "overrideFanSpeed": 0,
                 "powerSupplySlots": [
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498937.0240965,
+                                "maxSpeed": 23000,
+                                "lastSpeedStableChangeTime": 1682499033.0403435,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 33,
+                                "speedHwOverride": True,
+                                "speedStable": True,
+                                "label": "PowerSupply1/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "PowerSupply1",
+                    },
                     {
                         "status": "ok",
                         "fans": [
@@ -339,6 +429,60 @@ DATA: list[dict[str, Any]] = [
                         "speed": 30,
                         "label": "1",
                     },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9304729,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498939.9329433,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "2/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "2",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9383528,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140095,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "3/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "3",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9303904,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140295,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "4/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "4",
+                    },
                 ],
                 "minFanSpeed": 0,
                 "currentZones": 1,
@@ -362,6 +506,24 @@ DATA: list[dict[str, Any]] = [
                 "airflowDirection": "frontToBackAirflow",
                 "overrideFanSpeed": 0,
                 "powerSupplySlots": [
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498937.0240965,
+                                "maxSpeed": 23000,
+                                "lastSpeedStableChangeTime": 1682499033.0403435,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 33,
+                                "speedHwOverride": True,
+                                "speedStable": True,
+                                "label": "PowerSupply1/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "PowerSupply1",
+                    },
                     {
                         "status": "ok",
                         "fans": [
@@ -404,6 +566,24 @@ DATA: list[dict[str, Any]] = [
                         "status": "ok",
                         "fans": [
                             {
+                                "status": "ok",
+                                "uptime": 1682498923.9304729,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498939.9329433,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "2/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "2",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
                                 "status": "Not Inserted",
                                 "uptime": 1682498923.9383528,
                                 "maxSpeed": 17500,
@@ -417,6 +597,24 @@ DATA: list[dict[str, Any]] = [
                         ],
                         "speed": 30,
                         "label": "3",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9303904,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140295,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "4/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "4",
                     },
                 ],
                 "minFanSpeed": 0,
@@ -515,6 +713,42 @@ DATA: list[dict[str, Any]] = [
                         "speed": 30,
                         "label": "2",
                     },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "Not Inserted",
+                                "uptime": 1682498923.9383528,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140095,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "3/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "3",
+                    },
+                    {
+                        "status": "ok",
+                        "fans": [
+                            {
+                                "status": "ok",
+                                "uptime": 1682498923.9303904,
+                                "maxSpeed": 17500,
+                                "lastSpeedStableChangeTime": 1682498975.0140295,
+                                "configuredSpeed": 30,
+                                "actualSpeed": 30,
+                                "speedHwOverride": False,
+                                "speedStable": True,
+                                "label": "4/1",
+                            },
+                        ],
+                        "speed": 30,
+                        "label": "4",
+                    },
                 ],
                 "minFanSpeed": 0,
                 "currentZones": 1,
@@ -526,7 +760,7 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "PowerSupply: PowerSupply1 Fan: PowerSupply1/1 - Invalid state - Expected: ok, Not Inserted Actual: down",
+                "Power Slot: PowerSupply1 Fan: PowerSupply1/1 - Invalid state - Expected: ok, Not Inserted Actual: down",
             ],
         },
     },
@@ -669,7 +903,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"states": ["ok"]},
-        "expected": {"result": "failure", "messages": ["Power Supply: 1 - Invalid power supplies state - Expected: ok Actual: powerLoss"]},
+        "expected": {"result": "failure", "messages": ["Power Slot: 1 - Invalid power supplies state - Expected: ok Actual: powerLoss"]},
     },
     {
         "name": "success",
@@ -683,6 +917,6 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyAdverseDrops,
         "eos_data": [{"totalAdverseDrops": 10}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Invalid totalAdverseDrops counter - Expected: 0 Actual: 10"]},
+        "expected": {"result": "failure", "messages": ["Non-zero totalAdverseDrops counter - Actual: 10"]},
     },
 ]

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -48,8 +48,8 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Interface: 1 - Transceivers are from unapproved manufacturers - Expected: Arista Actual: Arista Networks",
-                "Interface: 2 - Transceivers are from unapproved manufacturers - Expected: Arista Actual: Arista Networks",
+                "Interface: 1 - Transceiver is from unapproved manufacturers - Expected: Arista Actual: Arista Networks",
+                "Interface: 2 - Transceiver is from unapproved manufacturers - Expected: Arista Actual: Arista Networks",
             ],
         },
     },
@@ -178,7 +178,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["Sensor: DomTemperatureSensor54 - Non-zero alert-count - Actual: 1"],
+            "messages": ["Sensor: DomTemperatureSensor54 - Non-zero alert counter - Actual: 1"],
         },
     },
     {

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -45,7 +45,13 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"manufacturers": ["Arista"]},
-        "expected": {"result": "failure", "messages": ["Some transceivers are from unapproved manufacturers: {'1': 'Arista Networks', '2': 'Arista Networks'}"]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Interface: 1 - Transceivers are from unapproved manufacturers - Expected: Arista Actual: Arista Networks",
+                "Interface: 2 - Transceivers are from unapproved manufacturers - Expected: Arista Actual: Arista Networks",
+            ],
+        },
     },
     {
         "name": "success",
@@ -77,7 +83,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device temperature exceeds acceptable limits. Current system status: 'temperatureKO'"]},
+        "expected": {"result": "failure", "messages": ["Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureKO"]},
     },
     {
         "name": "success",
@@ -139,11 +145,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": [
-                "The following sensors are operating outside the acceptable temperature range or have raised alerts: "
-                "{'DomTemperatureSensor54': "
-                "{'hwStatus': 'ko', 'alertCount': 0}}",
-            ],
+            "messages": ["Sensor: DomTemperatureSensor54 - Invalid Hardware State - Expected: ok Actual: ko"],
         },
     },
     {
@@ -176,11 +178,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": [
-                "The following sensors are operating outside the acceptable temperature range or have raised alerts: "
-                "{'DomTemperatureSensor54': "
-                "{'hwStatus': 'ok', 'alertCount': 1}}",
-            ],
+            "messages": ["Sensor: DomTemperatureSensor54 - Alert count mismatch - Expected: 0 Actual: 1"],
         },
     },
     {
@@ -227,7 +225,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device system cooling is not OK: 'coolingKo'"]},
+        "expected": {"result": "failure", "messages": ["Device system cooling is not OK - Actual: coolingKo"]},
     },
     {
         "name": "success",
@@ -242,24 +240,6 @@ DATA: list[dict[str, Any]] = [
                 "airflowDirection": "frontToBackAirflow",
                 "overrideFanSpeed": 0,
                 "powerSupplySlots": [
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498937.0240965,
-                                "maxSpeed": 23000,
-                                "lastSpeedStableChangeTime": 1682499033.0403435,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 33,
-                                "speedHwOverride": True,
-                                "speedStable": True,
-                                "label": "PowerSupply1/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "PowerSupply1",
-                    },
                     {
                         "status": "ok",
                         "fans": [
@@ -285,24 +265,6 @@ DATA: list[dict[str, Any]] = [
                         "fans": [
                             {
                                 "status": "ok",
-                                "uptime": 1682498923.9303148,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0139885,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 29,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "1/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "1",
-                    },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
                                 "uptime": 1682498923.9304729,
                                 "maxSpeed": 17500,
                                 "lastSpeedStableChangeTime": 1682498939.9329433,
@@ -315,43 +277,7 @@ DATA: list[dict[str, Any]] = [
                         ],
                         "speed": 30,
                         "label": "2",
-                    },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498923.9383528,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0140095,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "3/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "3",
-                    },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498923.9303904,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0140295,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "4/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "4",
-                    },
+                    }
                 ],
                 "minFanSpeed": 0,
                 "currentZones": 1,
@@ -375,24 +301,6 @@ DATA: list[dict[str, Any]] = [
                 "airflowDirection": "frontToBackAirflow",
                 "overrideFanSpeed": 0,
                 "powerSupplySlots": [
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498937.0240965,
-                                "maxSpeed": 23000,
-                                "lastSpeedStableChangeTime": 1682499033.0403435,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 33,
-                                "speedHwOverride": True,
-                                "speedStable": True,
-                                "label": "PowerSupply1/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "PowerSupply1",
-                    },
                     {
                         "status": "ok",
                         "fans": [
@@ -431,60 +339,6 @@ DATA: list[dict[str, Any]] = [
                         "speed": 30,
                         "label": "1",
                     },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498923.9304729,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498939.9329433,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "2/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "2",
-                    },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498923.9383528,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0140095,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "3/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "3",
-                    },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498923.9303904,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0140295,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "4/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "4",
-                    },
                 ],
                 "minFanSpeed": 0,
                 "currentZones": 1,
@@ -508,24 +362,6 @@ DATA: list[dict[str, Any]] = [
                 "airflowDirection": "frontToBackAirflow",
                 "overrideFanSpeed": 0,
                 "powerSupplySlots": [
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498937.0240965,
-                                "maxSpeed": 23000,
-                                "lastSpeedStableChangeTime": 1682499033.0403435,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 33,
-                                "speedHwOverride": True,
-                                "speedStable": True,
-                                "label": "PowerSupply1/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "PowerSupply1",
-                    },
                     {
                         "status": "ok",
                         "fans": [
@@ -568,24 +404,6 @@ DATA: list[dict[str, Any]] = [
                         "status": "ok",
                         "fans": [
                             {
-                                "status": "ok",
-                                "uptime": 1682498923.9304729,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498939.9329433,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "2/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "2",
-                    },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
                                 "status": "Not Inserted",
                                 "uptime": 1682498923.9383528,
                                 "maxSpeed": 17500,
@@ -600,24 +418,6 @@ DATA: list[dict[str, Any]] = [
                         "speed": 30,
                         "label": "3",
                     },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498923.9303904,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0140295,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "4/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "4",
-                    },
                 ],
                 "minFanSpeed": 0,
                 "currentZones": 1,
@@ -626,7 +426,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"states": ["ok", "Not Inserted"]},
-        "expected": {"result": "failure", "messages": ["Fan 1/1 on Fan Tray 1 is: 'down'"]},
+        "expected": {"result": "failure", "messages": ["Fan Tray: 1 Fan: 1/1 - Invalid state - Expected: ok, Not Inserted Actual: down"]},
     },
     {
         "name": "failure-power-supply",
@@ -715,42 +515,6 @@ DATA: list[dict[str, Any]] = [
                         "speed": 30,
                         "label": "2",
                     },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "Not Inserted",
-                                "uptime": 1682498923.9383528,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0140095,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "3/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "3",
-                    },
-                    {
-                        "status": "ok",
-                        "fans": [
-                            {
-                                "status": "ok",
-                                "uptime": 1682498923.9303904,
-                                "maxSpeed": 17500,
-                                "lastSpeedStableChangeTime": 1682498975.0140295,
-                                "configuredSpeed": 30,
-                                "actualSpeed": 30,
-                                "speedHwOverride": False,
-                                "speedStable": True,
-                                "label": "4/1",
-                            },
-                        ],
-                        "speed": 30,
-                        "label": "4",
-                    },
                 ],
                 "minFanSpeed": 0,
                 "currentZones": 1,
@@ -759,7 +523,12 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"states": ["ok", "Not Inserted"]},
-        "expected": {"result": "failure", "messages": ["Fan PowerSupply1/1 on PowerSupply PowerSupply1 is: 'down'"]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "PowerSupply: PowerSupply1 Fan: PowerSupply1/1 - Invalid state - Expected: ok, Not Inserted Actual: down",
+            ],
+        },
     },
     {
         "name": "success",
@@ -900,7 +669,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": {"states": ["ok"]},
-        "expected": {"result": "failure", "messages": ["The following power supplies status are not in the accepted states list: {'1': {'state': 'powerLoss'}}"]},
+        "expected": {"result": "failure", "messages": ["Power Supply: 1 - Invalid power supplies state - Expected: ok Actual: powerLoss"]},
     },
     {
         "name": "success",
@@ -914,6 +683,6 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyAdverseDrops,
         "eos_data": [{"totalAdverseDrops": 10}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device totalAdverseDrops counter is: '10'"]},
+        "expected": {"result": "failure", "messages": ["Invalid totalAdverseDrops counter - Expected: 0 Actual: 10"]},
     },
 ]

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -145,7 +145,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": None,
         "expected": {
             "result": "failure",
-            "messages": ["Sensor: DomTemperatureSensor54 - Invalid Hardware State - Expected: ok Actual: ko"],
+            "messages": ["Sensor: DomTemperatureSensor54 - Invalid hardware state - Expected: ok Actual: ko"],
         },
     },
     {
@@ -225,7 +225,7 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device system cooling is not OK - Actual: coolingKo"]},
+        "expected": {"result": "failure", "messages": ["Device system cooling status invalid - Expected: coolingOk Actual: coolingKo"]},
     },
     {
         "name": "success",
@@ -917,6 +917,6 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyAdverseDrops,
         "eos_data": [{"totalAdverseDrops": 10}],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Non-zero totalAdverseDrops counter - Actual: 10"]},
+        "expected": {"result": "failure", "messages": ["Non-zero total adverse drops counter - Actual: 10"]},
     },
 ]


### PR DESCRIPTION
Nicer result failure messages for following test module.
 1. Hardware 
 
 **Note**: Test with the Unit tests only, not able to test on ATD lab.

Fixes https://github.com/aristanetworks/anta/issues/587

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
