### PR TITLE
fix(anta): Catch ValueError in call to setrlimit if can't set RLIMIT_NOFILE.

### DIFF
--- a/anta/runner.py
+++ b/anta/runner.py
@@ -53,7 +53,10 @@ if os.name == "posix":
         logger.debug("Initial limit numbers for open file descriptors for the current ANTA process: Soft Limit: %s | Hard Limit: %s", limits[0], limits[1])
         nofile = min(limits[1], nofile)
         logger.debug("Setting soft limit for open file descriptors for the current ANTA process to %s", nofile)
-        resource.setrlimit(resource.RLIMIT_NOFILE, (nofile, limits[1]))
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (nofile, limits[1]))
+        except ValueError as exception:
+            logger.warning("Failed to set soft limit for open file descriptors for the current ANTA process: %s", exc_to_str(exception))
         return resource.getrlimit(resource.RLIMIT_NOFILE)
 
 


### PR DESCRIPTION
# Description

Catch ValueError in call to setrlimit if can't set RLIMIT_NOFILE

Fixes #1135

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
