### PR TITLE
fix(anta): fixed Multiple failure messages not rendered properly in the Markdown report

### DIFF
--- a/anta/reporter/md_reporter.py
+++ b/anta/reporter/md_reporter.py
@@ -286,7 +286,7 @@ class TestResults(MDReportBase):
     def generate_rows(self) -> Generator[str, None, None]:
         """Generate the rows of the all test results table."""
         for result in self.results.results:
-            messages = self.safe_markdown(", ".join(result.messages))
+            messages = self.safe_markdown(result.messages[0]) if len(result.messages) == 1 else self.safe_markdown("<br> ".join(result.messages))
             categories = ", ".join(sorted(convert_categories(result.categories)))
             yield (
                 f"| {result.name or '-'} | {categories or '-'} | {result.test or '-'} "

--- a/anta/reporter/md_reporter.py
+++ b/anta/reporter/md_reporter.py
@@ -177,7 +177,7 @@ class MDReportBase(ABC):
         if text is None:
             return ""
 
-        # Replace newlines with spaces to keep content on one line
+        # Replace newlines with <br> to preserve line breaks in HTML
         text = text.replace("\n", "<br>")
 
         # Replace backticks with single quotes

--- a/anta/reporter/md_reporter.py
+++ b/anta/reporter/md_reporter.py
@@ -178,7 +178,7 @@ class MDReportBase(ABC):
             return ""
 
         # Replace newlines with spaces to keep content on one line
-        text = text.replace("\n", " ")
+        text = text.replace("\n", "<br>")
 
         # Replace backticks with single quotes
         return text.replace("`", "'")
@@ -286,7 +286,7 @@ class TestResults(MDReportBase):
     def generate_rows(self) -> Generator[str, None, None]:
         """Generate the rows of the all test results table."""
         for result in self.results.results:
-            messages = self.safe_markdown(result.messages[0]) if len(result.messages) == 1 else self.safe_markdown("<br> ".join(result.messages))
+            messages = self.safe_markdown(result.messages[0]) if len(result.messages) == 1 else self.safe_markdown("<br>".join(result.messages))
             categories = ", ".join(sorted(convert_categories(result.categories)))
             yield (
                 f"| {result.name or '-'} | {categories or '-'} | {result.test or '-'} "

--- a/tests/data/test_md_report.md
+++ b/tests/data/test_md_report.md
@@ -15,65 +15,78 @@
 
 | Total Tests | Total Tests Success | Total Tests Skipped | Total Tests Failure | Total Tests Error |
 | ----------- | ------------------- | ------------------- | ------------------- | ------------------|
-| 30 | 7 | 2 | 19 | 2 |
+| 30 | 4 | 9 | 15 | 2 |
 
 ### Summary Totals Device Under Test
 
 | Device Under Test | Total Tests | Tests Success | Tests Skipped | Tests Failure | Tests Error | Categories Skipped | Categories Failed |
 | ------------------| ----------- | ------------- | ------------- | ------------- | ----------- | -------------------| ------------------|
-| DC1-LEAF1A | 15 | 5 | 0 | 9 | 1 | - | AAA, BFD, BGP, Connectivity, SNMP, STP, Services, Software, System |
-| DC1-SPINE1 | 15 | 2 | 2 | 10 | 1 | MLAG, VXLAN | AAA, BFD, BGP, Connectivity, Routing, SNMP, STP, Services, Software, System |
+| s1-spine1 | 30 | 4 | 9 | 15 | 2 | AVT, Field Notices, Hardware, ISIS, LANZ, OSPF, PTP, Path-Selection, Profiles | AAA, BFD, BGP, Connectivity, Cvx, Interfaces, Logging, MLAG, SNMP, STUN, Security, Services, Software, System, VLAN |
 
 ### Summary Totals Per Category
 
 | Test Category | Total Tests | Tests Success | Tests Skipped | Tests Failure | Tests Error |
 | ------------- | ----------- | ------------- | ------------- | ------------- | ----------- |
-| AAA | 2 | 0 | 0 | 2 | 0 |
-| BFD | 2 | 0 | 0 | 2 | 0 |
-| BGP | 2 | 0 | 0 | 2 | 0 |
-| Connectivity | 4 | 0 | 0 | 2 | 2 |
-| Interfaces | 2 | 2 | 0 | 0 | 0 |
-| MLAG | 2 | 1 | 1 | 0 | 0 |
-| Routing | 2 | 1 | 0 | 1 | 0 |
-| SNMP | 2 | 0 | 0 | 2 | 0 |
-| STP | 2 | 0 | 0 | 2 | 0 |
-| Security | 2 | 2 | 0 | 0 | 0 |
-| Services | 2 | 0 | 0 | 2 | 0 |
-| Software | 2 | 0 | 0 | 2 | 0 |
-| System | 2 | 0 | 0 | 2 | 0 |
-| VXLAN | 2 | 1 | 1 | 0 | 0 |
+| AAA | 1 | 0 | 0 | 1 | 0 |
+| AVT | 1 | 0 | 1 | 0 | 0 |
+| BFD | 1 | 0 | 0 | 1 | 0 |
+| BGP | 1 | 0 | 0 | 0 | 1 |
+| Configuration | 1 | 1 | 0 | 0 | 0 |
+| Connectivity | 1 | 0 | 0 | 1 | 0 |
+| Cvx | 1 | 0 | 0 | 0 | 1 |
+| Field Notices | 1 | 0 | 1 | 0 | 0 |
+| Hardware | 1 | 0 | 1 | 0 | 0 |
+| Interfaces | 1 | 0 | 0 | 1 | 0 |
+| ISIS | 1 | 0 | 1 | 0 | 0 |
+| LANZ | 1 | 0 | 1 | 0 | 0 |
+| Logging | 1 | 0 | 0 | 1 | 0 |
+| MLAG | 1 | 0 | 0 | 1 | 0 |
+| OSPF | 1 | 0 | 1 | 0 | 0 |
+| Path-Selection | 1 | 0 | 1 | 0 | 0 |
+| Profiles | 1 | 0 | 1 | 0 | 0 |
+| PTP | 1 | 0 | 1 | 0 | 0 |
+| Routing | 1 | 1 | 0 | 0 | 0 |
+| Security | 2 | 0 | 0 | 2 | 0 |
+| Services | 1 | 0 | 0 | 1 | 0 |
+| SNMP | 1 | 0 | 0 | 1 | 0 |
+| Software | 1 | 0 | 0 | 1 | 0 |
+| STP | 1 | 1 | 0 | 0 | 0 |
+| STUN | 2 | 0 | 0 | 2 | 0 |
+| System | 1 | 0 | 0 | 1 | 0 |
+| VLAN | 1 | 0 | 0 | 1 | 0 |
+| VXLAN | 1 | 1 | 0 | 0 | 0 |
 
 ## Test Results
 
 | Device Under Test | Categories | Test | Description | Custom Field | Result | Messages |
 | ----------------- | ---------- | ---- | ----------- | ------------ | ------ | -------- |
-| DC1-LEAF1A | AAA | VerifyTacacsSourceIntf | Verifies TACACS source-interface for a specified VRF. | - | failure | Source-interface Management0 is not configured in VRF default |
-| DC1-LEAF1A | BFD | VerifyBFDSpecificPeers | Verifies the IPv4 BFD peer's sessions and remote disc in the specified VRF. | - | failure | Following BFD peers are not configured, status is not up or remote disc is zero: {'192.0.255.8': {'default': 'Not Configured'}, '192.0.255.7': {'default': 'Not Configured'}} |
-| DC1-LEAF1A | BGP | VerifyBGPPeerCount | Verifies the count of BGP peers. | - | failure | Failures: [{'afi': 'ipv4', 'safi': 'unicast', 'vrfs': {'PROD': 'Expected: 2, Actual: 1'}}, {'afi': 'ipv4', 'safi': 'multicast', 'vrfs': {'DEV': 'Expected: 3, Actual: 0'}}] |
-| DC1-LEAF1A | Connectivity | VerifyLLDPNeighbors | Verifies that the provided LLDP neighbors are connected properly. | - | failure | Wrong LLDP neighbor(s) on port(s):    Ethernet1       DC1-SPINE1_Ethernet1    Ethernet2       DC1-SPINE2_Ethernet1 Port(s) not configured:    Ethernet7 |
-| DC1-LEAF1A | Connectivity | VerifyReachability | Test the network reachability to one or many destination IP(s). | - | error | ping vrf MGMT 1.1.1.1 source Management1 repeat 2 has failed: No source interface Management1 |
-| DC1-LEAF1A | Interfaces | VerifyInterfaceUtilization | Verifies that the utilization of interfaces is below a certain threshold. | - | success | - |
-| DC1-LEAF1A | MLAG | VerifyMlagStatus | Verifies the health status of the MLAG configuration. | - | success | - |
-| DC1-LEAF1A | Routing | VerifyRoutingTableEntry | Verifies that the provided routes are present in the routing table of a specified VRF. | - | success | - |
-| DC1-LEAF1A | SNMP | VerifySnmpStatus | Verifies if the SNMP agent is enabled. | - | failure | SNMP agent disabled in vrf default |
-| DC1-LEAF1A | STP | VerifySTPMode | Verifies the configured STP mode for a provided list of VLAN(s). | - | failure | Wrong STP mode configured for the following VLAN(s): [10, 20] |
-| DC1-LEAF1A | Security | VerifyTelnetStatus | Verifies if Telnet is disabled in the default VRF. | - | success | - |
-| DC1-LEAF1A | Services | VerifyHostname | Verifies the hostname of a device. | - | failure | Expected 's1-spine1' as the hostname, but found 'DC1-LEAF1A' instead. |
-| DC1-LEAF1A | Software | VerifyEOSVersion | Verifies the EOS version of the device. | - | failure | device is running version "4.31.1F-34554157.4311F (engineering build)" not in expected versions: ['4.25.4M', '4.26.1F'] |
-| DC1-LEAF1A | System | VerifyNTP | Verifies if NTP is synchronised. | - | failure | The device is not synchronized with the configured NTP server(s): 'NTP is disabled.' |
-| DC1-LEAF1A | VXLAN | VerifyVxlan1Interface | Verifies the Vxlan1 interface status. | - | success | - |
-| DC1-SPINE1 | AAA | VerifyTacacsSourceIntf | Verifies TACACS source-interface for a specified VRF. | - | failure | Source-interface Management0 is not configured in VRF default |
-| DC1-SPINE1 | BFD | VerifyBFDSpecificPeers | Verifies the IPv4 BFD peer's sessions and remote disc in the specified VRF. | - | failure | Following BFD peers are not configured, status is not up or remote disc is zero: {'192.0.255.8': {'default': 'Not Configured'}, '192.0.255.7': {'default': 'Not Configured'}} |
-| DC1-SPINE1 | BGP | VerifyBGPPeerCount | Verifies the count of BGP peers. | - | failure | Failures: [{'afi': 'ipv4', 'safi': 'unicast', 'vrfs': {'PROD': 'Not Configured', 'default': 'Expected: 3, Actual: 4'}}, {'afi': 'ipv4', 'safi': 'multicast', 'vrfs': {'DEV': 'Not Configured'}}, {'afi': 'evpn', 'vrfs': {'default': 'Expected: 2, Actual: 4'}}] |
-| DC1-SPINE1 | Connectivity | VerifyLLDPNeighbors | Verifies that the provided LLDP neighbors are connected properly. | - | failure | Wrong LLDP neighbor(s) on port(s):    Ethernet1       DC1-LEAF1A_Ethernet1    Ethernet2       DC1-LEAF1B_Ethernet1 Port(s) not configured:    Ethernet7 |
-| DC1-SPINE1 | Connectivity | VerifyReachability | Test the network reachability to one or many destination IP(s). | - | error | ping vrf MGMT 1.1.1.1 source Management1 repeat 2 has failed: No source interface Management1 |
-| DC1-SPINE1 | Interfaces | VerifyInterfaceUtilization | Verifies that the utilization of interfaces is below a certain threshold. | - | success | - |
-| DC1-SPINE1 | MLAG | VerifyMlagStatus | Verifies the health status of the MLAG configuration. | - | skipped | MLAG is disabled |
-| DC1-SPINE1 | Routing | VerifyRoutingTableEntry | Verifies that the provided routes are present in the routing table of a specified VRF. | - | failure | The following route(s) are missing from the routing table of VRF default: ['10.1.0.2'] |
-| DC1-SPINE1 | SNMP | VerifySnmpStatus | Verifies if the SNMP agent is enabled. | - | failure | SNMP agent disabled in vrf default |
-| DC1-SPINE1 | STP | VerifySTPMode | Verifies the configured STP mode for a provided list of VLAN(s). | - | failure | STP mode 'rapidPvst' not configured for the following VLAN(s): [10, 20] |
-| DC1-SPINE1 | Security | VerifyTelnetStatus | Verifies if Telnet is disabled in the default VRF. | - | success | - |
-| DC1-SPINE1 | Services | VerifyHostname | Verifies the hostname of a device. | - | failure | Expected 's1-spine1' as the hostname, but found 'DC1-SPINE1' instead. |
-| DC1-SPINE1 | Software | VerifyEOSVersion | Verifies the EOS version of the device. | - | failure | device is running version "4.31.1F-34554157.4311F (engineering build)" not in expected versions: ['4.25.4M', '4.26.1F'] |
-| DC1-SPINE1 | System | VerifyNTP | Verifies if NTP is synchronised. | - | failure | The device is not synchronized with the configured NTP server(s): 'NTP is disabled.' |
-| DC1-SPINE1 | VXLAN | VerifyVxlan1Interface | Verifies the Vxlan1 interface status. | - | skipped | Vxlan1 interface is not configured |
+| s1-spine1 | AAA | VerifyAcctConsoleMethods | Verifies the AAA accounting console method lists for different accounting types (system, exec, commands, dot1x). | - | failure | AAA console accounting is not configured for commands, exec, system, dot1x |
+| s1-spine1 | AVT | VerifyAVTPathHealth | Verifies the status of all AVT paths for all VRFs. | - | skipped | VerifyAVTPathHealth test is not supported on cEOSLab. |
+| s1-spine1 | BFD | VerifyBFDPeersHealth | Verifies the health of IPv4 BFD peers across all VRFs. | - | failure | No IPv4 BFD peers are configured for any VRF. |
+| s1-spine1 | BGP | VerifyBGPAdvCommunities | Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s). | - | error | show bgp neighbors vrf all has failed: The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model. |
+| s1-spine1 | Configuration | VerifyRunningConfigDiffs | Verifies there is no difference between the running-config and the startup-config. | - | success | - |
+| s1-spine1 | Connectivity | VerifyLLDPNeighbors | Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors. | - | failure | Port: Ethernet1 Neighbor: DC1-SPINE1 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine1-dc1.fun.aristanetworks.com/Ethernet3<br>Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine2-dc1.fun.aristanetworks.com/Ethernet3 |
+| s1-spine1 | Cvx | VerifyActiveCVXConnections | Verifies the number of active CVX Connections. | - | error | show cvx connections brief has failed: Unavailable command (controller not ready) (at token 2: 'connections') |
+| s1-spine1 | Field Notices | VerifyFieldNotice44Resolution | Verifies that the device is using the correct Aboot version per FN0044. | - | skipped | VerifyFieldNotice44Resolution test is not supported on cEOSLab. |
+| s1-spine1 | Hardware | VerifyTemperature | Verifies if the device temperature is within acceptable limits. | - | skipped | VerifyTemperature test is not supported on cEOSLab. |
+| s1-spine1 | Interfaces | VerifyIPProxyARP | Verifies if Proxy ARP is enabled. | - | failure | Interface: Ethernet1 - Proxy-ARP disabled<br>Interface: Ethernet2 - Proxy-ARP disabled |
+| s1-spine1 | ISIS | VerifyISISNeighborState | Verifies the health of IS-IS neighbors. | - | skipped | IS-IS not configured |
+| s1-spine1 | LANZ | VerifyLANZ | Verifies if LANZ is enabled. | - | skipped | VerifyLANZ test is not supported on cEOSLab. |
+| s1-spine1 | Logging | VerifyLoggingHosts | Verifies logging hosts (syslog servers) for a specified VRF. | - | failure | Syslog servers 1.1.1.1, 2.2.2.2 are not configured in VRF default |
+| s1-spine1 | MLAG | VerifyMlagDualPrimary | Verifies the MLAG dual-primary detection parameters. | - | failure | Dual-primary detection is disabled |
+| s1-spine1 | OSPF | VerifyOSPFMaxLSA | Verifies all OSPF instances did not cross the maximum LSA threshold. | - | skipped | No OSPF instance found. |
+| s1-spine1 | Path-Selection | VerifyPathsHealth | Verifies the path and telemetry state of all paths under router path-selection. | - | skipped | VerifyPathsHealth test is not supported on cEOSLab. |
+| s1-spine1 | Profiles | VerifyTcamProfile | Verifies the device TCAM profile. | - | skipped | VerifyTcamProfile test is not supported on cEOSLab. |
+| s1-spine1 | PTP | VerifyPtpGMStatus | Verifies that the device is locked to a valid PTP Grandmaster. | - | skipped | VerifyPtpGMStatus test is not supported on cEOSLab. |
+| s1-spine1 | Routing | VerifyIPv4RouteNextHops | Verifies the next-hops of the IPv4 prefixes. | - | success | - |
+| s1-spine1 | Security | VerifyBannerLogin | Verifies the login banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the login banner, but found '' instead. |
+| s1-spine1 | Security | VerifyBannerMotd | Verifies the motd banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the motd banner, but found '' instead. |
+| s1-spine1 | Services | VerifyHostname | Verifies the hostname of a device. | - | failure | Incorrect Hostname - Expected: s1-spine1 Actual: leaf1-dc1 |
+| s1-spine1 | SNMP | VerifySnmpContact | Verifies the SNMP contact of a device. | - | failure | SNMP contact is not configured. |
+| s1-spine1 | Software | VerifyEOSVersion | Verifies the EOS version of the device. | - | failure | EOS version mismatch - Actual: 4.31.0F-33804048.4310F (engineering build) not in Expected: 4.25.4M, 4.26.1F |
+| s1-spine1 | STP | VerifySTPBlockedPorts | Verifies there is no STP blocked ports. | - | success | - |
+| s1-spine1 | STUN | VerifyStunClient | (Deprecated) Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found. |
+| s1-spine1 | STUN | VerifyStunClientTranslation | Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found.<br>Client 100.64.3.2 Port: 4500 - STUN client translation not found. |
+| s1-spine1 | System | VerifyNTPAssociations | Verifies the Network Time Protocol (NTP) associations. | - | failure | NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Not configured<br>NTP Server: 2.2.2.2 Preferred: False Stratum: 2 - Not configured<br>NTP Server: 3.3.3.3 Preferred: False Stratum: 2 - Not configured |
+| s1-spine1 | VLAN | VerifyDynamicVlanSource | Verifies dynamic VLAN allocation for specified VLAN sources. | - | failure | Dynamic VLAN source(s) exist but have no VLANs allocated: mlagsync |
+| s1-spine1 | VXLAN | VerifyVxlan1ConnSettings | Verifies the interface vxlan1 source interface and UDP port. | - | success | - |

--- a/tests/units/result_manager/conftest.py
+++ b/tests/units/result_manager/conftest.py
@@ -34,12 +34,12 @@ def result_manager_factory(list_result_factory: Callable[[int], list[TestResult]
 def result_manager() -> ResultManager:
     """Return a ResultManager with 30 random tests loaded from a JSON file.
 
-    Devices: DC1-SPINE1, DC1-LEAF1A
+    Devices: s1-spine1
 
     - Total tests: 30
-    - Success: 7
-    - Skipped: 2
-    - Failure: 19
+    - Success: 4
+    - Skipped: 9
+    - Failure: 15
     - Error: 2
 
     See `tests/units/result_manager/test_md_report_results.json` for details.

--- a/tests/units/result_manager/test__init__.py
+++ b/tests/units/result_manager/test__init__.py
@@ -195,12 +195,12 @@ class TestResultManager:
         """Test ResultManager.get_results."""
         # Check for single status
         success_results = result_manager.get_results(status={AntaTestStatus.SUCCESS})
-        assert len(success_results) == 7
+        assert len(success_results) == 4
         assert all(r.result == "success" for r in success_results)
 
         # Check for multiple statuses
         failure_results = result_manager.get_results(status={AntaTestStatus.FAILURE, AntaTestStatus.ERROR})
-        assert len(failure_results) == 21
+        assert len(failure_results) == 17
         assert all(r.result in {"failure", "error"} for r in failure_results)
 
         # Check all results
@@ -212,19 +212,18 @@ class TestResultManager:
         # Check all results with sort_by result
         all_results = result_manager.get_results(sort_by=["result"])
         assert len(all_results) == 30
-        assert [r.result for r in all_results] == ["error"] * 2 + ["failure"] * 19 + ["skipped"] * 2 + ["success"] * 7
+        assert [r.result for r in all_results] == ["error"] * 2 + ["failure"] * 15 + ["skipped"] * 9 + ["success"] * 4
 
         # Check all results with sort_by device (name)
         all_results = result_manager.get_results(sort_by=["name"])
         assert len(all_results) == 30
-        assert all_results[0].name == "DC1-LEAF1A"
-        assert all_results[-1].name == "DC1-SPINE1"
+        assert all_results[0].name == "s1-spine1"
 
         # Check multiple statuses with sort_by categories
         success_skipped_results = result_manager.get_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.SKIPPED}, sort_by=["categories"])
-        assert len(success_skipped_results) == 9
-        assert success_skipped_results[0].categories == ["Interfaces"]
-        assert success_skipped_results[-1].categories == ["VXLAN"]
+        assert len(success_skipped_results) == 13
+        assert success_skipped_results[0].categories == ["avt"]
+        assert success_skipped_results[-1].categories == ["vxlan"]
 
         # Check all results with bad sort_by
         with pytest.raises(
@@ -241,14 +240,14 @@ class TestResultManager:
         assert result_manager.get_total_results() == 30
 
         # Test single status
-        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS}) == 7
-        assert result_manager.get_total_results(status={AntaTestStatus.FAILURE}) == 19
+        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS}) == 4
+        assert result_manager.get_total_results(status={AntaTestStatus.FAILURE}) == 15
         assert result_manager.get_total_results(status={AntaTestStatus.ERROR}) == 2
-        assert result_manager.get_total_results(status={AntaTestStatus.SKIPPED}) == 2
+        assert result_manager.get_total_results(status={AntaTestStatus.SKIPPED}) == 9
 
         # Test multiple statuses
-        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE}) == 26
-        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR}) == 28
+        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE}) == 19
+        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR}) == 21
         assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED}) == 30
 
     @pytest.mark.parametrize(

--- a/tests/units/result_manager/test_files/test_md_report_results.json
+++ b/tests/units/result_manager/test_files/test_md_report_results.json
@@ -1,378 +1,389 @@
 [
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyTacacsSourceIntf",
-        "categories": [
-            "AAA"
-        ],
-        "description": "Verifies TACACS source-interface for a specified VRF.",
-        "result": "failure",
-        "messages": [
-            "Source-interface Management0 is not configured in VRF default"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyLLDPNeighbors",
-        "categories": [
-            "Connectivity"
-        ],
-        "description": "Verifies that the provided LLDP neighbors are connected properly.",
-        "result": "failure",
-        "messages": [
-            "Wrong LLDP neighbor(s) on port(s):\n   Ethernet1\n      DC1-LEAF1A_Ethernet1\n   Ethernet2\n      DC1-LEAF1B_Ethernet1\nPort(s) not configured:\n   Ethernet7"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyBGPPeerCount",
-        "categories": [
-            "BGP"
-        ],
-        "description": "Verifies the count of BGP peers.",
-        "result": "failure",
-        "messages": [
-            "Failures: [{'afi': 'ipv4', 'safi': 'unicast', 'vrfs': {'PROD': 'Not Configured', 'default': 'Expected: 3, Actual: 4'}}, {'afi': 'ipv4', 'safi': 'multicast', 'vrfs': {'DEV': 'Not Configured'}}, {'afi': 'evpn', 'vrfs': {'default': 'Expected: 2, Actual: 4'}}]"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifySTPMode",
-        "categories": [
-            "STP"
-        ],
-        "description": "Verifies the configured STP mode for a provided list of VLAN(s).",
-        "result": "failure",
-        "messages": [
-            "STP mode 'rapidPvst' not configured for the following VLAN(s): [10, 20]"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifySnmpStatus",
-        "categories": [
-            "SNMP"
-        ],
-        "description": "Verifies if the SNMP agent is enabled.",
-        "result": "failure",
-        "messages": [
-            "SNMP agent disabled in vrf default"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyRoutingTableEntry",
-        "categories": [
-            "Routing"
-        ],
-        "description": "Verifies that the provided routes are present in the routing table of a specified VRF.",
-        "result": "failure",
-        "messages": [
-            "The following route(s) are missing from the routing table of VRF default: ['10.1.0.2']"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyInterfaceUtilization",
-        "categories": [
-            "Interfaces"
-        ],
-        "description": "Verifies that the utilization of interfaces is below a certain threshold.",
-        "result": "success",
-        "messages": [],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyMlagStatus",
-        "categories": [
-            "MLAG"
-        ],
-        "description": "Verifies the health status of the MLAG configuration.",
-        "result": "skipped",
-        "messages": [
-            "MLAG is disabled"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyVxlan1Interface",
-        "categories": [
-            "VXLAN"
-        ],
-        "description": "Verifies the Vxlan1 interface status.",
-        "result": "skipped",
-        "messages": [
-            "Vxlan1 interface is not configured"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyBFDSpecificPeers",
-        "categories": [
-            "BFD"
-        ],
-        "description": "Verifies the IPv4 BFD peer's sessions and remote disc in the specified VRF.",
-        "result": "failure",
-        "messages": [
-            "Following BFD peers are not configured, status is not up or remote disc is zero:\n{'192.0.255.8': {'default': 'Not Configured'}, '192.0.255.7': {'default': 'Not Configured'}}"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyNTP",
-        "categories": [
-            "System"
-        ],
-        "description": "Verifies if NTP is synchronised.",
-        "result": "failure",
-        "messages": [
-            "The device is not synchronized with the configured NTP server(s): 'NTP is disabled.'"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyReachability",
-        "categories": [
-            "Connectivity"
-        ],
-        "description": "Test the network reachability to one or many destination IP(s).",
-        "result": "error",
-        "messages": [
-            "ping vrf MGMT 1.1.1.1 source Management1 repeat 2 has failed: No source interface Management1"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyTelnetStatus",
-        "categories": [
-            "Security"
-        ],
-        "description": "Verifies if Telnet is disabled in the default VRF.",
-        "result": "success",
-        "messages": [],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyEOSVersion",
-        "categories": [
-            "Software"
-        ],
-        "description": "Verifies the EOS version of the device.",
-        "result": "failure",
-        "messages": [
-            "device is running version \"4.31.1F-34554157.4311F (engineering build)\" not in expected versions: ['4.25.4M', '4.26.1F']"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-SPINE1",
-        "test": "VerifyHostname",
-        "categories": [
-            "Services"
-        ],
-        "description": "Verifies the hostname of a device.",
-        "result": "failure",
-        "messages": [
-            "Expected `s1-spine1` as the hostname, but found `DC1-SPINE1` instead."
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyTacacsSourceIntf",
-        "categories": [
-            "AAA"
-        ],
-        "description": "Verifies TACACS source-interface for a specified VRF.",
-        "result": "failure",
-        "messages": [
-            "Source-interface Management0 is not configured in VRF default"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyLLDPNeighbors",
-        "categories": [
-            "Connectivity"
-        ],
-        "description": "Verifies that the provided LLDP neighbors are connected properly.",
-        "result": "failure",
-        "messages": [
-            "Wrong LLDP neighbor(s) on port(s):\n   Ethernet1\n      DC1-SPINE1_Ethernet1\n   Ethernet2\n      DC1-SPINE2_Ethernet1\nPort(s) not configured:\n   Ethernet7"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyBGPPeerCount",
-        "categories": [
-            "BGP"
-        ],
-        "description": "Verifies the count of BGP peers.",
-        "result": "failure",
-        "messages": [
-            "Failures: [{'afi': 'ipv4', 'safi': 'unicast', 'vrfs': {'PROD': 'Expected: 2, Actual: 1'}}, {'afi': 'ipv4', 'safi': 'multicast', 'vrfs': {'DEV': 'Expected: 3, Actual: 0'}}]"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifySTPMode",
-        "categories": [
-            "STP"
-        ],
-        "description": "Verifies the configured STP mode for a provided list of VLAN(s).",
-        "result": "failure",
-        "messages": [
-            "Wrong STP mode configured for the following VLAN(s): [10, 20]"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifySnmpStatus",
-        "categories": [
-            "SNMP"
-        ],
-        "description": "Verifies if the SNMP agent is enabled.",
-        "result": "failure",
-        "messages": [
-            "SNMP agent disabled in vrf default"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyRoutingTableEntry",
-        "categories": [
-            "Routing"
-        ],
-        "description": "Verifies that the provided routes are present in the routing table of a specified VRF.",
-        "result": "success",
-        "messages": [],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyInterfaceUtilization",
-        "categories": [
-            "Interfaces"
-        ],
-        "description": "Verifies that the utilization of interfaces is below a certain threshold.",
-        "result": "success",
-        "messages": [],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyMlagStatus",
-        "categories": [
-            "MLAG"
-        ],
-        "description": "Verifies the health status of the MLAG configuration.",
-        "result": "success",
-        "messages": [],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyVxlan1Interface",
-        "categories": [
-            "VXLAN"
-        ],
-        "description": "Verifies the Vxlan1 interface status.",
-        "result": "success",
-        "messages": [],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyBFDSpecificPeers",
-        "categories": [
-            "BFD"
-        ],
-        "description": "Verifies the IPv4 BFD peer's sessions and remote disc in the specified VRF.",
-        "result": "failure",
-        "messages": [
-            "Following BFD peers are not configured, status is not up or remote disc is zero:\n{'192.0.255.8': {'default': 'Not Configured'}, '192.0.255.7': {'default': 'Not Configured'}}"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyNTP",
-        "categories": [
-            "System"
-        ],
-        "description": "Verifies if NTP is synchronised.",
-        "result": "failure",
-        "messages": [
-            "The device is not synchronized with the configured NTP server(s): 'NTP is disabled.'"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyReachability",
-        "categories": [
-            "Connectivity"
-        ],
-        "description": "Test the network reachability to one or many destination IP(s).",
-        "result": "error",
-        "messages": [
-            "ping vrf MGMT 1.1.1.1 source Management1 repeat 2 has failed: No source interface Management1"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyTelnetStatus",
-        "categories": [
-            "Security"
-        ],
-        "description": "Verifies if Telnet is disabled in the default VRF.",
-        "result": "success",
-        "messages": [],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyEOSVersion",
-        "categories": [
-            "Software"
-        ],
-        "description": "Verifies the EOS version of the device.",
-        "result": "failure",
-        "messages": [
-            "device is running version \"4.31.1F-34554157.4311F (engineering build)\" not in expected versions: ['4.25.4M', '4.26.1F']"
-        ],
-        "custom_field": null
-    },
-    {
-        "name": "DC1-LEAF1A",
-        "test": "VerifyHostname",
-        "categories": [
-            "Services"
-        ],
-        "description": "Verifies the hostname of a device.",
-        "result": "failure",
-        "messages": [
-            "Expected `s1-spine1` as the hostname, but found `DC1-LEAF1A` instead."
-        ],
-        "custom_field": null
-    }
+  {
+    "name": "s1-spine1",
+    "test": "VerifyMlagDualPrimary",
+    "categories": [
+      "mlag"
+    ],
+    "description": "Verifies the MLAG dual-primary detection parameters.",
+    "result": "failure",
+    "messages": [
+      "Dual-primary detection is disabled"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyHostname",
+    "categories": [
+      "services"
+    ],
+    "description": "Verifies the hostname of a device.",
+    "result": "failure",
+    "messages": [
+      "Incorrect Hostname - Expected: s1-spine1 Actual: leaf1-dc1"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyBGPAdvCommunities",
+    "categories": [
+      "bgp"
+    ],
+    "description": "Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s).",
+    "result": "error",
+    "messages": [
+      "show bgp neighbors vrf all has failed: The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyStunClient",
+    "categories": [
+      "stun"
+    ],
+    "description": "(Deprecated) Verifies the translation for a source address on a STUN client.",
+    "result": "failure",
+    "messages": [
+      "Client 172.18.3.2 Port: 4500 - STUN client translation not found."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyBannerLogin",
+    "categories": [
+      "security"
+    ],
+    "description": "Verifies the login banner of a device.",
+    "result": "failure",
+    "messages": [
+      "Expected `# Copyright (c) 2023-2024 Arista Networks, Inc.\n# Use of this source code is governed by the Apache License 2.0\n# that can be found in the LICENSE file.\n` as the login banner, but found `` instead."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyISISNeighborState",
+    "categories": [
+      "isis"
+    ],
+    "description": "Verifies the health of IS-IS neighbors.",
+    "result": "skipped",
+    "messages": [
+      "IS-IS not configured"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyEOSVersion",
+    "categories": [
+      "software"
+    ],
+    "description": "Verifies the EOS version of the device.",
+    "result": "failure",
+    "messages": [
+      "EOS version mismatch - Actual: 4.31.0F-33804048.4310F (engineering build) not in Expected: 4.25.4M, 4.26.1F"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyTcamProfile",
+    "categories": [
+      "profiles"
+    ],
+    "description": "Verifies the device TCAM profile.",
+    "result": "skipped",
+    "messages": [
+      "VerifyTcamProfile test is not supported on cEOSLab."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyPathsHealth",
+    "categories": [
+      "path-selection"
+    ],
+    "description": "Verifies the path and telemetry state of all paths under router path-selection.",
+    "result": "skipped",
+    "messages": [
+      "VerifyPathsHealth test is not supported on cEOSLab."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyBannerMotd",
+    "categories": [
+      "security"
+    ],
+    "description": "Verifies the motd banner of a device.",
+    "result": "failure",
+    "messages": [
+      "Expected `# Copyright (c) 2023-2024 Arista Networks, Inc.\n# Use of this source code is governed by the Apache License 2.0\n# that can be found in the LICENSE file.\n` as the motd banner, but found `` instead."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyFieldNotice44Resolution",
+    "categories": [
+      "field notices"
+    ],
+    "description": "Verifies that the device is using the correct Aboot version per FN0044.",
+    "result": "skipped",
+    "messages": [
+      "VerifyFieldNotice44Resolution test is not supported on cEOSLab."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyLoggingHosts",
+    "categories": [
+      "logging"
+    ],
+    "description": "Verifies logging hosts (syslog servers) for a specified VRF.",
+    "result": "failure",
+    "messages": [
+      "Syslog servers 1.1.1.1, 2.2.2.2 are not configured in VRF default"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyAVTPathHealth",
+    "categories": [
+      "avt"
+    ],
+    "description": "Verifies the status of all AVT paths for all VRFs.",
+    "result": "skipped",
+    "messages": [
+      "VerifyAVTPathHealth test is not supported on cEOSLab."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyTemperature",
+    "categories": [
+      "hardware"
+    ],
+    "description": "Verifies if the device temperature is within acceptable limits.",
+    "result": "skipped",
+    "messages": [
+      "VerifyTemperature test is not supported on cEOSLab."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyNTPAssociations",
+    "categories": [
+      "system"
+    ],
+    "description": "Verifies the Network Time Protocol (NTP) associations.",
+    "result": "failure",
+    "messages": [
+      "NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Not configured",
+      "NTP Server: 2.2.2.2 Preferred: False Stratum: 2 - Not configured",
+      "NTP Server: 3.3.3.3 Preferred: False Stratum: 2 - Not configured"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyDynamicVlanSource",
+    "categories": [
+      "vlan"
+    ],
+    "description": "Verifies dynamic VLAN allocation for specified VLAN sources.",
+    "result": "failure",
+    "messages": [
+      "Dynamic VLAN source(s) exist but have no VLANs allocated: mlagsync"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyActiveCVXConnections",
+    "categories": [
+      "cvx"
+    ],
+    "description": "Verifies the number of active CVX Connections.",
+    "result": "error",
+    "messages": [
+      "show cvx connections brief has failed: Unavailable command (controller not ready) (at token 2: 'connections')"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyIPv4RouteNextHops",
+    "categories": [
+      "routing"
+    ],
+    "description": "Verifies the next-hops of the IPv4 prefixes.",
+    "result": "success",
+    "messages": [],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyVxlan1ConnSettings",
+    "categories": [
+      "vxlan"
+    ],
+    "description": "Verifies the interface vxlan1 source interface and UDP port.",
+    "result": "success",
+    "messages": [],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyStunClientTranslation",
+    "categories": [
+      "stun"
+    ],
+    "description": "Verifies the translation for a source address on a STUN client.",
+    "result": "failure",
+    "messages": [
+      "Client 172.18.3.2 Port: 4500 - STUN client translation not found.",
+      "Client 100.64.3.2 Port: 4500 - STUN client translation not found."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyPtpGMStatus",
+    "categories": [
+      "ptp"
+    ],
+    "description": "Verifies that the device is locked to a valid PTP Grandmaster.",
+    "result": "skipped",
+    "messages": [
+      "VerifyPtpGMStatus test is not supported on cEOSLab."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyRunningConfigDiffs",
+    "categories": [
+      "configuration"
+    ],
+    "description": "Verifies there is no difference between the running-config and the startup-config.",
+    "result": "success",
+    "messages": [],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyBFDPeersHealth",
+    "categories": [
+      "bfd"
+    ],
+    "description": "Verifies the health of IPv4 BFD peers across all VRFs.",
+    "result": "failure",
+    "messages": [
+      "No IPv4 BFD peers are configured for any VRF."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyIPProxyARP",
+    "categories": [
+      "interfaces"
+    ],
+    "description": "Verifies if Proxy ARP is enabled.",
+    "result": "failure",
+    "messages": [
+      "Interface: Ethernet1 - Proxy-ARP disabled",
+      "Interface: Ethernet2 - Proxy-ARP disabled"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifySnmpContact",
+    "categories": [
+      "snmp"
+    ],
+    "description": "Verifies the SNMP contact of a device.",
+    "result": "failure",
+    "messages": [
+      "SNMP contact is not configured."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyLLDPNeighbors",
+    "categories": [
+      "connectivity"
+    ],
+    "description": "Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors.",
+    "result": "failure",
+    "messages": [
+      "Port: Ethernet1 Neighbor: DC1-SPINE1 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine1-dc1.fun.aristanetworks.com/Ethernet3",
+      "Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine2-dc1.fun.aristanetworks.com/Ethernet3"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyAcctConsoleMethods",
+    "categories": [
+      "aaa"
+    ],
+    "description": "Verifies the AAA accounting console method lists for different accounting types (system, exec, commands, dot1x).",
+    "result": "failure",
+    "messages": [
+      "AAA console accounting is not configured for commands, exec, system, dot1x"
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyOSPFMaxLSA",
+    "categories": [
+      "ospf"
+    ],
+    "description": "Verifies all OSPF instances did not cross the maximum LSA threshold.",
+    "result": "skipped",
+    "messages": [
+      "No OSPF instance found."
+    ],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifySTPBlockedPorts",
+    "categories": [
+      "stp"
+    ],
+    "description": "Verifies there is no STP blocked ports.",
+    "result": "success",
+    "messages": [],
+    "custom_field": null
+  },
+  {
+    "name": "s1-spine1",
+    "test": "VerifyLANZ",
+    "categories": [
+      "lanz"
+    ],
+    "description": "Verifies if LANZ is enabled.",
+    "result": "skipped",
+    "messages": [
+      "VerifyLANZ test is not supported on cEOSLab."
+    ],
+    "custom_field": null
+  }
 ]


### PR DESCRIPTION
# Description
Updated `anta/reporter/md_reporter.py` with adding fix for Multiple failure messages not rendered properly in the Markdown report

Tested the change with considering `https://github.com/aristanetworks/anta/blob/main/examples/tests.yaml` 

### Here is the markdown report: [report.md](https://github.com/user-attachments/files/18940718/report.md)

 
Fixes #1055

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)

