### PR TITLE
doc(anta.tests): Fixed documentation issue for VerifySTPdisabledVlan and CVX input model

### DIFF
--- a/anta/input_models/cvx.py
+++ b/anta/input_models/cvx.py
@@ -16,4 +16,6 @@ class CVXPeers(BaseModel):
     """Model for a CVX Cluster Peer."""
 
     peer_name: Hostname
+    """The CVX Peer used communicate with a CVX server."""
     registration_state: Literal["Connecting", "Connected", "Registration error", "Registration complete", "Unexpected peer state"] = "Registration complete"
+    """The CVX registration state."""

--- a/anta/tests/stp.py
+++ b/anta/tests/stp.py
@@ -299,9 +299,9 @@ class VerifySTPDisabledVlans(AntaTest):
 
     This test performs the following checks:
 
-        1. Verifies that the STP is configured.
-        2. Verifies that the specified VLAN(s) exist on the device.
-        3. Verifies that the STP is disabled for the specified VLAN(s).
+      1. Verifies that the STP is configured.
+      2. Verifies that the specified VLAN(s) exist on the device.
+      3. Verifies that the STP is disabled for the specified VLAN(s).
 
     Expected Results
     ----------------

--- a/docs/api/tests/cvx.md
+++ b/docs/api/tests/cvx.md
@@ -8,7 +8,26 @@ anta_title: ANTA catalog for CVX tests
   ~ that can be found in the LICENSE file.
   -->
 
+# Test
+
 ::: anta.tests.cvx
+
+    options:
+      anta_hide_test_module_description: true
+      filters:
+        - "!test"
+        - "!render"
+      merge_init_into_class: false
+      show_bases: false
+      show_labels: true
+      show_root_heading: false
+      show_root_toc_entry: false
+      show_symbol_type_heading: false
+      show_symbol_type_toc: false
+
+# Input models
+
+::: anta.input_models.cvx
 
     options:
       anta_hide_test_module_description: true


### PR DESCRIPTION
# Description
 Fixed documentation issue for VerifySTPdisabledVlanTest  and CVX input model

Fixes #1104

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
