### PR TITLE
feat(anta.tests): VerifyLoggingErrors failure message should include the error logs

### DIFF
--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -433,7 +433,7 @@ class VerifyLoggingErrors(AntaTest):
         if len(command_output) == 0:
             self.result.is_success()
         else:
-            self.result.is_failure(f"Device has reported syslog messages at threshold level or above:\n{command_output}")
+            self.result.is_failure(f"Device has reported syslog messages with a severity of ERRORS or higher:\n{command_output}")
 
 
 class VerifyLoggingEntries(AntaTest):

--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -433,7 +433,7 @@ class VerifyLoggingErrors(AntaTest):
         if len(command_output) == 0:
             self.result.is_success()
         else:
-            self.result.is_failure("Device has reported syslog messages with a severity of ERRORS or higher")
+            self.result.is_failure(f"Device has reported syslog messages at threshold level or above:\n{command_output}")
 
 
 class VerifyLoggingEntries(AntaTest):

--- a/tests/units/anta_tests/test_logging.py
+++ b/tests/units/anta_tests/test_logging.py
@@ -277,7 +277,14 @@ DATA: list[dict[str, Any]] = [
             "Aug  2 19:57:42 DC1-LEAF1A Mlag: %FWK-3-SOCKET_CLOSE_REMOTE: Connection to Mlag (pid:27200) at tbt://192.168.0.1:4432/+n closed by peer (EOF)",
         ],
         "inputs": None,
-        "expected": {"result": "failure", "messages": ["Device has reported syslog messages with a severity of ERRORS or higher"]},
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Device has reported syslog messages at threshold level or above:\n"
+                "Aug  2 19:57:42 DC1-LEAF1A Mlag: %FWK-3-SOCKET_CLOSE_REMOTE: Connection to Mlag "
+                "(pid:27200) at tbt://192.168.0.1:4432/+n closed by peer (EOF)"
+            ]
+        },
     },
     {
         "name": "success",

--- a/tests/units/anta_tests/test_logging.py
+++ b/tests/units/anta_tests/test_logging.py
@@ -280,10 +280,10 @@ DATA: list[dict[str, Any]] = [
         "expected": {
             "result": "failure",
             "messages": [
-                "Device has reported syslog messages at threshold level or above:\n"
+                "Device has reported syslog messages with a severity of ERRORS or higher:\n"
                 "Aug  2 19:57:42 DC1-LEAF1A Mlag: %FWK-3-SOCKET_CLOSE_REMOTE: Connection to Mlag "
                 "(pid:27200) at tbt://192.168.0.1:4432/+n closed by peer (EOF)"
-            ]
+            ],
         },
     },
     {


### PR DESCRIPTION
# Description

VerifyLoggingErrors failure message should include the error logs

Fixes #1139 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)

## Failure message:

<img width="1193" alt="Screenshot 2025-04-08 at 8 23 37 PM" src="https://github.com/user-attachments/assets/9fa41eba-6ab3-4349-b2a3-5a91f2b599ce" />

