### PR TITLE
fix(anta.tests): VerifyIPProxyARP and VerifyInterfaceIPv4 tests for 'Incomplete command' error

### DIFF
--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -41,7 +41,7 @@ class InterfaceState(BaseModel):
     primary_ip: IPv4Interface | None = None
     """Primary IPv4 address in CIDR notation. Required field in the `VerifyInterfaceIPv4` test."""
     secondary_ips: list[IPv4Interface] | None = None
-    """Optional list of secondary IPv4 addresses in CIDR notation."""
+    """List of secondary IPv4 addresses in CIDR notation. Can be provided in the `VerifyInterfaceIPv4` test."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the InterfaceState for reporting.

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from ipaddress import IPv4Interface
+from typing import Any, Literal
+from warnings import warn
 
 from pydantic import BaseModel, ConfigDict
 
@@ -13,7 +15,10 @@ from anta.custom_types import Interface, PortChannelInterface
 
 
 class InterfaceState(BaseModel):
-    """Model for an interface state."""
+    """Model for an interface state.
+
+    TODO: Need to review this class name in ANTA v2.0.0.
+    """
 
     model_config = ConfigDict(extra="forbid")
     name: Interface
@@ -33,6 +38,10 @@ class InterfaceState(BaseModel):
 
     Can be enabled in the `VerifyLACPInterfacesStatus` tests.
     """
+    primary_ip: IPv4Interface | None = None
+    """Primary IPv4 address in CIDR notation. Required field in the `VerifyInterfaceIPv4` test."""
+    secondary_ips: list[IPv4Interface] | None = None
+    """Optional list of secondary IPv4 addresses in CIDR notation."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the InterfaceState for reporting.
@@ -46,3 +55,21 @@ class InterfaceState(BaseModel):
         if self.portchannel is not None:
             base_string += f" Port-Channel: {self.portchannel}"
         return base_string
+
+
+class InterfaceDetail(InterfaceState):  # pragma: no cover
+    """Alias for the InterfaceState model to maintain backward compatibility.
+
+    When initialized, it will emit a deprecation warning and call the InterfaceState model.
+
+    TODO: Remove this class in ANTA v2.0.0.
+    """
+
+    def __init__(self, **data: Any) -> None:  # noqa: ANN401
+        """Initialize the InterfaceState class, emitting a depreciation warning."""
+        warn(
+            message="InterfaceDetail model is deprecated and will be removed in ANTA v2.0.0. Use the InterfaceState model instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**data)

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -8,16 +8,14 @@
 from __future__ import annotations
 
 import re
-from ipaddress import IPv4Interface
 from typing import Any, ClassVar, TypeVar
 
 from pydantic import BaseModel, Field, field_validator
 from pydantic_extra_types.mac_address import MacAddress
 
-from anta import GITHUB_SUGGESTION
 from anta.custom_types import EthernetInterface, Interface, Percent, PositiveInteger
 from anta.decorators import skip_on_platforms
-from anta.input_models.interfaces import InterfaceState
+from anta.input_models.interfaces import InterfaceDetail, InterfaceState
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 from anta.tools import custom_division, format_data, get_failed_logs, get_item, get_value
 
@@ -517,7 +515,7 @@ class VerifyL3MTU(AntaTest):
 
 
 class VerifyIPProxyARP(AntaTest):
-    """Verifies if Proxy-ARP is enabled for the provided list of interface(s).
+    """Verifies if Proxy ARP is enabled.
 
     Expected Results
     ----------------
@@ -535,32 +533,28 @@ class VerifyIPProxyARP(AntaTest):
     ```
     """
 
-    description = "Verifies if Proxy ARP is enabled."
     categories: ClassVar[list[str]] = ["interfaces"]
-    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaTemplate(template="show ip interface {intf}", revision=2)]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ip interface", revision=2)]
 
     class Input(AntaTest.Input):
         """Input model for the VerifyIPProxyARP test."""
 
-        interfaces: list[str]
+        interfaces: list[Interface]
         """List of interfaces to be tested."""
