### PR TITLE
feat(anta.tests): The source field of VerifyReachability Host model should be optional

### DIFF
--- a/anta/input_models/connectivity.py
+++ b/anta/input_models/connectivity.py
@@ -20,8 +20,8 @@ class Host(BaseModel):
     model_config = ConfigDict(extra="forbid")
     destination: IPv4Address | IPv6Address
     """Destination address to ping."""
-    source: IPv4Address | IPv6Address | Interface
-    """Source address IP or egress interface to use."""
+    source: IPv4Address | IPv6Address | Interface | None = None
+    """Source address IP or egress interface to use. Can be provided in the `VerifyReachability` test."""
     vrf: str = "default"
     """VRF context."""
     repeat: int = 2
@@ -38,10 +38,15 @@ class Host(BaseModel):
 
         Examples
         --------
-        Host: 10.1.1.1 Source: 10.2.2.2 VRF: mgmt
+        - Host: 10.1.1.1 Source: 10.2.2.2 VRF: mgmt
+        - Host: 10.1.1.1 VRF: mgmt
 
         """
-        return f"Host: {self.destination} Source: {self.source} VRF: {self.vrf}"
+        base_string = f"Host: {self.destination}"
+        if self.source:
+            base_string += f" Source: {self.source}"
+        base_string += f" VRF: {self.vrf}"
+        return base_string
 
 
 class LLDPNeighbor(BaseModel):

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -131,8 +131,7 @@ anta.tests.connectivity:
           df_bit: True
           size: 100
           reachable: true
-        - source: Management0
-          destination: 8.8.8.8
+        - destination: 8.8.8.8
           vrf: MGMT
           df_bit: True
           size: 100

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -179,6 +179,26 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
+        "name": "success-without-source",
+        "test": VerifyReachability,
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "repeat": 1}]},
+        "eos_data": [
+            {
+                "messages": [
+                    """PING 10.0.0.1 (10.0.0.1) : 72(100) bytes of data.
+                80 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=0.247 ms
+
+                --- 10.0.0.1 ping statistics ---
+                1 packets transmitted, 1 received, 0% packet loss, time 0ms
+                rtt min/avg/max/mdev = 0.072/0.159/0.247/0.088 ms, ipg/ewma 0.370/0.225 ms
+
+                """,
+                ],
+            },
+        ],
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure-ip",
         "test": VerifyReachability,
         "inputs": {"hosts": [{"destination": "10.0.0.11", "source": "10.0.0.5"}, {"destination": "10.0.0.2", "source": "10.0.0.5"}]},
@@ -308,6 +328,25 @@ DATA: list[dict[str, Any]] = [
             "result": "failure",
             "messages": ["Host: 10.0.0.1 Source: 10.0.0.5 VRF: default - Destination is expected to be unreachable but found reachable"],
         },
+    },
+    {
+        "name": "failure-without-source",
+        "test": VerifyReachability,
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "repeat": 1}]},
+        "eos_data": [
+            {
+                "messages": [
+                    """ping: sendmsg: Network is unreachable
+                PING 10.0.0.1 (10.0.0.1) : 72(100) bytes of data.
+
+                --- 10.0.0.11 ping statistics ---
+                2 packets transmitted, 0 received, 100% packet loss, time 10ms
+
+                """,
+                ],
+            },
+        ],
+        "expected": {"result": "failure", "messages": ["Host: 10.0.0.1 VRF: default - Unreachable"]},
     },
     {
         "name": "success",


### PR DESCRIPTION
# Description

When source is None, that means we don't provide a source to the ping command and let EOS decides the source.

Fixes #1112

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
