### PR TITLE
ci: Update pyproject to new license format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ maintainers = [
   { name = "Carl Baillargeon", email = "carl.baillargeon@arista.com" },
 ]
 description = "Arista Network Test Automation (ANTA) Framework"
-license = { file = "LICENSE" }
 dependencies = [
   "asyncssh>=2.16",
   "cvprac>=1.3.1",
@@ -32,8 +31,9 @@ dependencies = [
   "typing_extensions>=4.12"  # required for deprecated before Python 3.13
 ]
 keywords = ["test", "anta", "Arista", "network", "automation", "networking", "devops", "netdevops"]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
# Description

cf https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license + deprecation warnings when running build