### PR TITLE
refactor: Do not over eager catch all import errors as missing anta[cli]

### DIFF
--- a/anta/cli/__init__.py
+++ b/anta/cli/__init__.py
@@ -16,11 +16,15 @@ try:
 
 except ImportError as exc:
 
-    def build_cli(exception: Exception) -> Callable[[], None]:
+    def build_cli(exception: ImportError) -> Callable[[], None]:
         """Build CLI function using the caught exception."""
 
         def wrap() -> None:
             """Error message if any CLI dependency is missing."""
+            print(f"EXCEPRTION {exception}")
+            if not exception.name or "click" not in exception.name:
+                raise exception
+
             print(
                 "The ANTA command line client could not run because the required "
                 "dependencies were not installed.\nMake sure you've installed "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ requires-python = ">=3.9"
 [project.optional-dependencies]
 cli = [
   "click~=8.1.6",
-  "click-help-colors>=0.9",
 ]
 dev = [
   "bumpver>=2023.1129",

--- a/tests/units/cli/test__init__.py
+++ b/tests/units/cli/test__init__.py
@@ -6,13 +6,10 @@
 from __future__ import annotations
 
 import sys
-from importlib import reload
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import patch
 
 import pytest
-
-import anta.cli
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -20,21 +17,28 @@ if TYPE_CHECKING:
 builtins_import = __import__
 
 
-# Tried to achieve this with mock
 # http://materials-scientist.com/blog/2021/02/11/mocking-failing-module-import-python/
-def import_mock(name: str, *args: Any) -> ModuleType:  # noqa: ANN401
-    """Mock."""
-    if name == "click":
-        msg = "No module named 'click'"
-        raise ModuleNotFoundError(msg)
-    return builtins_import(name, *args)
+def import_mock(delete_name: str) -> Callable[..., ModuleType]:
+    """Mock missing the package 'delete_name' when importing."""
+
+    def wrapper(name: str, *args: Any) -> ModuleType:  # noqa: ANN401
+        """Mock."""
+        if name == delete_name:
+            msg = f"No module named '{delete_name}'"
+            raise ModuleNotFoundError(msg, name=delete_name)
+        return builtins_import(name, *args)
+
+    return wrapper
 
 
-def test_cli_error_missing(capsys: pytest.CaptureFixture[Any]) -> None:
+def test_cli_error_missing_click(capsys: pytest.CaptureFixture[Any]) -> None:
+    # def test_cli_error_missing_click() -> None:
     """Test ANTA errors out when anta[cli] was not installed."""
-    with patch.dict(sys.modules) as sys_modules, patch("builtins.__import__", import_mock):
-        del sys_modules["anta.cli._main"]
-        reload(anta.cli)
+    with patch.dict(sys.modules) as sys_modules, patch("builtins.__import__", import_mock("click")):
+        for k in list(sys_modules.keys()):
+            if k.startswith("anta."):  # and k != "anta.cli":
+                del sys_modules[k]
+        import anta.cli
 
         with pytest.raises(SystemExit) as e_info:
             anta.cli.cli()
@@ -53,3 +57,16 @@ def test_cli_error_missing(capsys: pytest.CaptureFixture[Any]) -> None:
         assert "Make sure you've installed everything with: pip install 'anta[cli]'" in captured.out
         assert "The caught exception was:" in captured.out
         assert e_info.value.code == 1
+
+
+def test_cli_error_missing_other() -> None:
+    """Test ANTA errors out when anta[cli] was not installed."""
+    with patch.dict(sys.modules) as sys_modules, patch("builtins.__import__", import_mock("httpx")):
+        # Need to clean up from previous runs a path that will trigger reimporting httpx
+        for k in list(sys_modules.keys()):
+            if k.startswith("anta."):  # and k != "anta.cli":
+                del sys_modules[k]
+        import anta.cli
+
+        with pytest.raises(ImportError, match="httpx"):
+            anta.cli.cli()


### PR DESCRIPTION
# Description

* remove click-color-helper that is not used!
* raise the `anta[cli]` error message only if click is missing

Fixes #1099 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
