### PR TITLE
refactor(anta): Updated failure messages, updated skip_on_platforms decorator message

### DIFF
--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -161,7 +161,7 @@ def skip_on_platforms(platforms: list[str]) -> Callable[[F], F]:
                 return anta_test.result
 
             if anta_test.device.hw_model in platforms:
-                anta_test.result.is_skipped(f"{anta_test.__class__.__name__} test is not supported on {anta_test.device.hw_model}.")
+                anta_test.result.is_skipped(f"{anta_test.__class__.__name__} test is not supported on {anta_test.device.hw_model}")
                 AntaTest.update_progress()
                 return anta_test.result
 

--- a/anta/tests/cvx.py
+++ b/anta/tests/cvx.py
@@ -149,7 +149,7 @@ class VerifyMcsServerMounts(AntaTest):
         active_count = 0
 
         if not (connections := command_output.get("connections")):
-            self.result.is_failure("CVX connections are not available.")
+            self.result.is_failure("CVX connections are not available")
             return
 
         for connection in connections:

--- a/anta/tests/flow_tracking.py
+++ b/anta/tests/flow_tracking.py
@@ -109,7 +109,7 @@ class VerifyHardwareFlowTrackerStatus(AntaTest):
         command_output = self.instance_commands[0].json_output
         # Check if hardware flow tracking is configured
         if not command_output.get("running"):
-            self.result.is_failure("Hardware flow tracking is not running.")
+            self.result.is_failure("Hardware flow tracking is not running")
             return
 
         for tracker in self.inputs.trackers:

--- a/anta/tests/snmp.py
+++ b/anta/tests/snmp.py
@@ -320,7 +320,7 @@ class VerifySnmpErrorCounters(AntaTest):
 
         # Verify SNMP PDU counters.
         if not (snmp_counters := get_value(command_output, "counters")):
