### PR TITLE
feat(anta_tests): VerifyBGPAdvCommunities support a combination of communities

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -419,3 +419,4 @@ ReloadCause = Annotated[
     Literal["System reloaded due to Zero Touch Provisioning", "Reload requested by the user.", "Reload requested after FPGA upgrade", "USER", "FPGA", "ZTP"],
     BeforeValidator(convert_reload_cause),
 ]
+BGPCommunity = Literal["standard", "extended", "large"]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -419,4 +419,4 @@ ReloadCause = Annotated[
     Literal["System reloaded due to Zero Touch Provisioning", "Reload requested by the user.", "Reload requested after FPGA upgrade", "USER", "FPGA", "ZTP"],
     BeforeValidator(convert_reload_cause),
 ]
-BGPCommunity = Literal["standard", "extended", "large"]
+BgpCommunity = Literal["standard", "extended", "large"]

--- a/anta/input_models/routing/bgp.py
+++ b/anta/input_models/routing/bgp.py
@@ -12,7 +12,7 @@ from warnings import warn
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 from pydantic_extra_types.mac_address import MacAddress
 
-from anta.custom_types import Afi, BgpDropStats, BgpUpdateError, MultiProtocolCaps, RedistributedAfiSafi, RedistributedProtocol, Safi, Vni
+from anta.custom_types import Afi, BGPCommunity, BgpDropStats, BgpUpdateError, MultiProtocolCaps, RedistributedAfiSafi, RedistributedProtocol, Safi, Vni
 
 if TYPE_CHECKING:
     import sys
@@ -196,6 +196,10 @@ class BgpPeer(BaseModel):
     """The Time-To-Live (TTL). Required field in the `VerifyBGPPeerTtlMultiHops` test."""
     max_ttl_hops: int | None = Field(default=None, ge=1, le=255)
     """The Max TTL hops. Required field in the `VerifyBGPPeerTtlMultiHops` test."""
+    advertised_communities: list[BGPCommunity] = Field(default=["standard", "extended", "large"])
+    """List of advertised communities to be verified.
+
+    Optional field in the `VerifyBGPAdvCommunities` test. If not provided, the test will verifies all the advertised communities."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the BgpPeer for reporting."""

--- a/anta/input_models/routing/bgp.py
+++ b/anta/input_models/routing/bgp.py
@@ -12,7 +12,7 @@ from warnings import warn
 from pydantic import BaseModel, ConfigDict, Field, PositiveInt, model_validator
 from pydantic_extra_types.mac_address import MacAddress
 
-from anta.custom_types import Afi, BGPCommunity, BgpDropStats, BgpUpdateError, MultiProtocolCaps, RedistributedAfiSafi, RedistributedProtocol, Safi, Vni
+from anta.custom_types import Afi, BgpCommunity, BgpDropStats, BgpUpdateError, MultiProtocolCaps, RedistributedAfiSafi, RedistributedProtocol, Safi, Vni
 
 if TYPE_CHECKING:
     import sys
@@ -196,10 +196,10 @@ class BgpPeer(BaseModel):
     """The Time-To-Live (TTL). Required field in the `VerifyBGPPeerTtlMultiHops` test."""
     max_ttl_hops: int | None = Field(default=None, ge=1, le=255)
     """The Max TTL hops. Required field in the `VerifyBGPPeerTtlMultiHops` test."""
-    advertised_communities: list[BGPCommunity] = Field(default=["standard", "extended", "large"])
+    advertised_communities: list[BgpCommunity] = Field(default=["standard", "extended", "large"])
     """List of advertised communities to be verified.
 
-    Optional field in the `VerifyBGPAdvCommunities` test. If not provided, the test will verifies all the advertised communities."""
+    Optional field in the `VerifyBGPAdvCommunities` test. If not provided, the test will verify that all communities are advertised."""
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the BgpPeer for reporting."""

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -926,19 +926,16 @@ class VerifyBGPAdvCommunities(AntaTest):
     This test performs the following checks for each specified peer:
 
       1. Verifies that the peer is found in its VRF in the BGP configuration.
-      2. Validates that all required community types are advertised:
-        - Standard communities
-        - Extended communities
-        - Large communities
+      2. Validates that given community types are advertised. If not provided, validates all the advertised communities.
 
     Expected Results
     ----------------
     * Success: If all of the following conditions are met:
         - All specified peers are found in the BGP configuration.
-        - Each peer advertises standard, extended and large communities.
+        - Each peer adverties the given community types. If not provided, advertises standard, extended and large communities.
     * Failure: If any of the following occur:
         - A specified peer is not found in the BGP configuration.
-        - A peer does not advertise standard, extended or large communities.
+        - A peer does not advertise the given community types. If not provided, does not advertises standard, extended and large communities.
 
     Examples
     --------
@@ -951,6 +948,7 @@ class VerifyBGPAdvCommunities(AntaTest):
                 vrf: default
               - peer_address: 172.30.11.21
                 vrf: default