-
-    def render(self, template: AntaTemplate) -> list[AntaCommand]:
-        """Render the template for each interface in the input list."""
-        return [template.render(intf=intf) for intf in self.inputs.interfaces]
 
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyIPProxyARP."""
-        disabled_intf = []
-        for command in self.instance_commands:
-            intf = command.params.intf
-            if not command.json_output["interfaces"][intf]["proxyArp"]:
-                disabled_intf.append(intf)
-        if disabled_intf:
-            self.result.is_failure(f"The following interface(s) have Proxy-ARP disabled: {disabled_intf}")
-        else:
-            self.result.is_success()
+        self.result.is_success()
+        command_output = self.instance_commands[0].json_output
+
+        for interface in self.inputs.interfaces:
+            if (interface_detail := get_value(command_output["interfaces"], f"{interface}", separator="..")) is None:
+                self.result.is_failure(f"Interface: {interface} - Not found")
+                continue
+
+            if not interface_detail["proxyArp"]:
+                self.result.is_failure(f"Interface: {interface} - Proxy-ARP disabled")
 
 
 class VerifyL2MTU(AntaTest):
@@ -628,7 +622,7 @@ class VerifyL2MTU(AntaTest):
 
 
 class VerifyInterfaceIPv4(AntaTest):
-    """Verifies if an interface is configured with a correct primary and list of optional secondary IPv4 addresses.
+    """Verifies the interface IPv4 addresses.
 
     Expected Results
     ----------------
@@ -649,82 +643,60 @@ class VerifyInterfaceIPv4(AntaTest):
     ```
     """
 
-    description = "Verifies the interface IPv4 addresses."
     categories: ClassVar[list[str]] = ["interfaces"]
-    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaTemplate(template="show ip interface {interface}", revision=2)]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show ip interface", revision=2)]
 
     class Input(AntaTest.Input):
         """Input model for the VerifyInterfaceIPv4 test."""
 
-        interfaces: list[InterfaceDetail]
+        interfaces: list[InterfaceState]
         """List of interfaces with their details."""
+        InterfaceDetail: ClassVar[type[InterfaceDetail]] = InterfaceDetail
 
