### PR TITLE
feat(anta.tests): Added negative testing in VerifyReachability test

### DIFF
--- a/anta/input_models/connectivity.py
+++ b/anta/input_models/connectivity.py
@@ -23,13 +23,15 @@ class Host(BaseModel):
     source: IPv4Address | IPv6Address | Interface
     """Source address IP or egress interface to use."""
     vrf: str = "default"
-    """VRF context. Defaults to `default`."""
+    """VRF context."""
     repeat: int = 2
-    """Number of ping repetition. Defaults to 2."""
+    """Number of ping repetition."""
     size: int = 100
-    """Specify datagram size. Defaults to 100."""
+    """Specify datagram size."""
     df_bit: bool = False
-    """Enable do not fragment bit in IP header. Defaults to False."""
+    """Enable do not fragment bit in IP header."""
+    expected_unreachable: bool = False
+    """Indicates whether the expected network should be unreachable."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the Host for reporting.

--- a/anta/input_models/connectivity.py
+++ b/anta/input_models/connectivity.py
@@ -30,8 +30,8 @@ class Host(BaseModel):
     """Specify datagram size."""
     df_bit: bool = False
     """Enable do not fragment bit in IP header."""
-    expected_unreachable: bool = False
-    """Indicates whether the expected network should be unreachable."""
+    reachable: bool = True
+    """Indicates whether the destination should be reachable. Set to True if the network should be accessible, False otherwise."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the Host for reporting.

--- a/anta/input_models/connectivity.py
+++ b/anta/input_models/connectivity.py
@@ -31,7 +31,7 @@ class Host(BaseModel):
     df_bit: bool = False
     """Enable do not fragment bit in IP header."""
     reachable: bool = True
-    """Indicates whether the destination should be reachable. Set to True if the network should be accessible, False otherwise."""
+    """Indicates whether the destination should be reachable."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the Host for reporting.

--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -37,6 +37,7 @@ class VerifyReachability(AntaTest):
               vrf: MGMT
               df_bit: True
               size: 100
+              reachable: true
             - source: Management0
               destination: 8.8.8.8
               vrf: MGMT
@@ -47,7 +48,7 @@ class VerifyReachability(AntaTest):
               vrf: default
               df_bit: True
               size: 100
-              expected_unreachable: true
+              reachable: false
     ```
     """
 
@@ -91,12 +92,12 @@ class VerifyReachability(AntaTest):
 
         for command, host in zip(self.instance_commands, self.inputs.hosts):
             # Verifies the network is reachable
-            if not host.expected_unreachable and f"{host.repeat} received" not in command.json_output["messages"][0]:
+            if host.reachable and f"{host.repeat} received" not in command.json_output["messages"][0]:
                 self.result.is_failure(f"{host} - Unreachable")
 
             # Verifies the network is unreachable.
-            if host.expected_unreachable and "0 received" not in command.json_output["messages"][0]:
-                self.result.is_failure(f"{host} - Network is expected to be unreachable but found reachable.")
+            if not host.reachable and f"{host.repeat} received" in command.json_output["messages"][0]:
+                self.result.is_failure(f"{host} - Destination is expected to be unreachable but found reachable.")
 
 
 class VerifyLLDPNeighbors(AntaTest):

--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -47,6 +47,7 @@ class VerifyReachability(AntaTest):
               vrf: default
               df_bit: True
               size: 100
