### PR TITLE
doc(anta): fixed the invalid catalog due to evpn-type-5 docstring

### DIFF
--- a/anta/tests/evpn.py
+++ b/anta/tests/evpn.py
@@ -56,15 +56,15 @@ class VerifyEVPNType5Routes(AntaTest):
             - address: 192.168.20.0/24
               vni: 20
               routes:
-                - rd: 10.0.0.1:20
+                - rd: "10.0.0.1:20"
                   domain: local
-                - rd: 10.0.0.2:20
+                - rd: "10.0.0.2:20"
                   domain: remote
             # At least one active/valid path matching the nexthop
             - address: 192.168.30.0/24
               vni: 30
               routes:
-                - rd: 10.0.0.1:30
+                - rd: "10.0.0.1:30"
                   domain: local
                   paths:
                     - nexthop: 10.1.1.1
@@ -72,12 +72,12 @@ class VerifyEVPNType5Routes(AntaTest):
             - address: 192.168.40.0/24
               vni: 40
               routes:
-                - rd: 10.0.0.1:40
+                - rd: "10.0.0.1:40"
                   domain: local
                   paths:
                     - nexthop: 10.1.1.1
                       route_targets:
-                        - 40:40
+                        - "40:40"
     ```
     """
 

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -172,15 +172,15 @@ anta.tests.evpn:
         - address: 192.168.20.0/24
           vni: 20
           routes:
-            - rd: 10.0.0.1:20
+            - rd: "10.0.0.1:20"
               domain: local
-            - rd: 10.0.0.2:20
+            - rd: "10.0.0.2:20"
               domain: remote
         # At least one active/valid path matching the nexthop
         - address: 192.168.30.0/24
           vni: 30
           routes:
-            - rd: 10.0.0.1:30
+            - rd: "10.0.0.1:30"
               domain: local
               paths:
                 - nexthop: 10.1.1.1
@@ -188,12 +188,12 @@ anta.tests.evpn:
         - address: 192.168.40.0/24
           vni: 40
           routes:
-            - rd: 10.0.0.1:40
+            - rd: "10.0.0.1:40"
               domain: local
               paths:
                 - nexthop: 10.1.1.1
                   route_targets:
-                    - 40:40
+                    - "40:40"
 anta.tests.field_notices:
   - VerifyFieldNotice44Resolution:
       # Verifies that the device is using the correct Aboot version per FN0044.


### PR DESCRIPTION
# Description

```
CRITICAL Test catalog is invalid! (from examples/tests.yaml)                                                                 logger.py:151
                    ValidationError: 1 validation error for AntaCatalogFile                                                                          
                    inputs                                                                                                                           
                      VerifyEVPNType5Routes test inputs are not valid: 1 validation error for Input                                                  
                            prefixes.3.routes.0.paths.0.route_targets.0                                                                              
                              Input should be a valid string
```