+                advertised_communities: ["standard", "extended"]
     ```
     """
 
@@ -981,7 +979,7 @@ class VerifyBGPAdvCommunities(AntaTest):
                 continue
 
             # Check BGP peer advertised communities
-            if not all(get_value(peer_data, f"advertisedCommunities.{community}") is True for community in ["standard", "extended", "large"]):
+            if not all(get_value(peer_data, f"advertisedCommunities.{community}") is True for community in peer.advertised_communities):
                 self.result.is_failure(f"{peer} - {format_data(peer_data['advertisedCommunities'])}")
 
 

--- a/anta/tests/routing/bgp.py
+++ b/anta/tests/routing/bgp.py
@@ -921,21 +921,21 @@ class VerifyEVPNType2Route(AntaTest):
 
 
 class VerifyBGPAdvCommunities(AntaTest):
-    """Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s).
+    """Verifies the advertised communities for BGP IPv4 peer(s).
 
     This test performs the following checks for each specified peer:
 
       1. Verifies that the peer is found in its VRF in the BGP configuration.
-      2. Validates that given community types are advertised. If not provided, validates all the advertised communities.
+      2. Validates that given community types are advertised. If not provided, validates that all communities (standard, extended, large) are advertised.
 
     Expected Results
     ----------------
     * Success: If all of the following conditions are met:
         - All specified peers are found in the BGP configuration.
-        - Each peer adverties the given community types. If not provided, advertises standard, extended and large communities.
+        - Each peer advertises the given community types.
     * Failure: If any of the following occur:
         - A specified peer is not found in the BGP configuration.
-        - A peer does not advertise the given community types. If not provided, does not advertises standard, extended and large communities.
+        - A peer does not advertise any of the given community types.
 
     Examples
     --------

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -387,7 +387,7 @@ anta.tests.ptp:
       # Verifies the PTP interfaces state.
 anta.tests.routing.bgp:
   - VerifyBGPAdvCommunities:
-      # Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s).
+      # Verifies the advertised communities for BGP IPv4 peer(s).
       bgp_peers:
         - peer_address: 172.30.11.17
           vrf: default

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -393,6 +393,7 @@ anta.tests.routing.bgp:
           vrf: default
         - peer_address: 172.30.11.21
           vrf: default
+          advertised_communities: ["standard", "extended"]
   - VerifyBGPExchangedRoutes:
       # Verifies the advertised and received routes of BGP IPv4 peer(s).
       bgp_peers:

--- a/tests/units/anta_tests/routing/test_bgp.py
+++ b/tests/units/anta_tests/routing/test_bgp.py
@@ -3199,6 +3199,47 @@ DATA: list[dict[str, Any]] = [
         "expected": {"result": "success"},
     },
     {
+        "name": "success-specified-communities",
+        "test": VerifyBGPAdvCommunities,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "peerList": [
+                            {
+                                "peerAddress": "172.30.11.1",
+                                "advertisedCommunities": {
+                                    "standard": True,
+                                    "extended": True,
+                                    "large": False,
+                                },
+                            }
+                        ]
+                    },
+                    "MGMT": {
+                        "peerList": [
+                            {
+                                "peerAddress": "172.30.11.10",
+                                "advertisedCommunities": {
+                                    "standard": False,
+                                    "extended": True,
+                                    "large": False,
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {"peer_address": "172.30.11.1", "advertised_communities": ["standard", "extended"]},
+                {"peer_address": "172.30.11.10", "vrf": "MGMT", "advertised_communities": ["extended"]},
+            ]
+        },
+        "expected": {"result": "success"},
+    },
+    {
         "name": "failure-no-peer",
         "test": VerifyBGPAdvCommunities,
         "eos_data": [
@@ -3301,6 +3342,52 @@ DATA: list[dict[str, Any]] = [
             "messages": [
                 "Peer: 172.30.11.1 VRF: default - Standard: False, Extended: False, Large: False",
                 "Peer: 172.30.11.10 VRF: CS - Standard: True, Extended: True, Large: False",
+            ],
+        },
+    },
+    {
+        "name": "failure-specified-communities",
+        "test": VerifyBGPAdvCommunities,
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "peerList": [
+                            {
+                                "peerAddress": "172.30.11.1",
+                                "advertisedCommunities": {
+                                    "standard": False,
+                                    "extended": False,
+                                    "large": False,
+                                },
+                            }
+                        ]
+                    },
+                    "MGMT": {
+                        "peerList": [
+                            {
+                                "peerAddress": "172.30.11.10",
+                                "advertisedCommunities": {
+                                    "standard": False,
+                                    "extended": True,
+                                    "large": False,
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "bgp_peers": [
+                {"peer_address": "172.30.11.1", "advertised_communities": ["standard", "extended"]},
+                {"peer_address": "172.30.11.10", "vrf": "MGMT", "advertised_communities": ["extended"]},
+            ]
+        },
+        "expected": {
+            "result": "failure",
+            "messages": [
+                "Peer: 172.30.11.1 VRF: default - Standard: False, Extended: False, Large: False",
             ],
         },
     },


### PR DESCRIPTION
# Description

Extend BgpPeer model to support an optional list of communities and check against those instead of all.

advertised_communities: list[Community] = Field(default=["standard', "extended', "large"

Fixes #1173 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