+              expected_unreachable: true
     ```
     """
 
@@ -89,8 +90,13 @@ class VerifyReachability(AntaTest):
         self.result.is_success()
 
         for command, host in zip(self.instance_commands, self.inputs.hosts):
-            if f"{host.repeat} received" not in command.json_output["messages"][0]:
+            # Verifies the network is reachable
+            if not host.expected_unreachable and f"{host.repeat} received" not in command.json_output["messages"][0]:
                 self.result.is_failure(f"{host} - Unreachable")
+
+            # Verifies the network is unreachable.
+            if host.expected_unreachable and "0 received" not in command.json_output["messages"][0]:
+                self.result.is_failure(f"{host} - Network is expected to be unreachable but found reachable.")
 
 
 class VerifyLLDPNeighbors(AntaTest):

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -140,6 +140,7 @@ anta.tests.connectivity:
           vrf: default
           df_bit: True
           size: 100
+          expected_unreachable: true
 anta.tests.cvx:
   - VerifyActiveCVXConnections:
       # Verifies the number of active CVX Connections.

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -130,6 +130,7 @@ anta.tests.connectivity:
           vrf: MGMT
           df_bit: True
           size: 100
+          reachable: true
         - source: Management0
           destination: 8.8.8.8
           vrf: MGMT
@@ -140,7 +141,7 @@ anta.tests.connectivity:
           vrf: default
           df_bit: True
           size: 100
-          expected_unreachable: true
+          reachable: false
 anta.tests.cvx:
   - VerifyActiveCVXConnections:
       # Verifies the number of active CVX Connections.

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -46,6 +46,23 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
+        "name": "success-expected-unreachable",
+        "test": VerifyReachability,
+        "eos_data": [
+            {
+                "messages": [
+                    """PING 10.0.0.1 (10.0.0.1) from 10.0.0.5 : 72(100) bytes of data.
+
+                --- 10.0.0.1 ping statistics ---
+                2 packets transmitted, 0 received, 100% packet loss, time 10ms
+                """,
+                ],
+            },
+        ],
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "10.0.0.5", "expected_unreachable": True}]},
+        "expected": {"result": "success"},
+    },
+    {
         "name": "success-ipv6",
         "test": VerifyReachability,
         "eos_data": [
@@ -267,6 +284,27 @@ DATA: list[dict[str, Any]] = [
             },
         ],
         "expected": {"result": "failure", "messages": ["Host: 10.0.0.1 Source: Management0 VRF: default - Unreachable"]},
+    },
+    {
+        "name": "failure-expected-unreachable",
+        "test": VerifyReachability,
+        "eos_data": [
+            {
+                "messages": [
+                    """PING 10.0.0.1 (10.0.0.1) from 10.0.0.5 : 72(100) bytes of data.
+                80 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=0.247 ms
+                80 bytes from 10.0.0.1: icmp_seq=2 ttl=64 time=0.072 ms
+
+                --- 10.0.0.1 ping statistics ---
+                2 packets transmitted, 2 received, 0% packet loss, time 0ms
+                rtt min/avg/max/mdev = 0.072/0.159/0.247/0.088 ms, ipg/ewma 0.370/0.225 ms
+
+                """,
+                ],
+            },
+        ],
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "10.0.0.5", "expected_unreachable": True}]},
+        "expected": {"result": "failure", "messages": ["Host: 10.0.0.1 Source: 10.0.0.5 VRF: default - Network is expected to be unreachable but found reachable."]},
     },
     {
         "name": "success",

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -59,7 +59,7 @@ DATA: list[dict[str, Any]] = [
                 ],
             },
         ],
-        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "10.0.0.5", "expected_unreachable": True}]},
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "10.0.0.5", "reachable": False}]},
         "expected": {"result": "success"},
     },
     {
@@ -303,8 +303,11 @@ DATA: list[dict[str, Any]] = [
                 ],
             },
         ],
-        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "10.0.0.5", "expected_unreachable": True}]},
-        "expected": {"result": "failure", "messages": ["Host: 10.0.0.1 Source: 10.0.0.5 VRF: default - Network is expected to be unreachable but found reachable."]},
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "10.0.0.5", "reachable": False}]},
+        "expected": {
+            "result": "failure",
+            "messages": ["Host: 10.0.0.1 Source: 10.0.0.5 VRF: default - Destination is expected to be unreachable but found reachable."],
+        },
     },
     {
         "name": "success",


### PR DESCRIPTION
# Description

Added Negative testing in VerifyReachability

Added `reachable: bool = True` to the input model, Indicates whether the destination should be reachable. Set to True if the network should be accessible, False otherwise.
Validated with the unit tests.

Fixes #1047 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