-        class InterfaceDetail(BaseModel):
-            """Model for an interface detail."""
-
-            name: Interface
-            """Name of the interface."""
-            primary_ip: IPv4Interface
-            """Primary IPv4 address in CIDR notation."""
-            secondary_ips: list[IPv4Interface] | None = None
-            """Optional list of secondary IPv4 addresses in CIDR notation."""
-
-    def render(self, template: AntaTemplate) -> list[AntaCommand]:
-        """Render the template for each interface in the input list."""
-        return [template.render(interface=interface.name) for interface in self.inputs.interfaces]
+        @field_validator("interfaces")
+        @classmethod
+        def validate_interfaces(cls, interfaces: list[T]) -> list[T]:
+            """Validate that 'primary_ip' field is provided in each interface."""
+            for interface in interfaces:
+                if interface.primary_ip is None:
+                    msg = f"{interface} 'primary_ip' field missing in the input"
+                    raise ValueError(msg)
+            return interfaces
 
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyInterfaceIPv4."""
         self.result.is_success()
-        for command in self.instance_commands:
-            intf = command.params.interface
-            for interface in self.inputs.interfaces:
-                if interface.name == intf:
-                    input_interface_detail = interface
-                    break
-            else:
-                self.result.is_failure(f"Could not find `{intf}` in the input interfaces. {GITHUB_SUGGESTION}")
+        command_output = self.instance_commands[0].json_output
+
+        for interface in self.inputs.interfaces:
+            if (interface_detail := get_value(command_output["interfaces"], f"{interface.name}", separator="..")) is None:
+                self.result.is_failure(f"{interface} - Not found")
                 continue
 
-            input_primary_ip = str(input_interface_detail.primary_ip)
-            failed_messages = []
-
-            # Check if the interface has an IP address configured
-            if not (interface_output := get_value(command.json_output, f"interfaces.{intf}.interfaceAddress")):
-                self.result.is_failure(f"For interface `{intf}`, IP address is not configured.")
+            if (ip_address := get_value(interface_detail, "interfaceAddress.primaryIp")) is None:
+                self.result.is_failure(f"{interface} - IP address is not configured")
                 continue
-
-            primary_ip = get_value(interface_output, "primaryIp")
 
             # Combine IP address and subnet for primary IP
-            actual_primary_ip = f"{primary_ip['address']}/{primary_ip['maskLen']}"
+            actual_primary_ip = f"{ip_address['address']}/{ip_address['maskLen']}"
 
             # Check if the primary IP address matches the input
-            if actual_primary_ip != input_primary_ip:
-                failed_messages.append(f"The expected primary IP address is `{input_primary_ip}`, but the actual primary IP address is `{actual_primary_ip}`.")
+            if actual_primary_ip != str(interface.primary_ip):
+                self.result.is_failure(f"{interface} - IP address mismatch - Expected: {interface.primary_ip} Actual: {actual_primary_ip}")
 
-            if (param_secondary_ips := input_interface_detail.secondary_ips) is not None:
-                input_secondary_ips = sorted([str(network) for network in param_secondary_ips])
-                secondary_ips = get_value(interface_output, "secondaryIpsOrderedList")
+            if interface.secondary_ips:
+                if not (secondary_ips := get_value(interface_detail, "interfaceAddress.secondaryIpsOrderedList")):
+                    self.result.is_failure(f"{interface} - Secondary IP address is not configured")
+                    continue
 
-                # Combine IP address and subnet for secondary IPs
                 actual_secondary_ips = sorted([f"{secondary_ip['address']}/{secondary_ip['maskLen']}" for secondary_ip in secondary_ips])
+                input_secondary_ips = sorted([str(ip) for ip in interface.secondary_ips])
 
-                # Check if the secondary IP address is configured
-                if not actual_secondary_ips:
-                    failed_messages.append(
-                        f"The expected secondary IP addresses are `{input_secondary_ips}`, but the actual secondary IP address is not configured."
+                if actual_secondary_ips != input_secondary_ips:
+                    self.result.is_failure(
+                        f"{interface} - Secondary IP address mismatch - Expected: {', '.join(input_secondary_ips)} Actual: {', '.join(actual_secondary_ips)}"
                     )
-
-                # Check if the secondary IP addresses match the input
-                elif actual_secondary_ips != input_secondary_ips:
-                    failed_messages.append(
-                        f"The expected secondary IP addresses are `{input_secondary_ips}`, but the actual secondary IP addresses are `{actual_secondary_ips}`."
-                    )
-
-            if failed_messages:
-                self.result.is_failure(f"For interface `{intf}`, " + " ".join(failed_messages))
 
 
 class VerifyIpVirtualRouterMac(AntaTest):

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -1859,51 +1859,37 @@ DATA: list[dict[str, Any]] = [
                         "name": "Ethernet1",
                         "lineProtocolStatus": "up",
                         "interfaceStatus": "connected",
-                        "mtu": 1500,
-                        "interfaceAddressBrief": {"ipAddr": {"address": "10.1.0.0", "maskLen": 31}},
-                        "ipv4Routable240": False,
-                        "ipv4Routable0": False,
-                        "enabled": True,
-                        "description": "P2P_LINK_TO_NW-CORE_Ethernet1",
                         "proxyArp": True,
-                        "localProxyArp": False,
-                        "gratuitousArp": False,
-                        "vrf": "default",
-                        "urpf": "disable",
-                        "addresslessForwarding": "isInvalid",
-                        "directedBroadcastEnabled": False,
-                        "maxMssIngress": 0,
-                        "maxMssEgress": 0,
                     },
-                },
-            },
-            {
-                "interfaces": {
                     "Ethernet2": {
                         "name": "Ethernet2",
                         "lineProtocolStatus": "up",
                         "interfaceStatus": "connected",
-                        "mtu": 1500,
-                        "interfaceAddressBrief": {"ipAddr": {"address": "10.1.0.2", "maskLen": 31}},
-                        "ipv4Routable240": False,
-                        "ipv4Routable0": False,
-                        "enabled": True,
-                        "description": "P2P_LINK_TO_SW-CORE_Ethernet1",
                         "proxyArp": True,
-                        "localProxyArp": False,
-                        "gratuitousArp": False,
-                        "vrf": "default",
-                        "urpf": "disable",
-                        "addresslessForwarding": "isInvalid",
-                        "directedBroadcastEnabled": False,
-                        "maxMssIngress": 0,
-                        "maxMssEgress": 0,
                     },
                 },
             },
         ],
         "inputs": {"interfaces": ["Ethernet1", "Ethernet2"]},
         "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-interface-not-found",
+        "test": VerifyIPProxyARP,
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {
+                        "name": "Ethernet1",
+                        "lineProtocolStatus": "up",
+                        "interfaceStatus": "connected",
+                        "proxyArp": True,
+                    },
+                },
+            },
+        ],
+        "inputs": {"interfaces": ["Ethernet1", "Ethernet2"]},
+        "expected": {"result": "failure", "messages": ["Interface: Ethernet2 - Not found"]},
     },
     {
         "name": "failure",
@@ -1915,51 +1901,19 @@ DATA: list[dict[str, Any]] = [
                         "name": "Ethernet1",
                         "lineProtocolStatus": "up",
                         "interfaceStatus": "connected",
-                        "mtu": 1500,
-                        "interfaceAddressBrief": {"ipAddr": {"address": "10.1.0.0", "maskLen": 31}},
-                        "ipv4Routable240": False,
-                        "ipv4Routable0": False,
-                        "enabled": True,
-                        "description": "P2P_LINK_TO_NW-CORE_Ethernet1",
                         "proxyArp": True,
-                        "localProxyArp": False,
-                        "gratuitousArp": False,
-                        "vrf": "default",
-                        "urpf": "disable",
-                        "addresslessForwarding": "isInvalid",
-                        "directedBroadcastEnabled": False,
-                        "maxMssIngress": 0,
-                        "maxMssEgress": 0,
                     },
-                },
-            },
-            {
-                "interfaces": {
                     "Ethernet2": {
                         "name": "Ethernet2",
                         "lineProtocolStatus": "up",
                         "interfaceStatus": "connected",
-                        "mtu": 1500,
-                        "interfaceAddressBrief": {"ipAddr": {"address": "10.1.0.2", "maskLen": 31}},
-                        "ipv4Routable240": False,
-                        "ipv4Routable0": False,
-                        "enabled": True,
-                        "description": "P2P_LINK_TO_SW-CORE_Ethernet1",
                         "proxyArp": False,
-                        "localProxyArp": False,
-                        "gratuitousArp": False,
-                        "vrf": "default",
-                        "urpf": "disable",
-                        "addresslessForwarding": "isInvalid",
-                        "directedBroadcastEnabled": False,
-                        "maxMssIngress": 0,
-                        "maxMssEgress": 0,
                     },
                 },
             },
         ],
         "inputs": {"interfaces": ["Ethernet1", "Ethernet2"]},
-        "expected": {"result": "failure", "messages": ["The following interface(s) have Proxy-ARP disabled: ['Ethernet2']"]},
+        "expected": {"result": "failure", "messages": ["Interface: Ethernet2 - Proxy-ARP disabled"]},
     },
     {
         "name": "success",
@@ -1972,17 +1926,13 @@ DATA: list[dict[str, Any]] = [
                             "primaryIp": {"address": "172.30.11.1", "maskLen": 31},
                             "secondaryIpsOrderedList": [{"address": "10.10.10.1", "maskLen": 31}, {"address": "10.10.10.10", "maskLen": 31}],
                         }
-                    }
-                }
-            },
-            {
-                "interfaces": {
+                    },
                     "Ethernet12": {
                         "interfaceAddress": {
                             "primaryIp": {"address": "172.30.11.10", "maskLen": 31},
                             "secondaryIpsOrderedList": [{"address": "10.10.10.10", "maskLen": 31}, {"address": "10.10.10.20", "maskLen": 31}],
                         }
-                    }
+                    },
                 }
             },
         ],
@@ -2005,17 +1955,13 @@ DATA: list[dict[str, Any]] = [
                             "primaryIp": {"address": "172.30.11.0", "maskLen": 31},
                             "secondaryIpsOrderedList": [],
                         }
-                    }
-                }
-            },
-            {
-                "interfaces": {
+                    },
                     "Ethernet12": {
                         "interfaceAddress": {
                             "primaryIp": {"address": "172.30.11.10", "maskLen": 31},
                             "secondaryIpsOrderedList": [],
                         }
-                    }
+                    },
                 }
             },
         ],
@@ -2028,9 +1974,20 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
-        "name": "failure-not-l3-interface",
+        "name": "failure-interface-not-found",
         "test": VerifyInterfaceIPv4,
-        "eos_data": [{"interfaces": {"Ethernet2": {"interfaceAddress": {}}}}, {"interfaces": {"Ethernet12": {"interfaceAddress": {}}}}],
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet10": {
+                        "interfaceAddress": {
+                            "primaryIp": {"address": "172.30.11.0", "maskLen": 31},
+                            "secondaryIpsOrderedList": [],
+                        }
+                    }
+                }
+            }
+        ],
         "inputs": {
             "interfaces": [
                 {"name": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
@@ -2039,7 +1996,22 @@ DATA: list[dict[str, Any]] = [
         },
         "expected": {
             "result": "failure",
-            "messages": ["For interface `Ethernet2`, IP address is not configured.", "For interface `Ethernet12`, IP address is not configured."],
+            "messages": ["Interface: Ethernet2 - Not found", "Interface: Ethernet12 - Not found"],
+        },
+    },
+    {
+        "name": "failure-not-l3-interface",
+        "test": VerifyInterfaceIPv4,
+        "eos_data": [{"interfaces": {"Ethernet2": {"interfaceAddress": {}}, "Ethernet12": {"interfaceAddress": {}}}}],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet2", "primary_ip": "172.30.11.0/31", "secondary_ips": ["10.10.10.0/31", "10.10.10.10/31"]},
+                {"name": "Ethernet12", "primary_ip": "172.30.11.20/31", "secondary_ips": ["10.10.11.0/31", "10.10.11.10/31"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": ["Interface: Ethernet2 - IP address is not configured", "Interface: Ethernet12 - IP address is not configured"],
         },
     },
     {
@@ -2053,17 +2025,13 @@ DATA: list[dict[str, Any]] = [
                             "primaryIp": {"address": "0.0.0.0", "maskLen": 0},
                             "secondaryIpsOrderedList": [],
                         }
-                    }
-                }
-            },
-            {
-                "interfaces": {
+                    },
                     "Ethernet12": {
                         "interfaceAddress": {
                             "primaryIp": {"address": "0.0.0.0", "maskLen": 0},
                             "secondaryIpsOrderedList": [],
                         }
-                    }
+                    },
                 }
             },
         ],
@@ -2076,10 +2044,10 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "For interface `Ethernet2`, The expected primary IP address is `172.30.11.0/31`, but the actual primary IP address is `0.0.0.0/0`. "
-                "The expected secondary IP addresses are `['10.10.10.0/31', '10.10.10.10/31']`, but the actual secondary IP address is not configured.",
-                "For interface `Ethernet12`, The expected primary IP address is `172.30.11.10/31`, but the actual primary IP address is `0.0.0.0/0`. "
-                "The expected secondary IP addresses are `['10.10.11.0/31', '10.10.11.10/31']`, but the actual secondary IP address is not configured.",
+                "Interface: Ethernet2 - IP address mismatch - Expected: 172.30.11.0/31 Actual: 0.0.0.0/0",
+                "Interface: Ethernet2 - Secondary IP address is not configured",
+                "Interface: Ethernet12 - IP address mismatch - Expected: 172.30.11.10/31 Actual: 0.0.0.0/0",
+                "Interface: Ethernet12 - Secondary IP address is not configured",
             ],
         },
     },
@@ -2094,17 +2062,13 @@ DATA: list[dict[str, Any]] = [
                             "primaryIp": {"address": "172.30.11.0", "maskLen": 31},
                             "secondaryIpsOrderedList": [{"address": "10.10.10.0", "maskLen": 31}, {"address": "10.10.10.10", "maskLen": 31}],
                         }
-                    }
-                }
-            },
-            {
-                "interfaces": {
+                    },
                     "Ethernet3": {
                         "interfaceAddress": {
                             "primaryIp": {"address": "172.30.10.10", "maskLen": 31},
                             "secondaryIpsOrderedList": [{"address": "10.10.11.0", "maskLen": 31}, {"address": "10.11.11.10", "maskLen": 31}],
                         }
-                    }
+                    },
                 }
             },
         ],
@@ -2117,12 +2081,10 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "For interface `Ethernet2`, The expected primary IP address is `172.30.11.2/31`, but the actual primary IP address is `172.30.11.0/31`. "
-                "The expected secondary IP addresses are `['10.10.10.20/31', '10.10.10.30/31']`, but the actual secondary IP addresses are "
-                "`['10.10.10.0/31', '10.10.10.10/31']`.",
-                "For interface `Ethernet3`, The expected primary IP address is `172.30.10.2/31`, but the actual primary IP address is `172.30.10.10/31`. "
-                "The expected secondary IP addresses are `['10.10.11.0/31', '10.10.11.10/31']`, but the actual secondary IP addresses are "
-                "`['10.10.11.0/31', '10.11.11.10/31']`.",
+                "Interface: Ethernet2 - IP address mismatch - Expected: 172.30.11.2/31 Actual: 172.30.11.0/31",
+                "Interface: Ethernet2 - Secondary IP address mismatch - Expected: 10.10.10.20/31, 10.10.10.30/31 Actual: 10.10.10.0/31, 10.10.10.10/31",
+                "Interface: Ethernet3 - IP address mismatch - Expected: 172.30.10.2/31 Actual: 172.30.10.10/31",
+                "Interface: Ethernet3 - Secondary IP address mismatch - Expected: 10.10.11.0/31, 10.10.11.10/31 Actual: 10.10.11.0/31, 10.11.11.10/31",
             ],
         },
     },
@@ -2137,17 +2099,13 @@ DATA: list[dict[str, Any]] = [
                             "primaryIp": {"address": "172.30.11.0", "maskLen": 31},
                             "secondaryIpsOrderedList": [],
                         }
-                    }
-                }
-            },
-            {
-                "interfaces": {
+                    },
                     "Ethernet3": {
                         "interfaceAddress": {
                             "primaryIp": {"address": "172.30.10.10", "maskLen": 31},
                             "secondaryIpsOrderedList": [{"address": "10.10.11.0", "maskLen": 31}, {"address": "10.11.11.10", "maskLen": 31}],
                         }
-                    }
+                    },
                 }
             },
         ],
@@ -2160,11 +2118,10 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "For interface `Ethernet2`, The expected primary IP address is `172.30.11.2/31`, but the actual primary IP address is `172.30.11.0/31`. "
-                "The expected secondary IP addresses are `['10.10.10.20/31', '10.10.10.30/31']`, but the actual secondary IP address is not configured.",
-                "For interface `Ethernet3`, The expected primary IP address is `172.30.10.2/31`, but the actual primary IP address is `172.30.10.10/31`. "
-                "The expected secondary IP addresses are `['10.10.11.0/31', '10.10.11.10/31']`, but the actual secondary IP addresses are "
-                "`['10.10.11.0/31', '10.11.11.10/31']`.",
+                "Interface: Ethernet2 - IP address mismatch - Expected: 172.30.11.2/31 Actual: 172.30.11.0/31",
+                "Interface: Ethernet2 - Secondary IP address is not configured",
+                "Interface: Ethernet3 - IP address mismatch - Expected: 172.30.10.2/31 Actual: 172.30.10.10/31",
+                "Interface: Ethernet3 - Secondary IP address mismatch - Expected: 10.10.11.0/31, 10.10.11.10/31 Actual: 10.10.11.0/31, 10.11.11.10/31",
             ],
         },
     },

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -12,7 +12,7 @@ import pytest
 from pydantic import ValidationError
 
 from anta.input_models.interfaces import InterfaceState
-from anta.tests.interfaces import VerifyInterfacesStatus, VerifyLACPInterfacesStatus
+from anta.tests.interfaces import VerifyInterfaceIPv4, VerifyInterfacesStatus, VerifyLACPInterfacesStatus
 
 if TYPE_CHECKING:
     from anta.custom_types import Interface, PortChannelInterface
@@ -83,3 +83,28 @@ class TestVerifyLACPInterfacesStatusInput:
         """Test VerifyLACPInterfacesStatus.Input invalid inputs."""
         with pytest.raises(ValidationError):
             VerifyLACPInterfacesStatus.Input(interfaces=interfaces)
+
+
+class TestVerifyInterfaceIPv4Input:
+    """Test anta.tests.interfaces.VerifyInterfaceIPv4.Input."""
+
+    @pytest.mark.parametrize(
+        ("interfaces"),
+        [
+            pytest.param([{"name": "Ethernet1", "primary_ip": "172.30.11.1/31"}], id="valid"),
+        ],
+    )
+    def test_valid(self, interfaces: list[InterfaceState]) -> None:
+        """Test VerifyInterfaceIPv4.Input valid inputs."""
+        VerifyInterfaceIPv4.Input(interfaces=interfaces)
+
+    @pytest.mark.parametrize(
+        ("interfaces"),
+        [
+            pytest.param([{"name": "Ethernet1"}], id="invalid-no-primary-ip"),
+        ],
+    )
+    def test_invalid(self, interfaces: list[InterfaceState]) -> None:
+        """Test VerifyInterfaceIPv4.Input invalid inputs."""
+        with pytest.raises(ValidationError):
+            VerifyInterfaceIPv4.Input(interfaces=interfaces)


### PR DESCRIPTION
# Description

Modular switches have Ethernet X/X naming scheme. Could also be Ethernet X/X/X for multi-lane ports on modular switches.

Use AntaCommand with `show ip interface` command to fetch all interfaces and fail the test if any of the provided interface is not found.

Fixes #1051 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
