### PR TITLE
doc: Update contribution README with notes on quoting and verification path

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -32,6 +32,19 @@ Package Version Editable project location
 anta    1.3.0   /mnt/lab/projects/anta
 ```
 
+!!! info "Installation Note"
+    1. If you are using a terminal such as zsh, ensure that commands involving shell expansions within editable installs (like specifying development dependencies) are enclosed in double quotes. For example: `pip install -e ."[dev]"`
+    2. If you do not see any output when running the verification command (`pip list -e`), it is likely because the command needs to be executed from within the inner `anta` directory. Navigate to this directory and then verify the installation:
+
+     ```
+      $ cd anta/anta
+      # Verify installation
+      $ pip list -e
+      Package Version Editable project location
+      ------- ------- --------------------------
+      anta    1.3.0   /mnt/lab/projects/anta
+     ```
+
 Then, [`tox`](https://tox.wiki/) is configured with few environments to run CI locally:
 
 ```bash


### PR DESCRIPTION

# Description

Updated the contribution readme with the following changes:
1. Added a note to advise users using terminals like zsh to enclose commands in quotes to ensure correct interpretation. This addresses potential issues with how zsh handles certain special characters.

2. Included a note to clarify that the installation verification command (pip list -e) should be run from within the inner anta directory after performing the editable install. This addresses a scenario where users might not see any output if the command is run from the top-level repository directory.

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)