-            self.result.is_failure("SNMP counters not found.")
+            self.result.is_failure("SNMP counters not found")
             return
 
         # In case SNMP error counters not provided, It will check all the error counters.

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -451,7 +451,7 @@ class VerifyMaintenance(AntaTest):
     ```
     """
 
-    categories: ClassVar[list[str]] = ["Maintenance"]
+    categories: ClassVar[list[str]] = ["system"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show maintenance", revision=1)]
 
     @AntaTest.anta_test

--- a/anta/tests/system.py
+++ b/anta/tests/system.py
@@ -476,8 +476,8 @@ class VerifyMaintenance(AntaTest):
 
         # Building the error message.
         if units_under_maintenance:
-            self.result.is_failure(f"Units under maintenance: '{', '.join(units_under_maintenance)}'.")
+            self.result.is_failure(f"Units under maintenance: '{', '.join(units_under_maintenance)}'")
         if units_entering_maintenance:
-            self.result.is_failure(f"Units entering maintenance: '{', '.join(units_entering_maintenance)}'.")
+            self.result.is_failure(f"Units entering maintenance: '{', '.join(units_entering_maintenance)}'")
         if causes:
-            self.result.is_failure(f"Possible causes: '{', '.join(sorted(causes))}'.")
+            self.result.is_failure(f"Possible causes: '{', '.join(sorted(causes))}'")

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -155,7 +155,7 @@ class VerifyVxlanVniBinding(AntaTest):
 
 
 class VerifyVxlanVtep(AntaTest):
-    """Verifies the VTEP peers of the Vxlan1 interface.
+    """Verifies Vxlan1 VTEP peers.
 
     Expected Results
     ----------------
@@ -205,7 +205,7 @@ class VerifyVxlanVtep(AntaTest):
 
 
 class VerifyVxlan1ConnSettings(AntaTest):
-    """Verifies the interface vxlan1 source interface and UDP port.
+    """Verifies the Vxlan1 source interface and UDP port.
 
     Expected Results
     ----------------

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -136,7 +136,7 @@ class VerifyVxlanVniBinding(AntaTest):
         self.result.is_success()
 
         if (vxlan1 := get_value(self.instance_commands[0].json_output, "vxlanIntfs.Vxlan1")) is None:
-            self.result.is_skipped("Vxlan1 interface is not configured")
+            self.result.is_skipped("Interface: Vxlan1 - Not configured")
             return
 
         for vni, vlan in self.inputs.bindings.items():
@@ -191,7 +191,7 @@ class VerifyVxlanVtep(AntaTest):
         inputs_vteps = [str(input_vtep) for input_vtep in self.inputs.vteps]
 
         if (vxlan1 := get_value(self.instance_commands[0].json_output, "interfaces.Vxlan1")) is None:
-            self.result.is_skipped("Vxlan1 interface is not configured")
+            self.result.is_skipped("Interface: Vxlan1 - Not configured")
             return
 
         difference1 = set(inputs_vteps).difference(set(vxlan1["vteps"]))
@@ -243,7 +243,7 @@ class VerifyVxlan1ConnSettings(AntaTest):
         # Skip the test case if vxlan1 interface is not configured
         vxlan_output = get_value(command_output, "interfaces.Vxlan1")
         if not vxlan_output:
-            self.result.is_skipped("Vxlan1 interface is not configured.")
+            self.result.is_skipped("Interface: Vxlan1 - Not configured")
             return
 
         src_intf = vxlan_output.get("srcIpIntf")

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -205,7 +205,7 @@ class VerifyVxlanVtep(AntaTest):
 
 
 class VerifyVxlan1ConnSettings(AntaTest):
-    """Verifies the Vxlan1 source interface and UDP port.
+    """Verifies Vxlan1 source interface and UDP port.
 
     Expected Results
     ----------------

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -1028,7 +1028,7 @@ anta.tests.vlan:
       end_vlan_id: 4094
 anta.tests.vxlan:
   - VerifyVxlan1ConnSettings:
-      # Verifies the interface vxlan1 source interface and UDP port.
+      # Verifies the Vxlan1 source interface and UDP port.
       source_interface: Loopback1
       udp_port: 4789
   - VerifyVxlan1Interface:
@@ -1041,7 +1041,7 @@ anta.tests.vxlan:
         10010: 10
         10020: 20
   - VerifyVxlanVtep:
-      # Verifies the VTEP peers of the Vxlan1 interface.
+      # Verifies Vxlan1 VTEP peers.
       vteps:
         - 10.1.1.5
         - 10.1.1.6

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -1028,7 +1028,7 @@ anta.tests.vlan:
       end_vlan_id: 4094
 anta.tests.vxlan:
   - VerifyVxlan1ConnSettings:
-      # Verifies the Vxlan1 source interface and UDP port.
+      # Verifies Vxlan1 source interface and UDP port.
       source_interface: Loopback1
       udp_port: 4789
   - VerifyVxlan1Interface:

--- a/tests/units/anta_tests/test_flow_tracking.py
+++ b/tests/units/anta_tests/test_flow_tracking.py
@@ -81,7 +81,7 @@ DATA: list[dict[str, Any]] = [
         "inputs": {"trackers": [{"name": "FLOW-TRACKER"}]},
         "expected": {
             "result": "failure",
-            "messages": ["Hardware flow tracking is not running."],
+            "messages": ["Hardware flow tracking is not running"],
         },
     },
     {

--- a/tests/units/anta_tests/test_system.py
+++ b/tests/units/anta_tests/test_system.py
@@ -758,8 +758,8 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "Units under maintenance: 'mlag'.",
-                "Possible causes: 'Quiesce is configured'.",
+                "Units under maintenance: 'mlag'",
+                "Possible causes: 'Quiesce is configured'",
             ],
         },
     },
@@ -796,9 +796,9 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "Units under maintenance: 'mlag'.",
-                "Units entering maintenance: 'System'.",
-                "Possible causes: 'Quiesce is configured'.",
+                "Units under maintenance: 'mlag'",
+                "Units entering maintenance: 'System'",
+                "Possible causes: 'Quiesce is configured'",
             ],
         },
     },
@@ -826,8 +826,8 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "Units under maintenance: 'System'.",
-                "Possible causes: 'On-boot maintenance is configured, Quiesce is configured'.",
+                "Units under maintenance: 'System'",
+                "Possible causes: 'On-boot maintenance is configured, Quiesce is configured'",
             ],
         },
     },
@@ -855,8 +855,8 @@ poll interval unknown
         "expected": {
             "result": "failure",
             "messages": [
-                "Units entering maintenance: 'System'.",
-                "Possible causes: 'Interface traffic threshold violation, Quiesce is configured'.",
+                "Units entering maintenance: 'System'",
+                "Possible causes: 'Interface traffic threshold violation, Quiesce is configured'",
             ],
         },
     },

--- a/tests/units/anta_tests/test_vxlan.py
+++ b/tests/units/anta_tests/test_vxlan.py
@@ -266,7 +266,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyVxlanVniBinding,
         "eos_data": [{"vxlanIntfs": {}}],
         "inputs": {"bindings": {10020: 20, 500: 1199}},
-        "expected": {"result": "skipped", "messages": ["Vxlan1 interface is not configured"]},
+        "expected": {"result": "skipped", "messages": ["Interface: Vxlan1 - Not configured"]},
     },
     {
         "name": "success",
@@ -314,7 +314,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyVxlanVtep,
         "eos_data": [{"vteps": {}, "interfaces": {}}],
         "inputs": {"vteps": ["10.1.1.5", "10.1.1.6", "10.1.1.7"]},
-        "expected": {"result": "skipped", "messages": ["Vxlan1 interface is not configured"]},
+        "expected": {"result": "skipped", "messages": ["Interface: Vxlan1 - Not configured"]},
     },
     {
         "name": "success",
@@ -328,7 +328,7 @@ DATA: list[dict[str, Any]] = [
         "test": VerifyVxlan1ConnSettings,
         "eos_data": [{"interfaces": {}}],
         "inputs": {"source_interface": "Loopback1", "udp_port": 4789},
-        "expected": {"result": "skipped", "messages": ["Vxlan1 interface is not configured."]},
+        "expected": {"result": "skipped", "messages": ["Interface: Vxlan1 - Not configured"]},
     },
     {
         "name": "failure-wrong-interface",


### PR DESCRIPTION
# Description

Updated failure messages, updated skip_on_platforms decorator message

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
