### PR TITLE
Feat(anta.tests): Add test for Maintenance mode

### DIFF
--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -372,7 +372,7 @@ class VerifyMaintenance(AntaTest):
         self.result.is_success()
 
         # If units is not empty we have to examine the output for details.
-        if (units := get_value(self.instance_commands[0].json_output, "units")):
+        if units := get_value(self.instance_commands[0].json_output, "units"):
             unitsundermaintenance = []
             unitsenteringmaintenance = []
             under = False
@@ -399,11 +399,11 @@ class VerifyMaintenance(AntaTest):
 
             # Building the error message.
             else:
-                message = "Some units are under or entering maintenance."
+                message = ""
                 if under:
-                    message += f" The following units are currently under maintenance: '{unitsundermaintenance}'."
+                    message += f"Units under maintenance: '{unitsundermaintenance}'. "
                 if entering:
-                    message += f" The following units are currently entering maintenance: '{unitsenteringmaintenance}'."
+                    message += f"Units entering maintenance: '{unitsenteringmaintenance}'. "
                 if len(causes) > 0:
-                    message += f" Possible causes: '{causes}'"
+                    message += f"Possible causes: '{causes}'"
                 self.result.is_failure(message)

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -951,6 +951,8 @@ anta.tests.system:
       # Verifies there are no core dump files.
   - VerifyFileSystemUtilization:
       # Verifies that no partition is utilizing more than 75% of its disk space.
+  - VerifyMaintenance:
+      # Verifies that the device is not currently under maintenance.
   - VerifyMemoryUtilization:
       # Verifies whether the memory utilization is below 75%.
   - VerifyNTP:

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -17,6 +17,7 @@ from anta.tests.system import (
     VerifyNTPAssociations,
     VerifyReloadCause,
     VerifyUptime,
+    VerifyMaintenance
 )
 from tests.units.anta_tests import test
 
@@ -493,6 +494,200 @@ poll interval unknown
                 "NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Bad association - Condition: candidate, Stratum: 1",
                 "NTP Server: 2.2.2.2 Preferred: False Stratum: 1 - Not configured",
                 "NTP Server: 3.3.3.3 Preferred: False Stratum: 1 - Not configured",
+            ],
+        },
+    },
+    {
+        "name": "success-no-maintenance-configured",
+        "test": VerifyMaintenance,
+        "eos_data": [
+            {
+                "units": {},
+                "interfaces": {},
+                "vrfs": {},
+                "warnings": [
+                    "Maintenance Mode is disabled."
+                ],
+            },
+        ],
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-maintenance-configured-but-not-enabled",
+        "test": VerifyMaintenance,
+        "eos_data": [
+            {
+                "units": {
+                    "System": {
+                        "state": "active",
+                        "adminState": "active",
+                        "stateChangeTime": 0.0,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    }
+                },
+                "interfaces": {},
+                "vrfs": {},
+            },
+        ],
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "success-multiple-units-but-not-enabled",
+        "test": VerifyMaintenance,
+        "eos_data": [
+            {
+                "units": {
+                    "mlag": {
+                        "state": "active",
+                        "adminState": "active",
+                        "stateChangeTime": 0.0,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    },
+                    "System": {
+                        "state": "active",
+                        "adminState": "active",
+                        "stateChangeTime": 0.0,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    },
+                },
+                "interfaces": {},
+                "vrfs": {},
+            },
+        ],
+        "expected": {"result": "success"},
+    },
+    {
+        "name": "failure-maintenance-enabled",
+        "test": VerifyMaintenance,
+        "eos_data": [
+            {
+                "units": {
+                    "mlag": {
+                        "state": "underMaintenance",
+                        "adminState": "underMaintenance",
+                        "stateChangeTime": 1741257120.9532886,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    },
+                    "System": {
+                        "state": "active",
+                        "adminState": "active",
+                        "stateChangeTime": 0.0,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    }
+                },
+                "interfaces": {},
+                "vrfs": {},
+            },
+        ],
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Some units are under or entering maintenance.  The following units are currently under maintenance: '['mlag']'. Possible causes: ['quiesce is configured']",
+            ],
+        },
+    },
+    {
+        "name": "failure-multiple-reasons",
+        "test": VerifyMaintenance,
+        "eos_data": [
+            {
+                "units": {
+                    "mlag": {
+                        "state": "underMaintenance",
+                        "adminState": "underMaintenance",
+                        "stateChangeTime": 1741257120.9532895,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    },
+                    "System": {
+                        "state": "maintenanceModeEnter",
+                        "adminState": "underMaintenance",
+                        "stateChangeTime": 1741257669.7231765,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    }
+                },
+                "interfaces": {},
+                "vrfs": {},
+            },
+        ],
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Some units are under or entering maintenance.  The following units are currently under maintenance: '['mlag']'. The following units are currently entering maintenance: '['System']' Possible causes: ['quiesce is configured','quiesce is configured']",
+            ],
+        },
+    },
+    {
+        "name": "failure-onboot-maintenance",
+        "test": VerifyMaintenance,
+        "eos_data": [
+            {
+                "units": {
+                    "System": {
+                        "state": "underMaintenance",
+                        "adminState": "underMaintenance",
+                        "stateChangeTime": 1741258774.3756502,
+                        "onBootMaintenance": True,
+                        "intfsViolatingTrafficThreshold": False,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    }
+                },
+                "interfaces": {},
+                "vrfs": {}
+            },
+        ],
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Some units are under or entering maintenance. The following units are currently under maintenance: '['System']'. Possible causes: ['On-boot maintenance is configured']",
+            ],
+        },
+    },
+    {
+        "name": "failure-entering-maintenance-interface-violation",
+        "test": VerifyMaintenance,
+        "eos_data": [
+            {
+                "units": {
+                    "System": {
+                        "state": "maintenanceModeEnter",
+                        "adminState": "underMaintenance",
+                        "stateChangeTime": 1741257669.7231765,
+                        "onBootMaintenance": False,
+                        "intfsViolatingTrafficThreshold": True,
+                        "aggInBpsRate": 0,
+                        "aggOutBpsRate": 0
+                    }
+                },
+                "interfaces": {},
+                "vrfs": {}
+            },
+        ],
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Some units are under or entering maintenance. The following units are currently entering maintenance: '['System']'. Possible causes: ['Interface traffic threshold violation']",
             ],
         },
     },

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -12,12 +12,12 @@ from anta.tests.system import (
     VerifyCoredump,
     VerifyCPUUtilization,
     VerifyFileSystemUtilization,
+    VerifyMaintenance,
     VerifyMemoryUtilization,
     VerifyNTP,
     VerifyNTPAssociations,
     VerifyReloadCause,
     VerifyUptime,
-    VerifyMaintenance
 )
 from tests.units.anta_tests import test
 
@@ -505,9 +505,7 @@ poll interval unknown
                 "units": {},
                 "interfaces": {},
                 "vrfs": {},
-                "warnings": [
-                    "Maintenance Mode is disabled."
-                ],
+                "warnings": ["Maintenance Mode is disabled."],
             },
         ],
         "expected": {"result": "success"},
@@ -525,7 +523,7 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
+                        "aggOutBpsRate": 0,
                     }
                 },
                 "interfaces": {},
@@ -547,7 +545,7 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
+                        "aggOutBpsRate": 0,
                     },
                     "System": {
                         "state": "active",
@@ -556,7 +554,7 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
+                        "aggOutBpsRate": 0,
                     },
                 },
                 "interfaces": {},
@@ -578,7 +576,7 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
+                        "aggOutBpsRate": 0,
                     },
                     "System": {
                         "state": "active",
@@ -587,8 +585,8 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
-                    }
+                        "aggOutBpsRate": 0,
+                    },
                 },
                 "interfaces": {},
                 "vrfs": {},
@@ -597,7 +595,7 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "Some units are under or entering maintenance.  The following units are currently under maintenance: '['mlag']'. Possible causes: ['quiesce is configured']",
+                "The following units are currently under maintenance: '['mlag']'. Possible causes: ['quiesce is configured']",
             ],
         },
     },
@@ -614,7 +612,7 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
+                        "aggOutBpsRate": 0,
                     },
                     "System": {
                         "state": "maintenanceModeEnter",
@@ -623,8 +621,8 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
-                    }
+                        "aggOutBpsRate": 0,
+                    },
                 },
                 "interfaces": {},
                 "vrfs": {},
@@ -633,7 +631,7 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "Some units are under or entering maintenance.  The following units are currently under maintenance: '['mlag']'. The following units are currently entering maintenance: '['System']' Possible causes: ['quiesce is configured','quiesce is configured']",
+                "Units under maintenance: '['mlag']'. Units entering maintenance: '['System']' Possible causes: ['quiesce is configured','quiesce is configured']",
             ],
         },
     },
@@ -650,17 +648,17 @@ poll interval unknown
                         "onBootMaintenance": True,
                         "intfsViolatingTrafficThreshold": False,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
+                        "aggOutBpsRate": 0,
                     }
                 },
                 "interfaces": {},
-                "vrfs": {}
+                "vrfs": {},
             },
         ],
         "expected": {
             "result": "failure",
             "messages": [
-                "Some units are under or entering maintenance. The following units are currently under maintenance: '['System']'. Possible causes: ['On-boot maintenance is configured']",
+                "Units under maintenance: '['System']'. Possible causes: ['On-boot maintenance is configured']",
             ],
         },
     },
@@ -677,17 +675,17 @@ poll interval unknown
                         "onBootMaintenance": False,
                         "intfsViolatingTrafficThreshold": True,
                         "aggInBpsRate": 0,
-                        "aggOutBpsRate": 0
+                        "aggOutBpsRate": 0,
                     }
                 },
                 "interfaces": {},
-                "vrfs": {}
+                "vrfs": {},
             },
         ],
         "expected": {
             "result": "failure",
             "messages": [
-                "Some units are under or entering maintenance. The following units are currently entering maintenance: '['System']'. Possible causes: ['Interface traffic threshold violation']",
+                "Units entering maintenance: '['System']'. Possible causes: ['Interface traffic threshold violation']",
             ],
         },
     },


### PR DESCRIPTION
# Description

Test to verify if one or more units are under or entering maintenance mode for different reasons:

* On-boot configuration
* Interface traffic violation
* quiesce explicitly configured

# Checklist:

<!-- Delete not relevant items !-->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)
