### PR TITLE
refactor(anta): Special characters from failure messages should be escaped properly in Markdown

### DIFF
--- a/anta/reporter/md_reporter.py
+++ b/anta/reporter/md_reporter.py
@@ -139,10 +139,7 @@ class MDReportBase(ABC):
             return ""
 
         # Replace newlines with <br> to preserve line breaks in HTML
-        text = text.replace("\n", "<br>")
-
-        # Replace backticks with single quotes
-        return text.replace("`", "'")
+        return text.replace("\n", "<br>")
 
 
 class ANTAReport(MDReportBase):

--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -450,10 +450,10 @@ class VerifyLoggingEntries(AntaTest):
     anta.tests.logging:
       - VerifyLoggingEntries:
           logging_entries:
-            - regex_match: ".ACCOUNTING-5-EXEC: cvpadmin ssh."
+            - regex_match: ".*ACCOUNTING-5-EXEC: cvpadmin ssh.*"
               last_number_messages: 30
               severity_level: alerts
-            - regex_match: ".SPANTREE-6-INTERFACE_ADD:."
+            - regex_match: ".*SPANTREE-6-INTERFACE_ADD:.*"
               last_number_messages: 10
               severity_level: critical
     ```
@@ -482,5 +482,5 @@ class VerifyLoggingEntries(AntaTest):
             output = command_output.text_output
             if not re.search(logging_entry.regex_match, output):
                 self.result.is_failure(
-                    f"Pattern: {logging_entry.regex_match} - Not found in last {logging_entry.last_number_messages} {logging_entry.severity_level} log entries"
+                    f"Pattern: `{logging_entry.regex_match}` - Not found in last {logging_entry.last_number_messages} {logging_entry.severity_level} log entries"
                 )

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -329,10 +329,10 @@ anta.tests.logging:
   - VerifyLoggingEntries:
       # Verifies that the expected log string is present in the last specified log messages.
       logging_entries:
-        - regex_match: ".ACCOUNTING-5-EXEC: cvpadmin ssh."
+        - regex_match: ".*ACCOUNTING-5-EXEC: cvpadmin ssh.*"
           last_number_messages: 30
           severity_level: alerts
-        - regex_match: ".SPANTREE-6-INTERFACE_ADD:."
+        - regex_match: ".*SPANTREE-6-INTERFACE_ADD:.*"
           last_number_messages: 10
           severity_level: critical
   - VerifyLoggingErrors:

--- a/tests/data/test_md_report.md
+++ b/tests/data/test_md_report.md
@@ -15,78 +15,233 @@
 
 | Total Tests | Total Tests Success | Total Tests Skipped | Total Tests Failure | Total Tests Error |
 | ----------- | ------------------- | ------------------- | ------------------- | ------------------|
-| 30 | 4 | 9 | 15 | 2 |
+| 181 | 43 | 34 | 103 | 1 |
 
 ### Summary Totals Device Under Test
 
 | Device Under Test | Total Tests | Tests Success | Tests Skipped | Tests Failure | Tests Error | Categories Skipped | Categories Failed |
 | ------------------| ----------- | ------------- | ------------- | ------------- | ----------- | -------------------| ------------------|
-| s1-spine1 | 30 | 4 | 9 | 15 | 2 | AVT, Field Notices, Hardware, ISIS, LANZ, OSPF, PTP, Path-Selection, Profiles | AAA, BFD, BGP, Connectivity, Cvx, Interfaces, Logging, MLAG, SNMP, STUN, Security, Services, Software, System, VLAN |
+| s1-spine1 | 181 | 43 | 34 | 103 | 1 | AVT, Field Notices, Flow Tracking, Hardware, ISIS, Interfaces, LANZ, OSPF, PTP, Path-Selection, Profiles, Segment-Routing | AAA, BFD, BGP, Configuration, Connectivity, Cvx, Greent, Interfaces, Logging, MLAG, Multicast, Routing, SNMP, STP, STUN, Security, Services, Software, VLAN, VXLAN |
 
 ### Summary Totals Per Category
 
 | Test Category | Total Tests | Tests Success | Tests Skipped | Tests Failure | Tests Error |
 | ------------- | ----------- | ------------- | ------------- | ------------- | ----------- |
-| AAA | 1 | 0 | 0 | 1 | 0 |
-| AVT | 1 | 0 | 1 | 0 | 0 |
-| BFD | 1 | 0 | 0 | 1 | 0 |
-| BGP | 1 | 0 | 0 | 0 | 1 |
-| Configuration | 1 | 1 | 0 | 0 | 0 |
-| Connectivity | 1 | 0 | 0 | 1 | 0 |
-| Cvx | 1 | 0 | 0 | 0 | 1 |
-| Field Notices | 1 | 0 | 1 | 0 | 0 |
-| Hardware | 1 | 0 | 1 | 0 | 0 |
-| Interfaces | 1 | 0 | 0 | 1 | 0 |
-| ISIS | 1 | 0 | 1 | 0 | 0 |
+| AAA | 7 | 0 | 0 | 7 | 0 |
+| AVT | 3 | 0 | 3 | 0 | 0 |
+| BFD | 4 | 1 | 0 | 3 | 0 |
+| BGP | 25 | 3 | 0 | 21 | 1 |
+| Configuration | 3 | 1 | 0 | 2 | 0 |
+| Connectivity | 2 | 1 | 0 | 1 | 0 |
+| Cvx | 5 | 0 | 0 | 5 | 0 |
+| Field Notices | 2 | 0 | 2 | 0 | 0 |
+| Flow Tracking | 1 | 0 | 1 | 0 | 0 |
+| Greent | 2 | 0 | 0 | 2 | 0 |
+| Hardware | 7 | 0 | 7 | 0 | 0 |
+| Interfaces | 16 | 7 | 1 | 8 | 0 |
+| ISIS | 7 | 0 | 7 | 0 | 0 |
 | LANZ | 1 | 0 | 1 | 0 | 0 |
-| Logging | 1 | 0 | 0 | 1 | 0 |
-| MLAG | 1 | 0 | 0 | 1 | 0 |
-| OSPF | 1 | 0 | 1 | 0 | 0 |
-| Path-Selection | 1 | 0 | 1 | 0 | 0 |
-| Profiles | 1 | 0 | 1 | 0 | 0 |
-| PTP | 1 | 0 | 1 | 0 | 0 |
-| Routing | 1 | 1 | 0 | 0 | 0 |
-| Security | 2 | 0 | 0 | 2 | 0 |
-| Services | 1 | 0 | 0 | 1 | 0 |
-| SNMP | 1 | 0 | 0 | 1 | 0 |
-| Software | 1 | 0 | 0 | 1 | 0 |
-| STP | 1 | 1 | 0 | 0 | 0 |
-| STUN | 2 | 0 | 0 | 2 | 0 |
-| System | 1 | 0 | 0 | 1 | 0 |
-| VLAN | 1 | 0 | 0 | 1 | 0 |
-| VXLAN | 1 | 1 | 0 | 0 | 0 |
+| Logging | 10 | 3 | 0 | 7 | 0 |
+| MLAG | 6 | 4 | 0 | 2 | 0 |
+| Multicast | 2 | 1 | 0 | 1 | 0 |
+| OSPF | 3 | 0 | 3 | 0 | 0 |
+| Path-Selection | 2 | 0 | 2 | 0 | 0 |
+| Profiles | 2 | 0 | 2 | 0 | 0 |
+| PTP | 5 | 0 | 5 | 0 | 0 |
+| Routing | 6 | 2 | 0 | 4 | 0 |
+| Security | 15 | 3 | 0 | 12 | 0 |
+| Segment-Routing | 3 | 0 | 3 | 0 | 0 |
+| Services | 4 | 1 | 0 | 3 | 0 |
+| SNMP | 12 | 0 | 0 | 12 | 0 |
+| Software | 3 | 1 | 0 | 2 | 0 |
+| STP | 7 | 4 | 0 | 3 | 0 |
+| STUN | 3 | 0 | 0 | 3 | 0 |
+| System | 8 | 8 | 0 | 0 | 0 |
+| VLAN | 3 | 0 | 0 | 3 | 0 |
+| VXLAN | 5 | 3 | 0 | 2 | 0 |
 
 ## Test Results
 
 | Device Under Test | Categories | Test | Description | Custom Field | Result | Messages |
 | ----------------- | ---------- | ---- | ----------- | ------------ | ------ | -------- |
 | s1-spine1 | AAA | VerifyAcctConsoleMethods | Verifies the AAA accounting console method lists for different accounting types (system, exec, commands, dot1x). | - | failure | AAA console accounting is not configured for commands, exec, system, dot1x |
-| s1-spine1 | AVT | VerifyAVTPathHealth | Verifies the status of all AVT paths for all VRFs. | - | skipped | VerifyAVTPathHealth test is not supported on cEOSLab. |
-| s1-spine1 | BFD | VerifyBFDPeersHealth | Verifies the health of IPv4 BFD peers across all VRFs. | - | failure | No IPv4 BFD peers are configured for any VRF. |
-| s1-spine1 | BGP | VerifyBGPAdvCommunities | Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s). | - | error | show bgp neighbors vrf all has failed: The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model. |
-| s1-spine1 | Configuration | VerifyRunningConfigDiffs | Verifies there is no difference between the running-config and the startup-config. | - | success | - |
+| s1-spine1 | AAA | VerifyAcctDefaultMethods | Verifies the AAA accounting default method lists for different accounting types (system, exec, commands, dot1x). | - | failure | AAA default accounting is not configured for commands, exec, system, dot1x |
+| s1-spine1 | AAA | VerifyAuthenMethods | Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x). | - | failure | AAA authentication methods are not configured for login console |
+| s1-spine1 | AAA | VerifyAuthzMethods | Verifies the AAA authorization method lists for different authorization types (commands, exec). | - | failure | AAA authorization methods local, none, logging are not matching for commands, exec |
+| s1-spine1 | AAA | VerifyTacacsServerGroups | Verifies if the provided TACACS server group(s) are configured. | - | failure | No TACACS server group(s) are configured |
+| s1-spine1 | AAA | VerifyTacacsServers | Verifies TACACS servers are configured for a specified VRF. | - | failure | No TACACS servers are configured |
+| s1-spine1 | AAA | VerifyTacacsSourceIntf | Verifies TACACS source-interface for a specified VRF. | - | failure | VRF: MGMT Source Interface: Management0 - Not configured |
+| s1-spine1 | AVT | VerifyAVTPathHealth | Verifies the status of all AVT paths for all VRFs. | - | skipped | VerifyAVTPathHealth test is not supported on cEOSLab |
+| s1-spine1 | AVT | VerifyAVTRole | Verifies the AVT role of a device. | - | skipped | VerifyAVTRole test is not supported on cEOSLab |
+| s1-spine1 | AVT | VerifyAVTSpecificPath | Verifies the Adaptive Virtual Topology (AVT) path. | - | skipped | VerifyAVTSpecificPath test is not supported on cEOSLab |
+| s1-spine1 | BFD | VerifyBFDPeersHealth | Verifies the health of IPv4 BFD peers across all VRFs. | - | success | - |
+| s1-spine1 | BFD | VerifyBFDPeersIntervals | Verifies the timers of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.8 VRF: default - Not found<br>Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BFD | VerifyBFDPeersRegProtocols | Verifies the registered routing protocol of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BFD | VerifyBFDSpecificPeers | Verifies the state of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.8 VRF: default - Not found<br>Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPAdvCommunities | Verifies the advertised communities of BGP peers. | - | failure | Peer: 172.30.11.17 VRF: default - Not found<br>Peer: 172.30.11.21 VRF: MGMT - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPExchangedRoutes | Verifies the advertised and received routes of BGP IPv4 peer(s). | - | failure | Peer: 172.30.255.5 VRF: default Advertised route: 192.0.254.5/32 - Not found<br>Peer: 172.30.255.5 VRF: default Received route: 192.0.255.4/32 - Not found<br>Peer: 172.30.255.1 VRF: default Advertised route: 192.0.255.1/32 - Not found<br>Peer: 172.30.255.1 VRF: default Advertised route: 192.0.254.5/32 - Not found |
+| s1-spine1 | BGP | VerifyBGPNlriAcceptance | Verifies that all received NLRI are accepted for all AFI/SAFI configured for BGP peers. | - | failure | Peer: 10.100.0.128 VRF: default - Not found<br>Peer: 2001:db8:1::2 VRF: default - Not found<br>Peer: fe80::2%Et1 VRF: default - Not found<br>Peer: fe80::2%Et1 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerASNCap | Verifies the four octet ASN capability of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerCount | Verifies the count of BGP peers for given address families. | - | failure | AFI: ipv4 SAFI: unicast VRF: PROD - VRF not configured<br>AFI: ipv4 SAFI: multicast VRF: DEV - VRF not configured |
+| s1-spine1 | BGP | VerifyBGPPeerDropStats | Verifies BGP NLRI drop statistics of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerGroup | Verifies BGP peer group of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerMD5Auth | Verifies the MD5 authentication and state of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.5 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: default - Session does not have MD5 authentication enabled |
+| s1-spine1 | BGP | VerifyBGPPeerMPCaps | Verifies the multiprotocol capabilities of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: default - ipv4MplsLabels not found<br>Interface: Ethernet1 VRF: default - ipv4MplsVpn not found |
+| s1-spine1 | BGP | VerifyBGPPeerRouteLimit | Verifies maximum routes and warning limit for BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerRouteRefreshCap | Verifies the route refresh capabilities of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerSession | Verifies the session state of BGP peers. | - | failure | Peer: 10.1.0.1 VRF: default - Not found<br>Peer: 10.1.0.2 VRF: default - Not found<br>Peer: 10.1.255.2 VRF: DEV - Not found<br>Peer: 10.1.255.4 VRF: DEV - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Vlan3499 VRF: PROD - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerSessionRibd | Verifies the session state of BGP peers. | - | failure | Peer: 10.1.0.1 VRF: default - Not found<br>Peer: 10.1.255.4 VRF: DEV - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerTtlMultiHops | Verifies BGP TTL and max-ttl-hops count for BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.2 VRF: test - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerUpdateErrors | Verifies BGP update error counters of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeersHealth | Verifies the health of BGP peers for given address families. | - | failure | AFI: ipv6 SAFI: unicast VRF: DEV - VRF not configured |
+| s1-spine1 | BGP | VerifyBGPPeersHealthRibd | Verifies the health of all the BGP peers. | - | success | - |
+| s1-spine1 | BGP | VerifyBGPRedistribution | Verifies BGP redistribution. | - | error | show bgp instance vrf all has failed: Invalid requested version for ModelMetaClass: no such revision 4, most current is 3 |
+| s1-spine1 | BGP | VerifyBGPRouteECMP | Verifies BGP IPv4 route ECMP paths. | - | success | - |
+| s1-spine1 | BGP | VerifyBGPRoutePaths | Verifies BGP IPv4 route paths. | - | success | - |
+| s1-spine1 | BGP | VerifyBGPSpecificPeers | Verifies the health of specific BGP peer(s) for given address families. | - | failure | AFI: evpn Peer: 10.1.0.1 - Not configured<br>AFI: evpn Peer: 10.1.0.2 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.254.1 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.0 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.2 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.4 - Not configured |
+| s1-spine1 | BGP | VerifyBGPTimers | Verifies the timers of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.5 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBgpRouteMaps | Verifies BGP inbound and outbound route-maps of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyEVPNType2Route | Verifies the EVPN Type-2 routes for a given IPv4 or MAC address and VNI. | - | failure | Address: 192.168.20.102 VNI: 10020 - No EVPN Type-2 route<br>Address: aa:c1:ab:5d:b4:1e VNI: 10010 - No EVPN Type-2 route |
+| s1-spine1 | BGP | VerifyEVPNType5Routes | Verifies EVPN Type-5 routes for given IP prefixes and VNIs. | - | failure | Prefix: 192.168.10.0/24 VNI: 10 - No EVPN Type-5 routes found<br>Prefix: 192.168.20.0/24 VNI: 20 - No EVPN Type-5 routes found<br>Prefix: 192.168.30.0/24 VNI: 30 - No EVPN Type-5 routes found<br>Prefix: 192.168.40.0/24 VNI: 40 - No EVPN Type-5 routes found |
+| s1-spine1 | Configuration | VerifyRunningConfigDiffs | Verifies there is no difference between the running-config and the startup-config. | - | failure | --- flash:/startup-config<br>+++ system:/running-config<br>@@ -18,6 +18,7 @@<br> hostname leaf1-dc1<br> ip name-server vrf MGMT 10.14.0.1<br> dns domain fun.aristanetworks.com<br>+ip host vitthal 192.168.66.220<br> !<br> platform tfa<br>    personality arfa<br> |
+| s1-spine1 | Configuration | VerifyRunningConfigLines | Search the Running-Config for the given RegEx patterns. | - | failure | Following patterns were not found: '^enable password.*$', 'bla bla' |
+| s1-spine1 | Configuration | VerifyZeroTouch | Verifies ZeroTouch is disabled. | - | success | - |
 | s1-spine1 | Connectivity | VerifyLLDPNeighbors | Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors. | - | failure | Port: Ethernet1 Neighbor: DC1-SPINE1 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine1-dc1.fun.aristanetworks.com/Ethernet3<br>Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine2-dc1.fun.aristanetworks.com/Ethernet3 |
-| s1-spine1 | Cvx | VerifyActiveCVXConnections | Verifies the number of active CVX Connections. | - | error | show cvx connections brief has failed: Unavailable command (controller not ready) (at token 2: 'connections') |
-| s1-spine1 | Field Notices | VerifyFieldNotice44Resolution | Verifies that the device is using the correct Aboot version per FN0044. | - | skipped | VerifyFieldNotice44Resolution test is not supported on cEOSLab. |
-| s1-spine1 | Hardware | VerifyTemperature | Verifies if the device temperature is within acceptable limits. | - | skipped | VerifyTemperature test is not supported on cEOSLab. |
+| s1-spine1 | Connectivity | VerifyReachability | Test network reachability to one or many destination IP(s). | - | success | - |
+| s1-spine1 | Cvx | VerifyActiveCVXConnections | Verifies the number of active CVX Connections. | - | failure | 'show cvx connections brief' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'connections') |
+| s1-spine1 | Cvx | VerifyCVXClusterStatus | Verifies the CVX Server Cluster status. | - | failure | CVX Server status is not enabled<br>CVX Server is not a cluster |
+| s1-spine1 | Cvx | VerifyManagementCVX | Verifies the management CVX global status. | - | failure | Management CVX status is not valid: Expected: enabled Actual: disabled |
+| s1-spine1 | Cvx | VerifyMcsClientMounts | Verify if all MCS client mounts are in mountStateMountComplete. | - | failure | MCS Client mount states are not present |
+| s1-spine1 | Cvx | VerifyMcsServerMounts | Verify if all MCS server mounts are in a MountComplete state. | - | failure | 'show cvx mounts' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'mounts') |
+| s1-spine1 | Field Notices | VerifyFieldNotice44Resolution | Verifies that the device is using the correct Aboot version per FN0044. | - | skipped | VerifyFieldNotice44Resolution test is not supported on cEOSLab |
+| s1-spine1 | Field Notices | VerifyFieldNotice72Resolution | Verifies if the device is exposed to FN0072, and if the issue has been mitigated. | - | skipped | VerifyFieldNotice72Resolution test is not supported on cEOSLab |
+| s1-spine1 | Flow Tracking | VerifyHardwareFlowTrackerStatus | Verifies the hardware flow tracking state. | - | skipped | VerifyHardwareFlowTrackerStatus test is not supported on cEOSLab |
+| s1-spine1 | Greent | VerifyGreenT | Verifies if a GreenT policy other than the default is created. | - | failure | No GreenT policy is created |
+| s1-spine1 | Greent | VerifyGreenTCounters | Verifies if the GreenT counters are incremented. | - | failure | GreenT counters are not incremented |
+| s1-spine1 | Hardware | VerifyAdverseDrops | Verifies there are no adverse drops on DCS-7280 and DCS-7500 family switches. | - | skipped | VerifyAdverseDrops test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyEnvironmentCooling | Verifies the status of power supply fans and all fan trays. | - | skipped | VerifyEnvironmentCooling test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyEnvironmentPower | Verifies the power supplies status. | - | skipped | VerifyEnvironmentPower test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyEnvironmentSystemCooling | Verifies the device's system cooling status. | - | skipped | VerifyEnvironmentSystemCooling test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyTemperature | Verifies if the device temperature is within acceptable limits. | - | skipped | VerifyTemperature test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyTransceiversManufacturers | Verifies if all the transceivers come from approved manufacturers. | - | skipped | VerifyTransceiversManufacturers test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyTransceiversTemperature | Verifies if all the transceivers are operating at an acceptable temperature. | - | skipped | VerifyTransceiversTemperature test is not supported on cEOSLab |
 | s1-spine1 | Interfaces | VerifyIPProxyARP | Verifies if Proxy ARP is enabled. | - | failure | Interface: Ethernet1 - Proxy-ARP disabled<br>Interface: Ethernet2 - Proxy-ARP disabled |
-| s1-spine1 | ISIS | VerifyISISNeighborState | Verifies the health of IS-IS neighbors. | custom | skipped | IS-IS not configured |
-| s1-spine1 | LANZ | VerifyLANZ | Verifies if LANZ is enabled. | - | skipped | VerifyLANZ test is not supported on cEOSLab. |
+| s1-spine1 | Interfaces | VerifyIllegalLACP | Verifies there are no illegal LACP packets in all port channels. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfaceErrDisabled | Verifies there are no interfaces in the errdisabled state. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfaceErrors | Verifies that the interfaces error counters are equal to zero. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfaceIPv4 | Verifies the interface IPv4 addresses. | - | failure | Interface: Ethernet2 - IP address mismatch - Expected: 172.30.11.1/31 Actual: 10.100.0.11/31<br>Interface: Ethernet2 - Secondary IP address is not configured |
+| s1-spine1 | Interfaces | VerifyInterfaceUtilization | Verifies that the utilization of interfaces is below a certain threshold. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfacesSpeed | Verifies the speed, lanes, auto-negotiation status, and mode as full duplex for interfaces. | - | failure | Interface: Ethernet2 - Bandwidth mismatch - Expected: 10.0Gbps Actual: 1Gbps<br>Interface: Ethernet3 - Bandwidth mismatch - Expected: 100.0Gbps Actual: 1Gbps<br>Interface: Ethernet3 - Auto-negotiation mismatch - Expected: success Actual: unknown<br>Interface: Ethernet3 - Data lanes count mismatch - Expected: 1 Actual: 0<br>Interface: Ethernet2 - Bandwidth mismatch - Expected: 2.5Gbps Actual: 1Gbps |
+| s1-spine1 | Interfaces | VerifyInterfacesStatus | Verifies the operational states of specified interfaces to ensure they match expected configurations. | interface | failure | Port-Channel100 - Not configured<br>Ethernet49/1 - Not configured |
+| s1-spine1 | Interfaces | VerifyIpVirtualRouterMac | Verifies the IP virtual router MAC address. | - | success | - |
+| s1-spine1 | Interfaces | VerifyL2MTU | Verifies the global L2 MTU of all L2 interfaces. | - | failure | Interface: Ethernet3 - Incorrect MTU configured - Expected: 1500 Actual: 9214<br>Interface: Port-Channel5 - Incorrect MTU configured - Expected: 1500 Actual: 9214 |
+| s1-spine1 | Interfaces | VerifyL3MTU | Verifies the global L3 MTU of all L3 interfaces. | - | failure | Interface: Ethernet2 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Ethernet1 - Incorrect MTU - Expected: 2500 Actual: 9214<br>Interface: Loopback0 - Incorrect MTU - Expected: 1500 Actual: 65535<br>Interface: Loopback1 - Incorrect MTU - Expected: 1500 Actual: 65535<br>Interface: Vlan1006 - Incorrect MTU - Expected: 1500 Actual: 9164<br>Interface: Vlan1199 - Incorrect MTU - Expected: 1500 Actual: 9164<br>Interface: Vlan4093 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan4094 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan3019 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan3009 - Incorrect MTU - Expected: 1500 Actual: 9214 |
+| s1-spine1 | Interfaces | VerifyLACPInterfacesStatus | Verifies the Link Aggregation Control Protocol (LACP) status of the interface. | - | failure | Interface: Ethernet1 Port-Channel: Port-Channel100 - Not configured |
+| s1-spine1 | Interfaces | VerifyLoopbackCount | Verifies the number of loopback interfaces and their status. | - | failure | Loopback interface(s) count mismatch: Expected 3 Actual: 2 |
+| s1-spine1 | Interfaces | VerifyPortChannels | Verifies there are no inactive ports in all port channels. | - | success | - |
+| s1-spine1 | Interfaces | VerifySVI | Verifies the status of all SVIs. | - | success | - |
+| s1-spine1 | Interfaces | VerifyStormControlDrops | Verifies there are no interface storm-control drop counters. | - | skipped | VerifyStormControlDrops test is not supported on cEOSLab |
+| s1-spine1 | ISIS | VerifyISISGracefulRestart | Verifies the IS-IS graceful restart feature. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS | VerifyISISInterfaceMode | Verifies IS-IS interfaces are running in the correct mode. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS | VerifyISISNeighborCount | Verifies the number of IS-IS neighbors per interface and level. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS | VerifyISISNeighborState | Verifies the health of IS-IS neighbors. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS, Segment-Routing | VerifyISISSegmentRoutingAdjacencySegments | Verifies IS-IS segment routing adjacency segments. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS, Segment-Routing | VerifyISISSegmentRoutingDataplane | Verifies IS-IS segment routing data-plane configuration. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS, Segment-Routing | VerifyISISSegmentRoutingTunnels | Verify ISIS-SR tunnels computed by device. | - | skipped | IS-IS-SR not configured |
+| s1-spine1 | LANZ | VerifyLANZ | Verifies if LANZ is enabled. | - | skipped | VerifyLANZ test is not supported on cEOSLab |
+| s1-spine1 | Logging | VerifyLoggingAccounting | Verifies if AAA accounting logs are generated. | - | success | - |
+| s1-spine1 | Logging | VerifyLoggingEntries | Verifies that the expected log string is present in the last specified log messages. | - | failure | Pattern: `.*ACCOUNTING-5-EXEC: cvpadmin ssh.*` - Not found in last 30 alerts log entries<br>Pattern: `.*SPANTREE-6-INTERFACE_ADD:.*` - Not found in last 10 critical log entries |
+| s1-spine1 | Logging | VerifyLoggingErrors | Verifies there are no syslog messages with a severity of ERRORS or higher. | - | failure | Device has reported syslog messages with a severity of ERRORS or higher:<br>Apr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF data AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> Apr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> Apr 29 08:01:29 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: received from neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> <br> |
+| s1-spine1 | Logging | VerifyLoggingHostname | Verifies if logs are generated with the device FQDN. | - | failure | Logs are not generated with the device FQDN |
 | s1-spine1 | Logging | VerifyLoggingHosts | Verifies logging hosts (syslog servers) for a specified VRF. | - | failure | Syslog servers 1.1.1.1, 2.2.2.2 are not configured in VRF default |
+| s1-spine1 | Logging | VerifyLoggingLogsGeneration | Verifies if logs are generated. | - | success | - |
+| s1-spine1 | Logging | VerifyLoggingPersistent | Verifies if logging persistent is enabled and logs are saved in flash. | - | failure | Persistent logging is disabled |
+| s1-spine1 | Logging | VerifyLoggingSourceIntf | Verifies logging source-interface for a specified VRF. | - | failure | Source-interface: Management0 VRF: default - Not configured |
+| s1-spine1 | Logging | VerifyLoggingTimestamp | Verifies if logs are generated with the appropriate timestamp. | - | failure | Logs are not generated with the appropriate timestamp format |
+| s1-spine1 | Logging | VerifySyslogLogging | Verifies if syslog logging is enabled. | - | success | - |
+| s1-spine1 | MLAG | VerifyMlagConfigSanity | Verifies there are no MLAG config-sanity inconsistencies. | - | success | - |
 | s1-spine1 | MLAG | VerifyMlagDualPrimary | Verifies the MLAG dual-primary detection parameters. | - | failure | Dual-primary detection is disabled |
-| s1-spine1 | OSPF | VerifyOSPFMaxLSA | Verifies all OSPF instances did not cross the maximum LSA threshold. | - | skipped | No OSPF instance found. |
-| s1-spine1 | Path-Selection | VerifyPathsHealth | Verifies the path and telemetry state of all paths under router path-selection. | - | skipped | VerifyPathsHealth test is not supported on cEOSLab. |
-| s1-spine1 | Profiles | VerifyTcamProfile | Verifies the device TCAM profile. | - | skipped | VerifyTcamProfile test is not supported on cEOSLab. |
-| s1-spine1 | PTP | VerifyPtpGMStatus | Verifies that the device is locked to a valid PTP Grandmaster. | - | skipped | VerifyPtpGMStatus test is not supported on cEOSLab. |
+| s1-spine1 | MLAG | VerifyMlagInterfaces | Verifies there are no inactive or active-partial MLAG ports. | - | success | - |
+| s1-spine1 | MLAG | VerifyMlagPrimaryPriority | Verifies the configuration of the MLAG primary priority. | - | failure | MLAG primary priority mismatch - Expected: 3276 Actual: 32767 |
+| s1-spine1 | MLAG | VerifyMlagReloadDelay | Verifies the reload-delay parameters of the MLAG configuration. | - | success | - |
+| s1-spine1 | MLAG | VerifyMlagStatus | Verifies the health status of the MLAG configuration. | - | success | - |
+| s1-spine1 | Multicast | VerifyIGMPSnoopingGlobal | Verifies the IGMP snooping global status. | - | success | - |
+| s1-spine1 | Multicast | VerifyIGMPSnoopingVlans | Verifies the IGMP snooping status for the provided VLANs. | - | failure | VLAN10 - Incorrect IGMP state - Expected: disabled Actual: enabled<br>Supplied vlan 12 is not present on the device |
+| s1-spine1 | OSPF | VerifyOSPFMaxLSA | Verifies all OSPF instances did not cross the maximum LSA threshold. | - | skipped | OSPF not configured |
+| s1-spine1 | OSPF | VerifyOSPFNeighborCount | Verifies the number of OSPF neighbors in FULL state is the one we expect. | - | skipped | OSPF not configured |
+| s1-spine1 | OSPF | VerifyOSPFNeighborState | Verifies all OSPF neighbors are in FULL state. | - | skipped | OSPF not configured |
+| s1-spine1 | Path-Selection | VerifyPathsHealth | Verifies the path and telemetry state of all paths under router path-selection. | - | skipped | VerifyPathsHealth test is not supported on cEOSLab |
+| s1-spine1 | Path-Selection | VerifySpecificPath | Verifies the DPS path and telemetry state of an IPv4 peer. | - | skipped | VerifySpecificPath test is not supported on cEOSLab |
+| s1-spine1 | Profiles | VerifyTcamProfile | Verifies the device TCAM profile. | - | skipped | VerifyTcamProfile test is not supported on cEOSLab |
+| s1-spine1 | Profiles | VerifyUnifiedForwardingTableMode | Verifies the device is using the expected UFT mode. | - | skipped | VerifyUnifiedForwardingTableMode test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpGMStatus | Verifies that the device is locked to a valid PTP Grandmaster. | - | skipped | VerifyPtpGMStatus test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpLockStatus | Verifies that the device was locked to the upstream PTP GM in the last minute. | - | skipped | VerifyPtpLockStatus test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpModeStatus | Verifies that the device is configured as a PTP Boundary Clock. | - | skipped | VerifyPtpModeStatus test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpOffset | Verifies that the PTP timing offset is within +/- 1000ns from the master clock. | - | skipped | VerifyPtpOffset test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpPortModeStatus | Verifies the PTP interfaces state. | - | skipped | VerifyPtpPortModeStatus test is not supported on cEOSLab |
 | s1-spine1 | Routing | VerifyIPv4RouteNextHops | Verifies the next-hops of the IPv4 prefixes. | - | success | - |
-| s1-spine1 | Security | VerifyBannerLogin | Verifies the login banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the login banner, but found '' instead. |
-| s1-spine1 | Security | VerifyBannerMotd | Verifies the motd banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the motd banner, but found '' instead. |
+| s1-spine1 | Routing | VerifyIPv4RouteType | Verifies the route-type of the IPv4 prefixes. | - | failure | Prefix: 10.100.0.12/31 VRF: default - Route not found<br>Prefix: 10.100.1.5/32 VRF: default - Incorrect route type - Expected: iBGP Actual: connected |
+| s1-spine1 | Routing | VerifyRoutingProtocolModel | Verifies the configured routing protocol model. | - | success | - |
+| s1-spine1 | Routing | VerifyRoutingStatus | Verifies the routing status for IPv4/IPv6 unicast, multicast, and IPv6 interfaces (RFC5549). | - | failure | IPv6 unicast routing enabled status mismatch - Expected: True Actual: False |
+| s1-spine1 | Routing | VerifyRoutingTableEntry | Verifies that the provided routes are present in the routing table of a specified VRF. | - | failure | The following route(s) are missing from the routing table of VRF default: 10.1.0.1, 10.1.0.2 |
+| s1-spine1 | Routing | VerifyRoutingTableSize | Verifies the size of the IP routing table of the default VRF. | - | failure | Routing table routes are outside the routes range - Expected: 2 <= to >= 20 Actual: 35 |
+| s1-spine1 | Security | VerifyAPIHttpStatus | Verifies if eAPI HTTP server is disabled globally. | - | success | - |
+| s1-spine1 | Security | VerifyAPIHttpsSSL | Verifies if the eAPI has a valid SSL profile. | - | failure | eAPI HTTPS server SSL profile default is not configured |
+| s1-spine1 | Security | VerifyAPIIPv4Acl | Verifies if eAPI has the right number IPv4 ACL(s) configured for a specified VRF. | - | failure | VRF: default - eAPI IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifyAPIIPv6Acl | Verifies if eAPI has the right number IPv6 ACL(s) configured for a specified VRF. | - | failure | VRF: default - eAPI IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifyAPISSLCertificate | Verifies the eAPI SSL certificate expiry, common subject name, encryption algorithm and key size. | - | success | - |
+| s1-spine1 | Security | VerifyBannerLogin | Verifies the login banner of a device. | - | failure | Login banner is not configured |
+| s1-spine1 | Security | VerifyBannerMotd | Verifies the motd banner of a device. | - | failure | MOTD banner is not configured |
+| s1-spine1 | Security | VerifyHardwareEntropy | Verifies hardware entropy generation is enabled on device. | - | failure | Hardware entropy generation is disabled |
+| s1-spine1 | Security | VerifyIPSecConnHealth | Verifies all IPv4 security connections. | - | failure | No IPv4 security connection configured |
+| s1-spine1 | Security | VerifyIPv4ACL | Verifies the configuration of IPv4 ACLs. | - | failure | ACL name: LabTest - Not configured |
+| s1-spine1 | Security | VerifySSHIPv4Acl | Verifies if the SSHD agent has IPv4 ACL(s) configured. | - | failure | VRF: default - SSH IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifySSHIPv6Acl | Verifies if the SSHD agent has IPv6 ACL(s) configured. | - | failure | VRF: default - SSH IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifySSHStatus | Verifies if the SSHD agent is disabled in the default VRF. | - | failure | SSHD status for Default VRF is enabled |
+| s1-spine1 | Security | VerifySpecificIPSecConn | Verifies the IPv4 security connections. | - | failure | Peer: 10.255.0.1 VRF: default - Not configured<br>Peer: 10.255.0.2 VRF: default - Not configured |
+| s1-spine1 | Security | VerifyTelnetStatus | Verifies if Telnet is disabled in the default VRF. | - | success | - |
+| s1-spine1 | Services | VerifyDNSLookup | Verifies the DNS name to IP address resolution. | - | success | - |
+| s1-spine1 | Services | VerifyDNSServers | Verifies if the DNS (Domain Name Service) servers are correctly configured. | - | failure | Server 10.14.0.1 VRF: default Priority: 1 - Not configured<br>Server 10.14.0.11 VRF: MGMT Priority: 0 - Not configured |
+| s1-spine1 | Services | VerifyErrdisableRecovery | Verifies the error disable recovery functionality. | - | failure | Reason: acl Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300<br>Reason: bpduguard Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300 |
 | s1-spine1 | Services | VerifyHostname | Verifies the hostname of a device. | - | failure | Incorrect Hostname - Expected: s1-spine1 Actual: leaf1-dc1 |
-| s1-spine1 | SNMP | VerifySnmpContact | Verifies the SNMP contact of a device. | - | failure | SNMP contact is not configured. |
+| s1-spine1 | SNMP | VerifySnmpContact | Verifies the SNMP contact of a device. | - | failure | SNMP contact is not configured |
+| s1-spine1 | SNMP | VerifySnmpErrorCounters | Verifies the SNMP error counters. | - | failure | SNMP counters not found |
+| s1-spine1 | SNMP | VerifySnmpGroup | Verifies the SNMP group configurations for specified version(s). | - | failure | Group: Group1 Version: v1 - Not configured<br>Group: Group2 Version: v3 - Not configured |
+| s1-spine1 | SNMP | VerifySnmpHostLogging | Verifies SNMP logging configurations. | - | failure | SNMP logging is disabled |
+| s1-spine1 | SNMP | VerifySnmpIPv4Acl | Verifies if the SNMP agent has IPv4 ACL(s) configured. | - | failure | VRF: default - Incorrect SNMP IPv4 ACL(s) - Expected: 3 Actual: 0 |
+| s1-spine1 | SNMP | VerifySnmpIPv6Acl | Verifies if the SNMP agent has IPv6 ACL(s) configured. | - | failure | VRF: default - Incorrect SNMP IPv6 ACL(s) - Expected: 3 Actual: 0 |
+| s1-spine1 | SNMP | VerifySnmpLocation | Verifies the SNMP location of a device. | - | failure | SNMP location is not configured |
+| s1-spine1 | SNMP | VerifySnmpNotificationHost | Verifies the SNMP notification host(s) (SNMP manager) configurations. | - | failure | No SNMP host is configured |
+| s1-spine1 | SNMP | VerifySnmpPDUCounters | Verifies the SNMP PDU counters. | - | failure | SNMP counters not found |
+| s1-spine1 | SNMP | VerifySnmpSourceInterface | Verifies SNMP source interfaces. | - | failure | SNMP source interface(s) not configured |
+| s1-spine1 | SNMP | VerifySnmpStatus | Verifies if the SNMP agent is enabled. | - | failure | VRF: default - SNMP agent disabled |
+| s1-spine1 | SNMP | VerifySnmpUser | Verifies the SNMP user configurations. | - | failure | User: test Group: test_group Version: v3 - Not found |
+| s1-spine1 | Software | VerifyEOSExtensions | Verifies that all EOS extensions installed on the device are enabled for boot persistence. | - | success | - |
 | s1-spine1 | Software | VerifyEOSVersion | Verifies the EOS version of the device. | - | failure | EOS version mismatch - Actual: 4.31.0F-33804048.4310F (engineering build) not in Expected: 4.25.4M, 4.26.1F |
+| s1-spine1 | Software | VerifyTerminAttrVersion | Verifies the TerminAttr version of the device. | - | failure | TerminAttr version mismatch - Actual: v1.29.0 not in Expected: v1.13.6, v1.8.0 |
 | s1-spine1 | STP | VerifySTPBlockedPorts | Verifies there is no STP blocked ports. | - | success | - |
-| s1-spine1 | STUN | VerifyStunClient | (Deprecated) Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found. |
-| s1-spine1 | STUN | VerifyStunClientTranslation | Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found.<br>Client 100.64.3.2 Port: 4500 - STUN client translation not found. |
-| s1-spine1 | System | VerifyNTPAssociations | Verifies the Network Time Protocol (NTP) associations. | - | failure | NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Not configured<br>NTP Server: 2.2.2.2 Preferred: False Stratum: 2 - Not configured<br>NTP Server: 3.3.3.3 Preferred: False Stratum: 2 - Not configured |
+| s1-spine1 | STP | VerifySTPCounters | Verifies there is no errors in STP BPDU packets. | - | success | - |
+| s1-spine1 | STP | VerifySTPDisabledVlans | Verifies the STP disabled VLAN(s). | - | failure | VLAN: 6 - Not configured |
+| s1-spine1 | STP | VerifySTPForwardingPorts | Verifies that all interfaces are forwarding for a provided list of VLAN(s). | - | success | - |
+| s1-spine1 | STP | VerifySTPMode | Verifies the configured STP mode for a provided list of VLAN(s). | - | failure | VLAN 10 - Incorrect STP mode - Expected: rapidPvst Actual: mstp<br>VLAN 20 - Incorrect STP mode - Expected: rapidPvst Actual: mstp |
+| s1-spine1 | STP | VerifySTPRootPriority | Verifies the STP root priority for a provided list of VLAN or MST instance ID(s). | - | failure | Instance: MST10 - Not configured<br>Instance: MST20 - Not configured |
+| s1-spine1 | STP | VerifyStpTopologyChanges | Verifies the number of changes across all interfaces in the Spanning Tree Protocol (STP) topology is below a threshold. | - | success | - |
+| s1-spine1 | STUN | VerifyStunClient | (Deprecated) Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found |
+| s1-spine1 | STUN | VerifyStunClientTranslation | Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found<br>Client 100.64.3.2 Port: 4500 - STUN client translation not found |
+| s1-spine1 | STUN | VerifyStunServer | Verifies the STUN server status is enabled and running. | - | failure | STUN server status is disabled and not running |
+| s1-spine1 | System | VerifyAgentLogs | Verifies there are no agent crash reports. | - | success | - |
+| s1-spine1 | System | VerifyCPUUtilization | Verifies whether the CPU utilization is below 75%. | - | success | - |
+| s1-spine1 | System | VerifyCoredump | Verifies there are no core dump files. | - | success | - |
+| s1-spine1 | System | VerifyFileSystemUtilization | Verifies that no partition is utilizing more than 75% of its disk space. | - | success | - |
+| s1-spine1 | System | VerifyMaintenance | Verifies that the device is not currently under or entering maintenance. | - | success | - |
+| s1-spine1 | System | VerifyNTP | Verifies if NTP is synchronised. | - | success | - |
+| s1-spine1 | System | VerifyReloadCause | Verifies the last reload cause of the device. | reload-cause | success | - |
+| s1-spine1 | System | VerifyUptime | Verifies the device uptime. | - | success | - |
 | s1-spine1 | VLAN | VerifyDynamicVlanSource | Verifies dynamic VLAN allocation for specified VLAN sources. | - | failure | Dynamic VLAN source(s) exist but have no VLANs allocated: mlagsync |
-| s1-spine1 | VXLAN | VerifyVxlan1ConnSettings | Verifies the interface vxlan1 source interface and UDP port. | - | success | - |
+| s1-spine1 | VLAN | VerifyVlanInternalPolicy | Verifies the VLAN internal allocation policy and the range of VLANs. | - | failure | VLAN internal allocation policy: ascending - Incorrect end VLAN id configured - Expected: 4094 Actual: 1199 |
+| s1-spine1 | VLAN | VerifyVlanStatus | Verifies the administrative status of specified VLANs. | - | failure | VLAN: Vlan10 - Incorrect administrative status - Expected: suspended Actual: active |
+| s1-spine1 | VXLAN | VerifyVxlan1ConnSettings | Verifies Vxlan1 source interface and UDP port. | - | success | - |
+| s1-spine1 | VXLAN | VerifyVxlan1Interface | Verifies the Vxlan1 interface status. | - | success | - |
+| s1-spine1 | VXLAN | VerifyVxlanConfigSanity | Verifies there are no VXLAN config-sanity inconsistencies. | - | success | - |
+| s1-spine1 | VXLAN | VerifyVxlanVniBinding | Verifies the VNI-VLAN, VNI-VRF bindings of the Vxlan1 interface. | - | failure | Interface: Vxlan1 VNI: 500 - Binding not found |
+| s1-spine1 | VXLAN | VerifyVxlanVtep | Verifies Vxlan1 VTEP peers. | - | failure | The following VTEP peer(s) are missing from the Vxlan1 interface: 10.1.1.5, 10.1.1.6<br>Unexpected VTEP peer(s) on Vxlan1 interface: 10.100.2.3 |

--- a/tests/data/test_md_report_custom_sections.md
+++ b/tests/data/test_md_report_custom_sections.md
@@ -15,98 +15,341 @@
 
 | Total Tests | Total Tests Success | Total Tests Skipped | Total Tests Failure | Total Tests Error |
 | ----------- | ------------------- | ------------------- | ------------------- | ------------------|
-| 30 | 4 | 9 | 15 | 2 |
+| 181 | 43 | 34 | 103 | 1 |
 
 ### Summary Totals Device Under Test
 
 | Device Under Test | Total Tests | Tests Success | Tests Skipped | Tests Failure | Tests Error | Categories Skipped | Categories Failed |
 | ------------------| ----------- | ------------- | ------------- | ------------- | ----------- | -------------------| ------------------|
-| s1-spine1 | 30 | 4 | 9 | 15 | 2 | AVT, Field Notices, Hardware, ISIS, LANZ, OSPF, PTP, Path-Selection, Profiles | AAA, BFD, BGP, Connectivity, Cvx, Interfaces, Logging, MLAG, SNMP, STUN, Security, Services, Software, System, VLAN |
+| s1-spine1 | 181 | 43 | 34 | 103 | 1 | AVT, Field Notices, Flow Tracking, Hardware, ISIS, Interfaces, LANZ, OSPF, PTP, Path-Selection, Profiles, Segment-Routing | AAA, BFD, BGP, Configuration, Connectivity, Cvx, Greent, Interfaces, Logging, MLAG, Multicast, Routing, SNMP, STP, STUN, Security, Services, Software, VLAN, VXLAN |
 
 ### Summary Totals Per Category
 
 | Test Category | Total Tests | Tests Success | Tests Skipped | Tests Failure | Tests Error |
 | ------------- | ----------- | ------------- | ------------- | ------------- | ----------- |
-| AAA | 1 | 0 | 0 | 1 | 0 |
-| AVT | 1 | 0 | 1 | 0 | 0 |
-| BFD | 1 | 0 | 0 | 1 | 0 |
-| BGP | 1 | 0 | 0 | 0 | 1 |
-| Configuration | 1 | 1 | 0 | 0 | 0 |
-| Connectivity | 1 | 0 | 0 | 1 | 0 |
-| Cvx | 1 | 0 | 0 | 0 | 1 |
-| Field Notices | 1 | 0 | 1 | 0 | 0 |
-| Hardware | 1 | 0 | 1 | 0 | 0 |
-| Interfaces | 1 | 0 | 0 | 1 | 0 |
-| ISIS | 1 | 0 | 1 | 0 | 0 |
+| AAA | 7 | 0 | 0 | 7 | 0 |
+| AVT | 3 | 0 | 3 | 0 | 0 |
+| BFD | 4 | 1 | 0 | 3 | 0 |
+| BGP | 25 | 3 | 0 | 21 | 1 |
+| Configuration | 3 | 1 | 0 | 2 | 0 |
+| Connectivity | 2 | 1 | 0 | 1 | 0 |
+| Cvx | 5 | 0 | 0 | 5 | 0 |
+| Field Notices | 2 | 0 | 2 | 0 | 0 |
+| Flow Tracking | 1 | 0 | 1 | 0 | 0 |
+| Greent | 2 | 0 | 0 | 2 | 0 |
+| Hardware | 7 | 0 | 7 | 0 | 0 |
+| Interfaces | 16 | 7 | 1 | 8 | 0 |
+| ISIS | 7 | 0 | 7 | 0 | 0 |
 | LANZ | 1 | 0 | 1 | 0 | 0 |
-| Logging | 1 | 0 | 0 | 1 | 0 |
-| MLAG | 1 | 0 | 0 | 1 | 0 |
-| OSPF | 1 | 0 | 1 | 0 | 0 |
-| Path-Selection | 1 | 0 | 1 | 0 | 0 |
-| Profiles | 1 | 0 | 1 | 0 | 0 |
-| PTP | 1 | 0 | 1 | 0 | 0 |
-| Routing | 1 | 1 | 0 | 0 | 0 |
-| Security | 2 | 0 | 0 | 2 | 0 |
-| Services | 1 | 0 | 0 | 1 | 0 |
-| SNMP | 1 | 0 | 0 | 1 | 0 |
-| Software | 1 | 0 | 0 | 1 | 0 |
-| STP | 1 | 1 | 0 | 0 | 0 |
-| STUN | 2 | 0 | 0 | 2 | 0 |
-| System | 1 | 0 | 0 | 1 | 0 |
-| VLAN | 1 | 0 | 0 | 1 | 0 |
-| VXLAN | 1 | 1 | 0 | 0 | 0 |
+| Logging | 10 | 3 | 0 | 7 | 0 |
+| MLAG | 6 | 4 | 0 | 2 | 0 |
+| Multicast | 2 | 1 | 0 | 1 | 0 |
+| OSPF | 3 | 0 | 3 | 0 | 0 |
+| Path-Selection | 2 | 0 | 2 | 0 | 0 |
+| Profiles | 2 | 0 | 2 | 0 | 0 |
+| PTP | 5 | 0 | 5 | 0 | 0 |
+| Routing | 6 | 2 | 0 | 4 | 0 |
+| Security | 15 | 3 | 0 | 12 | 0 |
+| Segment-Routing | 3 | 0 | 3 | 0 | 0 |
+| Services | 4 | 1 | 0 | 3 | 0 |
+| SNMP | 12 | 0 | 0 | 12 | 0 |
+| Software | 3 | 1 | 0 | 2 | 0 |
+| STP | 7 | 4 | 0 | 3 | 0 |
+| STUN | 3 | 0 | 0 | 3 | 0 |
+| System | 8 | 8 | 0 | 0 | 0 |
+| VLAN | 3 | 0 | 0 | 3 | 0 |
+| VXLAN | 5 | 3 | 0 | 2 | 0 |
 
 ## Failed Test Results Summary
 
 | Device Under Test | Categories | Test | Description | Custom Field | Result | Messages |
 | ----------------- | ---------- | ---- | ----------- | ------------ | ------ | -------- |
 | s1-spine1 | AAA | VerifyAcctConsoleMethods | Verifies the AAA accounting console method lists for different accounting types (system, exec, commands, dot1x). | - | failure | AAA console accounting is not configured for commands, exec, system, dot1x |
-| s1-spine1 | BFD | VerifyBFDPeersHealth | Verifies the health of IPv4 BFD peers across all VRFs. | - | failure | No IPv4 BFD peers are configured for any VRF. |
+| s1-spine1 | AAA | VerifyAcctDefaultMethods | Verifies the AAA accounting default method lists for different accounting types (system, exec, commands, dot1x). | - | failure | AAA default accounting is not configured for commands, exec, system, dot1x |
+| s1-spine1 | AAA | VerifyAuthenMethods | Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x). | - | failure | AAA authentication methods are not configured for login console |
+| s1-spine1 | AAA | VerifyAuthzMethods | Verifies the AAA authorization method lists for different authorization types (commands, exec). | - | failure | AAA authorization methods local, none, logging are not matching for commands, exec |
+| s1-spine1 | AAA | VerifyTacacsServerGroups | Verifies if the provided TACACS server group(s) are configured. | - | failure | No TACACS server group(s) are configured |
+| s1-spine1 | AAA | VerifyTacacsServers | Verifies TACACS servers are configured for a specified VRF. | - | failure | No TACACS servers are configured |
+| s1-spine1 | AAA | VerifyTacacsSourceIntf | Verifies TACACS source-interface for a specified VRF. | - | failure | VRF: MGMT Source Interface: Management0 - Not configured |
+| s1-spine1 | BFD | VerifyBFDPeersIntervals | Verifies the timers of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.8 VRF: default - Not found<br>Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BFD | VerifyBFDPeersRegProtocols | Verifies the registered routing protocol of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BFD | VerifyBFDSpecificPeers | Verifies the state of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.8 VRF: default - Not found<br>Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPAdvCommunities | Verifies the advertised communities of BGP peers. | - | failure | Peer: 172.30.11.17 VRF: default - Not found<br>Peer: 172.30.11.21 VRF: MGMT - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPExchangedRoutes | Verifies the advertised and received routes of BGP IPv4 peer(s). | - | failure | Peer: 172.30.255.5 VRF: default Advertised route: 192.0.254.5/32 - Not found<br>Peer: 172.30.255.5 VRF: default Received route: 192.0.255.4/32 - Not found<br>Peer: 172.30.255.1 VRF: default Advertised route: 192.0.255.1/32 - Not found<br>Peer: 172.30.255.1 VRF: default Advertised route: 192.0.254.5/32 - Not found |
+| s1-spine1 | BGP | VerifyBGPNlriAcceptance | Verifies that all received NLRI are accepted for all AFI/SAFI configured for BGP peers. | - | failure | Peer: 10.100.0.128 VRF: default - Not found<br>Peer: 2001:db8:1::2 VRF: default - Not found<br>Peer: fe80::2%Et1 VRF: default - Not found<br>Peer: fe80::2%Et1 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerASNCap | Verifies the four octet ASN capability of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerCount | Verifies the count of BGP peers for given address families. | - | failure | AFI: ipv4 SAFI: unicast VRF: PROD - VRF not configured<br>AFI: ipv4 SAFI: multicast VRF: DEV - VRF not configured |
+| s1-spine1 | BGP | VerifyBGPPeerDropStats | Verifies BGP NLRI drop statistics of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerGroup | Verifies BGP peer group of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerMD5Auth | Verifies the MD5 authentication and state of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.5 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: default - Session does not have MD5 authentication enabled |
+| s1-spine1 | BGP | VerifyBGPPeerMPCaps | Verifies the multiprotocol capabilities of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: default - ipv4MplsLabels not found<br>Interface: Ethernet1 VRF: default - ipv4MplsVpn not found |
+| s1-spine1 | BGP | VerifyBGPPeerRouteLimit | Verifies maximum routes and warning limit for BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerRouteRefreshCap | Verifies the route refresh capabilities of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerSession | Verifies the session state of BGP peers. | - | failure | Peer: 10.1.0.1 VRF: default - Not found<br>Peer: 10.1.0.2 VRF: default - Not found<br>Peer: 10.1.255.2 VRF: DEV - Not found<br>Peer: 10.1.255.4 VRF: DEV - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Vlan3499 VRF: PROD - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerSessionRibd | Verifies the session state of BGP peers. | - | failure | Peer: 10.1.0.1 VRF: default - Not found<br>Peer: 10.1.255.4 VRF: DEV - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerTtlMultiHops | Verifies BGP TTL and max-ttl-hops count for BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.2 VRF: test - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerUpdateErrors | Verifies BGP update error counters of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeersHealth | Verifies the health of BGP peers for given address families. | - | failure | AFI: ipv6 SAFI: unicast VRF: DEV - VRF not configured |
+| s1-spine1 | BGP | VerifyBGPSpecificPeers | Verifies the health of specific BGP peer(s) for given address families. | - | failure | AFI: evpn Peer: 10.1.0.1 - Not configured<br>AFI: evpn Peer: 10.1.0.2 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.254.1 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.0 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.2 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.4 - Not configured |
+| s1-spine1 | BGP | VerifyBGPTimers | Verifies the timers of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.5 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBgpRouteMaps | Verifies BGP inbound and outbound route-maps of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyEVPNType2Route | Verifies the EVPN Type-2 routes for a given IPv4 or MAC address and VNI. | - | failure | Address: 192.168.20.102 VNI: 10020 - No EVPN Type-2 route<br>Address: aa:c1:ab:5d:b4:1e VNI: 10010 - No EVPN Type-2 route |
+| s1-spine1 | BGP | VerifyEVPNType5Routes | Verifies EVPN Type-5 routes for given IP prefixes and VNIs. | - | failure | Prefix: 192.168.10.0/24 VNI: 10 - No EVPN Type-5 routes found<br>Prefix: 192.168.20.0/24 VNI: 20 - No EVPN Type-5 routes found<br>Prefix: 192.168.30.0/24 VNI: 30 - No EVPN Type-5 routes found<br>Prefix: 192.168.40.0/24 VNI: 40 - No EVPN Type-5 routes found |
+| s1-spine1 | Configuration | VerifyRunningConfigDiffs | Verifies there is no difference between the running-config and the startup-config. | - | failure | --- flash:/startup-config<br>+++ system:/running-config<br>@@ -18,6 +18,7 @@<br> hostname leaf1-dc1<br> ip name-server vrf MGMT 10.14.0.1<br> dns domain fun.aristanetworks.com<br>+ip host vitthal 192.168.66.220<br> !<br> platform tfa<br>    personality arfa<br> |
+| s1-spine1 | Configuration | VerifyRunningConfigLines | Search the Running-Config for the given RegEx patterns. | - | failure | Following patterns were not found: '^enable password.*$', 'bla bla' |
 | s1-spine1 | Connectivity | VerifyLLDPNeighbors | Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors. | - | failure | Port: Ethernet1 Neighbor: DC1-SPINE1 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine1-dc1.fun.aristanetworks.com/Ethernet3<br>Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine2-dc1.fun.aristanetworks.com/Ethernet3 |
+| s1-spine1 | Cvx | VerifyActiveCVXConnections | Verifies the number of active CVX Connections. | - | failure | 'show cvx connections brief' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'connections') |
+| s1-spine1 | Cvx | VerifyCVXClusterStatus | Verifies the CVX Server Cluster status. | - | failure | CVX Server status is not enabled<br>CVX Server is not a cluster |
+| s1-spine1 | Cvx | VerifyManagementCVX | Verifies the management CVX global status. | - | failure | Management CVX status is not valid: Expected: enabled Actual: disabled |
+| s1-spine1 | Cvx | VerifyMcsClientMounts | Verify if all MCS client mounts are in mountStateMountComplete. | - | failure | MCS Client mount states are not present |
+| s1-spine1 | Cvx | VerifyMcsServerMounts | Verify if all MCS server mounts are in a MountComplete state. | - | failure | 'show cvx mounts' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'mounts') |
+| s1-spine1 | Greent | VerifyGreenT | Verifies if a GreenT policy other than the default is created. | - | failure | No GreenT policy is created |
+| s1-spine1 | Greent | VerifyGreenTCounters | Verifies if the GreenT counters are incremented. | - | failure | GreenT counters are not incremented |
 | s1-spine1 | Interfaces | VerifyIPProxyARP | Verifies if Proxy ARP is enabled. | - | failure | Interface: Ethernet1 - Proxy-ARP disabled<br>Interface: Ethernet2 - Proxy-ARP disabled |
+| s1-spine1 | Interfaces | VerifyInterfaceIPv4 | Verifies the interface IPv4 addresses. | - | failure | Interface: Ethernet2 - IP address mismatch - Expected: 172.30.11.1/31 Actual: 10.100.0.11/31<br>Interface: Ethernet2 - Secondary IP address is not configured |
+| s1-spine1 | Interfaces | VerifyInterfacesSpeed | Verifies the speed, lanes, auto-negotiation status, and mode as full duplex for interfaces. | - | failure | Interface: Ethernet2 - Bandwidth mismatch - Expected: 10.0Gbps Actual: 1Gbps<br>Interface: Ethernet3 - Bandwidth mismatch - Expected: 100.0Gbps Actual: 1Gbps<br>Interface: Ethernet3 - Auto-negotiation mismatch - Expected: success Actual: unknown<br>Interface: Ethernet3 - Data lanes count mismatch - Expected: 1 Actual: 0<br>Interface: Ethernet2 - Bandwidth mismatch - Expected: 2.5Gbps Actual: 1Gbps |
+| s1-spine1 | Interfaces | VerifyInterfacesStatus | Verifies the operational states of specified interfaces to ensure they match expected configurations. | interface | failure | Port-Channel100 - Not configured<br>Ethernet49/1 - Not configured |
+| s1-spine1 | Interfaces | VerifyL2MTU | Verifies the global L2 MTU of all L2 interfaces. | - | failure | Interface: Ethernet3 - Incorrect MTU configured - Expected: 1500 Actual: 9214<br>Interface: Port-Channel5 - Incorrect MTU configured - Expected: 1500 Actual: 9214 |
+| s1-spine1 | Interfaces | VerifyL3MTU | Verifies the global L3 MTU of all L3 interfaces. | - | failure | Interface: Ethernet2 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Ethernet1 - Incorrect MTU - Expected: 2500 Actual: 9214<br>Interface: Loopback0 - Incorrect MTU - Expected: 1500 Actual: 65535<br>Interface: Loopback1 - Incorrect MTU - Expected: 1500 Actual: 65535<br>Interface: Vlan1006 - Incorrect MTU - Expected: 1500 Actual: 9164<br>Interface: Vlan1199 - Incorrect MTU - Expected: 1500 Actual: 9164<br>Interface: Vlan4093 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan4094 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan3019 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan3009 - Incorrect MTU - Expected: 1500 Actual: 9214 |
+| s1-spine1 | Interfaces | VerifyLACPInterfacesStatus | Verifies the Link Aggregation Control Protocol (LACP) status of the interface. | - | failure | Interface: Ethernet1 Port-Channel: Port-Channel100 - Not configured |
+| s1-spine1 | Interfaces | VerifyLoopbackCount | Verifies the number of loopback interfaces and their status. | - | failure | Loopback interface(s) count mismatch: Expected 3 Actual: 2 |
+| s1-spine1 | Logging | VerifyLoggingEntries | Verifies that the expected log string is present in the last specified log messages. | - | failure | Pattern: `.*ACCOUNTING-5-EXEC: cvpadmin ssh.*` - Not found in last 30 alerts log entries<br>Pattern: `.*SPANTREE-6-INTERFACE_ADD:.*` - Not found in last 10 critical log entries |
+| s1-spine1 | Logging | VerifyLoggingErrors | Verifies there are no syslog messages with a severity of ERRORS or higher. | - | failure | Device has reported syslog messages with a severity of ERRORS or higher:<br>Apr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF data AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> Apr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> Apr 29 08:01:29 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: received from neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> <br> |
+| s1-spine1 | Logging | VerifyLoggingHostname | Verifies if logs are generated with the device FQDN. | - | failure | Logs are not generated with the device FQDN |
 | s1-spine1 | Logging | VerifyLoggingHosts | Verifies logging hosts (syslog servers) for a specified VRF. | - | failure | Syslog servers 1.1.1.1, 2.2.2.2 are not configured in VRF default |
+| s1-spine1 | Logging | VerifyLoggingPersistent | Verifies if logging persistent is enabled and logs are saved in flash. | - | failure | Persistent logging is disabled |
+| s1-spine1 | Logging | VerifyLoggingSourceIntf | Verifies logging source-interface for a specified VRF. | - | failure | Source-interface: Management0 VRF: default - Not configured |
+| s1-spine1 | Logging | VerifyLoggingTimestamp | Verifies if logs are generated with the appropriate timestamp. | - | failure | Logs are not generated with the appropriate timestamp format |
 | s1-spine1 | MLAG | VerifyMlagDualPrimary | Verifies the MLAG dual-primary detection parameters. | - | failure | Dual-primary detection is disabled |
-| s1-spine1 | Security | VerifyBannerLogin | Verifies the login banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the login banner, but found '' instead. |
-| s1-spine1 | Security | VerifyBannerMotd | Verifies the motd banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the motd banner, but found '' instead. |
+| s1-spine1 | MLAG | VerifyMlagPrimaryPriority | Verifies the configuration of the MLAG primary priority. | - | failure | MLAG primary priority mismatch - Expected: 3276 Actual: 32767 |
+| s1-spine1 | Multicast | VerifyIGMPSnoopingVlans | Verifies the IGMP snooping status for the provided VLANs. | - | failure | VLAN10 - Incorrect IGMP state - Expected: disabled Actual: enabled<br>Supplied vlan 12 is not present on the device |
+| s1-spine1 | Routing | VerifyIPv4RouteType | Verifies the route-type of the IPv4 prefixes. | - | failure | Prefix: 10.100.0.12/31 VRF: default - Route not found<br>Prefix: 10.100.1.5/32 VRF: default - Incorrect route type - Expected: iBGP Actual: connected |
+| s1-spine1 | Routing | VerifyRoutingStatus | Verifies the routing status for IPv4/IPv6 unicast, multicast, and IPv6 interfaces (RFC5549). | - | failure | IPv6 unicast routing enabled status mismatch - Expected: True Actual: False |
+| s1-spine1 | Routing | VerifyRoutingTableEntry | Verifies that the provided routes are present in the routing table of a specified VRF. | - | failure | The following route(s) are missing from the routing table of VRF default: 10.1.0.1, 10.1.0.2 |
+| s1-spine1 | Routing | VerifyRoutingTableSize | Verifies the size of the IP routing table of the default VRF. | - | failure | Routing table routes are outside the routes range - Expected: 2 <= to >= 20 Actual: 35 |
+| s1-spine1 | Security | VerifyAPIHttpsSSL | Verifies if the eAPI has a valid SSL profile. | - | failure | eAPI HTTPS server SSL profile default is not configured |
+| s1-spine1 | Security | VerifyAPIIPv4Acl | Verifies if eAPI has the right number IPv4 ACL(s) configured for a specified VRF. | - | failure | VRF: default - eAPI IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifyAPIIPv6Acl | Verifies if eAPI has the right number IPv6 ACL(s) configured for a specified VRF. | - | failure | VRF: default - eAPI IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifyBannerLogin | Verifies the login banner of a device. | - | failure | Login banner is not configured |
+| s1-spine1 | Security | VerifyBannerMotd | Verifies the motd banner of a device. | - | failure | MOTD banner is not configured |
+| s1-spine1 | Security | VerifyHardwareEntropy | Verifies hardware entropy generation is enabled on device. | - | failure | Hardware entropy generation is disabled |
+| s1-spine1 | Security | VerifyIPSecConnHealth | Verifies all IPv4 security connections. | - | failure | No IPv4 security connection configured |
+| s1-spine1 | Security | VerifyIPv4ACL | Verifies the configuration of IPv4 ACLs. | - | failure | ACL name: LabTest - Not configured |
+| s1-spine1 | Security | VerifySSHIPv4Acl | Verifies if the SSHD agent has IPv4 ACL(s) configured. | - | failure | VRF: default - SSH IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifySSHIPv6Acl | Verifies if the SSHD agent has IPv6 ACL(s) configured. | - | failure | VRF: default - SSH IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifySSHStatus | Verifies if the SSHD agent is disabled in the default VRF. | - | failure | SSHD status for Default VRF is enabled |
+| s1-spine1 | Security | VerifySpecificIPSecConn | Verifies the IPv4 security connections. | - | failure | Peer: 10.255.0.1 VRF: default - Not configured<br>Peer: 10.255.0.2 VRF: default - Not configured |
+| s1-spine1 | Services | VerifyDNSServers | Verifies if the DNS (Domain Name Service) servers are correctly configured. | - | failure | Server 10.14.0.1 VRF: default Priority: 1 - Not configured<br>Server 10.14.0.11 VRF: MGMT Priority: 0 - Not configured |
+| s1-spine1 | Services | VerifyErrdisableRecovery | Verifies the error disable recovery functionality. | - | failure | Reason: acl Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300<br>Reason: bpduguard Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300 |
 | s1-spine1 | Services | VerifyHostname | Verifies the hostname of a device. | - | failure | Incorrect Hostname - Expected: s1-spine1 Actual: leaf1-dc1 |
-| s1-spine1 | SNMP | VerifySnmpContact | Verifies the SNMP contact of a device. | - | failure | SNMP contact is not configured. |
+| s1-spine1 | SNMP | VerifySnmpContact | Verifies the SNMP contact of a device. | - | failure | SNMP contact is not configured |
+| s1-spine1 | SNMP | VerifySnmpErrorCounters | Verifies the SNMP error counters. | - | failure | SNMP counters not found |
+| s1-spine1 | SNMP | VerifySnmpGroup | Verifies the SNMP group configurations for specified version(s). | - | failure | Group: Group1 Version: v1 - Not configured<br>Group: Group2 Version: v3 - Not configured |
+| s1-spine1 | SNMP | VerifySnmpHostLogging | Verifies SNMP logging configurations. | - | failure | SNMP logging is disabled |
+| s1-spine1 | SNMP | VerifySnmpIPv4Acl | Verifies if the SNMP agent has IPv4 ACL(s) configured. | - | failure | VRF: default - Incorrect SNMP IPv4 ACL(s) - Expected: 3 Actual: 0 |
+| s1-spine1 | SNMP | VerifySnmpIPv6Acl | Verifies if the SNMP agent has IPv6 ACL(s) configured. | - | failure | VRF: default - Incorrect SNMP IPv6 ACL(s) - Expected: 3 Actual: 0 |
+| s1-spine1 | SNMP | VerifySnmpLocation | Verifies the SNMP location of a device. | - | failure | SNMP location is not configured |
+| s1-spine1 | SNMP | VerifySnmpNotificationHost | Verifies the SNMP notification host(s) (SNMP manager) configurations. | - | failure | No SNMP host is configured |
+| s1-spine1 | SNMP | VerifySnmpPDUCounters | Verifies the SNMP PDU counters. | - | failure | SNMP counters not found |
+| s1-spine1 | SNMP | VerifySnmpSourceInterface | Verifies SNMP source interfaces. | - | failure | SNMP source interface(s) not configured |
+| s1-spine1 | SNMP | VerifySnmpStatus | Verifies if the SNMP agent is enabled. | - | failure | VRF: default - SNMP agent disabled |
+| s1-spine1 | SNMP | VerifySnmpUser | Verifies the SNMP user configurations. | - | failure | User: test Group: test_group Version: v3 - Not found |
 | s1-spine1 | Software | VerifyEOSVersion | Verifies the EOS version of the device. | - | failure | EOS version mismatch - Actual: 4.31.0F-33804048.4310F (engineering build) not in Expected: 4.25.4M, 4.26.1F |
-| s1-spine1 | STUN | VerifyStunClient | (Deprecated) Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found. |
-| s1-spine1 | STUN | VerifyStunClientTranslation | Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found.<br>Client 100.64.3.2 Port: 4500 - STUN client translation not found. |
-| s1-spine1 | System | VerifyNTPAssociations | Verifies the Network Time Protocol (NTP) associations. | - | failure | NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Not configured<br>NTP Server: 2.2.2.2 Preferred: False Stratum: 2 - Not configured<br>NTP Server: 3.3.3.3 Preferred: False Stratum: 2 - Not configured |
+| s1-spine1 | Software | VerifyTerminAttrVersion | Verifies the TerminAttr version of the device. | - | failure | TerminAttr version mismatch - Actual: v1.29.0 not in Expected: v1.13.6, v1.8.0 |
+| s1-spine1 | STP | VerifySTPDisabledVlans | Verifies the STP disabled VLAN(s). | - | failure | VLAN: 6 - Not configured |
+| s1-spine1 | STP | VerifySTPMode | Verifies the configured STP mode for a provided list of VLAN(s). | - | failure | VLAN 10 - Incorrect STP mode - Expected: rapidPvst Actual: mstp<br>VLAN 20 - Incorrect STP mode - Expected: rapidPvst Actual: mstp |
+| s1-spine1 | STP | VerifySTPRootPriority | Verifies the STP root priority for a provided list of VLAN or MST instance ID(s). | - | failure | Instance: MST10 - Not configured<br>Instance: MST20 - Not configured |
+| s1-spine1 | STUN | VerifyStunClient | (Deprecated) Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found |
+| s1-spine1 | STUN | VerifyStunClientTranslation | Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found<br>Client 100.64.3.2 Port: 4500 - STUN client translation not found |
+| s1-spine1 | STUN | VerifyStunServer | Verifies the STUN server status is enabled and running. | - | failure | STUN server status is disabled and not running |
 | s1-spine1 | VLAN | VerifyDynamicVlanSource | Verifies dynamic VLAN allocation for specified VLAN sources. | - | failure | Dynamic VLAN source(s) exist but have no VLANs allocated: mlagsync |
+| s1-spine1 | VLAN | VerifyVlanInternalPolicy | Verifies the VLAN internal allocation policy and the range of VLANs. | - | failure | VLAN internal allocation policy: ascending - Incorrect end VLAN id configured - Expected: 4094 Actual: 1199 |
+| s1-spine1 | VLAN | VerifyVlanStatus | Verifies the administrative status of specified VLANs. | - | failure | VLAN: Vlan10 - Incorrect administrative status - Expected: suspended Actual: active |
+| s1-spine1 | VXLAN | VerifyVxlanVniBinding | Verifies the VNI-VLAN, VNI-VRF bindings of the Vxlan1 interface. | - | failure | Interface: Vxlan1 VNI: 500 - Binding not found |
+| s1-spine1 | VXLAN | VerifyVxlanVtep | Verifies Vxlan1 VTEP peers. | - | failure | The following VTEP peer(s) are missing from the Vxlan1 interface: 10.1.1.5, 10.1.1.6<br>Unexpected VTEP peer(s) on Vxlan1 interface: 10.100.2.3 |
 
 ## Test Results
 
 | Device Under Test | Categories | Test | Description | Custom Field | Result | Messages |
 | ----------------- | ---------- | ---- | ----------- | ------------ | ------ | -------- |
 | s1-spine1 | AAA | VerifyAcctConsoleMethods | Verifies the AAA accounting console method lists for different accounting types (system, exec, commands, dot1x). | - | failure | AAA console accounting is not configured for commands, exec, system, dot1x |
-| s1-spine1 | AVT | VerifyAVTPathHealth | Verifies the status of all AVT paths for all VRFs. | - | skipped | VerifyAVTPathHealth test is not supported on cEOSLab. |
-| s1-spine1 | BFD | VerifyBFDPeersHealth | Verifies the health of IPv4 BFD peers across all VRFs. | - | failure | No IPv4 BFD peers are configured for any VRF. |
-| s1-spine1 | BGP | VerifyBGPAdvCommunities | Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s). | - | error | show bgp neighbors vrf all has failed: The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model. |
-| s1-spine1 | Configuration | VerifyRunningConfigDiffs | Verifies there is no difference between the running-config and the startup-config. | - | success | - |
+| s1-spine1 | AAA | VerifyAcctDefaultMethods | Verifies the AAA accounting default method lists for different accounting types (system, exec, commands, dot1x). | - | failure | AAA default accounting is not configured for commands, exec, system, dot1x |
+| s1-spine1 | AAA | VerifyAuthenMethods | Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x). | - | failure | AAA authentication methods are not configured for login console |
+| s1-spine1 | AAA | VerifyAuthzMethods | Verifies the AAA authorization method lists for different authorization types (commands, exec). | - | failure | AAA authorization methods local, none, logging are not matching for commands, exec |
+| s1-spine1 | AAA | VerifyTacacsServerGroups | Verifies if the provided TACACS server group(s) are configured. | - | failure | No TACACS server group(s) are configured |
+| s1-spine1 | AAA | VerifyTacacsServers | Verifies TACACS servers are configured for a specified VRF. | - | failure | No TACACS servers are configured |
+| s1-spine1 | AAA | VerifyTacacsSourceIntf | Verifies TACACS source-interface for a specified VRF. | - | failure | VRF: MGMT Source Interface: Management0 - Not configured |
+| s1-spine1 | AVT | VerifyAVTPathHealth | Verifies the status of all AVT paths for all VRFs. | - | skipped | VerifyAVTPathHealth test is not supported on cEOSLab |
+| s1-spine1 | AVT | VerifyAVTRole | Verifies the AVT role of a device. | - | skipped | VerifyAVTRole test is not supported on cEOSLab |
+| s1-spine1 | AVT | VerifyAVTSpecificPath | Verifies the Adaptive Virtual Topology (AVT) path. | - | skipped | VerifyAVTSpecificPath test is not supported on cEOSLab |
+| s1-spine1 | BFD | VerifyBFDPeersHealth | Verifies the health of IPv4 BFD peers across all VRFs. | - | success | - |
+| s1-spine1 | BFD | VerifyBFDPeersIntervals | Verifies the timers of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.8 VRF: default - Not found<br>Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BFD | VerifyBFDPeersRegProtocols | Verifies the registered routing protocol of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BFD | VerifyBFDSpecificPeers | Verifies the state of IPv4 BFD peer sessions. | - | failure | Peer: 192.0.255.8 VRF: default - Not found<br>Peer: 192.0.255.7 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPAdvCommunities | Verifies the advertised communities of BGP peers. | - | failure | Peer: 172.30.11.17 VRF: default - Not found<br>Peer: 172.30.11.21 VRF: MGMT - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPExchangedRoutes | Verifies the advertised and received routes of BGP IPv4 peer(s). | - | failure | Peer: 172.30.255.5 VRF: default Advertised route: 192.0.254.5/32 - Not found<br>Peer: 172.30.255.5 VRF: default Received route: 192.0.255.4/32 - Not found<br>Peer: 172.30.255.1 VRF: default Advertised route: 192.0.255.1/32 - Not found<br>Peer: 172.30.255.1 VRF: default Advertised route: 192.0.254.5/32 - Not found |
+| s1-spine1 | BGP | VerifyBGPNlriAcceptance | Verifies that all received NLRI are accepted for all AFI/SAFI configured for BGP peers. | - | failure | Peer: 10.100.0.128 VRF: default - Not found<br>Peer: 2001:db8:1::2 VRF: default - Not found<br>Peer: fe80::2%Et1 VRF: default - Not found<br>Peer: fe80::2%Et1 VRF: default - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerASNCap | Verifies the four octet ASN capability of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerCount | Verifies the count of BGP peers for given address families. | - | failure | AFI: ipv4 SAFI: unicast VRF: PROD - VRF not configured<br>AFI: ipv4 SAFI: multicast VRF: DEV - VRF not configured |
+| s1-spine1 | BGP | VerifyBGPPeerDropStats | Verifies BGP NLRI drop statistics of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerGroup | Verifies BGP peer group of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerMD5Auth | Verifies the MD5 authentication and state of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.5 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: default - Session does not have MD5 authentication enabled |
+| s1-spine1 | BGP | VerifyBGPPeerMPCaps | Verifies the multiprotocol capabilities of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: default - ipv4MplsLabels not found<br>Interface: Ethernet1 VRF: default - ipv4MplsVpn not found |
+| s1-spine1 | BGP | VerifyBGPPeerRouteLimit | Verifies maximum routes and warning limit for BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerRouteRefreshCap | Verifies the route refresh capabilities of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerSession | Verifies the session state of BGP peers. | - | failure | Peer: 10.1.0.1 VRF: default - Not found<br>Peer: 10.1.0.2 VRF: default - Not found<br>Peer: 10.1.255.2 VRF: DEV - Not found<br>Peer: 10.1.255.4 VRF: DEV - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Vlan3499 VRF: PROD - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerSessionRibd | Verifies the session state of BGP peers. | - | failure | Peer: 10.1.0.1 VRF: default - Not found<br>Peer: 10.1.255.4 VRF: DEV - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerTtlMultiHops | Verifies BGP TTL and max-ttl-hops count for BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.2 VRF: test - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeerUpdateErrors | Verifies BGP update error counters of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBGPPeersHealth | Verifies the health of BGP peers for given address families. | - | failure | AFI: ipv6 SAFI: unicast VRF: DEV - VRF not configured |
+| s1-spine1 | BGP | VerifyBGPPeersHealthRibd | Verifies the health of all the BGP peers. | - | success | - |
+| s1-spine1 | BGP | VerifyBGPRedistribution | Verifies BGP redistribution. | - | error | show bgp instance vrf all has failed: Invalid requested version for ModelMetaClass: no such revision 4, most current is 3 |
+| s1-spine1 | BGP | VerifyBGPRouteECMP | Verifies BGP IPv4 route ECMP paths. | - | success | - |
+| s1-spine1 | BGP | VerifyBGPRoutePaths | Verifies BGP IPv4 route paths. | - | success | - |
+| s1-spine1 | BGP | VerifyBGPSpecificPeers | Verifies the health of specific BGP peer(s) for given address families. | - | failure | AFI: evpn Peer: 10.1.0.1 - Not configured<br>AFI: evpn Peer: 10.1.0.2 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.254.1 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.0 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.2 - Not configured<br>AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.4 - Not configured |
+| s1-spine1 | BGP | VerifyBGPTimers | Verifies the timers of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: 172.30.11.5 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyBgpRouteMaps | Verifies BGP inbound and outbound route-maps of BGP peers. | - | failure | Peer: 172.30.11.1 VRF: default - Not found<br>Peer: fd00:dc:1::1 VRF: default - Not found<br>Interface: Ethernet1 VRF: MGMT - Not found |
+| s1-spine1 | BGP | VerifyEVPNType2Route | Verifies the EVPN Type-2 routes for a given IPv4 or MAC address and VNI. | - | failure | Address: 192.168.20.102 VNI: 10020 - No EVPN Type-2 route<br>Address: aa:c1:ab:5d:b4:1e VNI: 10010 - No EVPN Type-2 route |
+| s1-spine1 | BGP | VerifyEVPNType5Routes | Verifies EVPN Type-5 routes for given IP prefixes and VNIs. | - | failure | Prefix: 192.168.10.0/24 VNI: 10 - No EVPN Type-5 routes found<br>Prefix: 192.168.20.0/24 VNI: 20 - No EVPN Type-5 routes found<br>Prefix: 192.168.30.0/24 VNI: 30 - No EVPN Type-5 routes found<br>Prefix: 192.168.40.0/24 VNI: 40 - No EVPN Type-5 routes found |
+| s1-spine1 | Configuration | VerifyRunningConfigDiffs | Verifies there is no difference between the running-config and the startup-config. | - | failure | --- flash:/startup-config<br>+++ system:/running-config<br>@@ -18,6 +18,7 @@<br> hostname leaf1-dc1<br> ip name-server vrf MGMT 10.14.0.1<br> dns domain fun.aristanetworks.com<br>+ip host vitthal 192.168.66.220<br> !<br> platform tfa<br>    personality arfa<br> |
+| s1-spine1 | Configuration | VerifyRunningConfigLines | Search the Running-Config for the given RegEx patterns. | - | failure | Following patterns were not found: '^enable password.*$', 'bla bla' |
+| s1-spine1 | Configuration | VerifyZeroTouch | Verifies ZeroTouch is disabled. | - | success | - |
 | s1-spine1 | Connectivity | VerifyLLDPNeighbors | Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors. | - | failure | Port: Ethernet1 Neighbor: DC1-SPINE1 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine1-dc1.fun.aristanetworks.com/Ethernet3<br>Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine2-dc1.fun.aristanetworks.com/Ethernet3 |
-| s1-spine1 | Cvx | VerifyActiveCVXConnections | Verifies the number of active CVX Connections. | - | error | show cvx connections brief has failed: Unavailable command (controller not ready) (at token 2: 'connections') |
-| s1-spine1 | Field Notices | VerifyFieldNotice44Resolution | Verifies that the device is using the correct Aboot version per FN0044. | - | skipped | VerifyFieldNotice44Resolution test is not supported on cEOSLab. |
-| s1-spine1 | Hardware | VerifyTemperature | Verifies if the device temperature is within acceptable limits. | - | skipped | VerifyTemperature test is not supported on cEOSLab. |
+| s1-spine1 | Connectivity | VerifyReachability | Test network reachability to one or many destination IP(s). | - | success | - |
+| s1-spine1 | Cvx | VerifyActiveCVXConnections | Verifies the number of active CVX Connections. | - | failure | 'show cvx connections brief' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'connections') |
+| s1-spine1 | Cvx | VerifyCVXClusterStatus | Verifies the CVX Server Cluster status. | - | failure | CVX Server status is not enabled<br>CVX Server is not a cluster |
+| s1-spine1 | Cvx | VerifyManagementCVX | Verifies the management CVX global status. | - | failure | Management CVX status is not valid: Expected: enabled Actual: disabled |
+| s1-spine1 | Cvx | VerifyMcsClientMounts | Verify if all MCS client mounts are in mountStateMountComplete. | - | failure | MCS Client mount states are not present |
+| s1-spine1 | Cvx | VerifyMcsServerMounts | Verify if all MCS server mounts are in a MountComplete state. | - | failure | 'show cvx mounts' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'mounts') |
+| s1-spine1 | Field Notices | VerifyFieldNotice44Resolution | Verifies that the device is using the correct Aboot version per FN0044. | - | skipped | VerifyFieldNotice44Resolution test is not supported on cEOSLab |
+| s1-spine1 | Field Notices | VerifyFieldNotice72Resolution | Verifies if the device is exposed to FN0072, and if the issue has been mitigated. | - | skipped | VerifyFieldNotice72Resolution test is not supported on cEOSLab |
+| s1-spine1 | Flow Tracking | VerifyHardwareFlowTrackerStatus | Verifies the hardware flow tracking state. | - | skipped | VerifyHardwareFlowTrackerStatus test is not supported on cEOSLab |
+| s1-spine1 | Greent | VerifyGreenT | Verifies if a GreenT policy other than the default is created. | - | failure | No GreenT policy is created |
+| s1-spine1 | Greent | VerifyGreenTCounters | Verifies if the GreenT counters are incremented. | - | failure | GreenT counters are not incremented |
+| s1-spine1 | Hardware | VerifyAdverseDrops | Verifies there are no adverse drops on DCS-7280 and DCS-7500 family switches. | - | skipped | VerifyAdverseDrops test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyEnvironmentCooling | Verifies the status of power supply fans and all fan trays. | - | skipped | VerifyEnvironmentCooling test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyEnvironmentPower | Verifies the power supplies status. | - | skipped | VerifyEnvironmentPower test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyEnvironmentSystemCooling | Verifies the device's system cooling status. | - | skipped | VerifyEnvironmentSystemCooling test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyTemperature | Verifies if the device temperature is within acceptable limits. | - | skipped | VerifyTemperature test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyTransceiversManufacturers | Verifies if all the transceivers come from approved manufacturers. | - | skipped | VerifyTransceiversManufacturers test is not supported on cEOSLab |
+| s1-spine1 | Hardware | VerifyTransceiversTemperature | Verifies if all the transceivers are operating at an acceptable temperature. | - | skipped | VerifyTransceiversTemperature test is not supported on cEOSLab |
 | s1-spine1 | Interfaces | VerifyIPProxyARP | Verifies if Proxy ARP is enabled. | - | failure | Interface: Ethernet1 - Proxy-ARP disabled<br>Interface: Ethernet2 - Proxy-ARP disabled |
-| s1-spine1 | ISIS | VerifyISISNeighborState | Verifies the health of IS-IS neighbors. | custom | skipped | IS-IS not configured |
-| s1-spine1 | LANZ | VerifyLANZ | Verifies if LANZ is enabled. | - | skipped | VerifyLANZ test is not supported on cEOSLab. |
+| s1-spine1 | Interfaces | VerifyIllegalLACP | Verifies there are no illegal LACP packets in all port channels. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfaceErrDisabled | Verifies there are no interfaces in the errdisabled state. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfaceErrors | Verifies that the interfaces error counters are equal to zero. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfaceIPv4 | Verifies the interface IPv4 addresses. | - | failure | Interface: Ethernet2 - IP address mismatch - Expected: 172.30.11.1/31 Actual: 10.100.0.11/31<br>Interface: Ethernet2 - Secondary IP address is not configured |
+| s1-spine1 | Interfaces | VerifyInterfaceUtilization | Verifies that the utilization of interfaces is below a certain threshold. | - | success | - |
+| s1-spine1 | Interfaces | VerifyInterfacesSpeed | Verifies the speed, lanes, auto-negotiation status, and mode as full duplex for interfaces. | - | failure | Interface: Ethernet2 - Bandwidth mismatch - Expected: 10.0Gbps Actual: 1Gbps<br>Interface: Ethernet3 - Bandwidth mismatch - Expected: 100.0Gbps Actual: 1Gbps<br>Interface: Ethernet3 - Auto-negotiation mismatch - Expected: success Actual: unknown<br>Interface: Ethernet3 - Data lanes count mismatch - Expected: 1 Actual: 0<br>Interface: Ethernet2 - Bandwidth mismatch - Expected: 2.5Gbps Actual: 1Gbps |
+| s1-spine1 | Interfaces | VerifyInterfacesStatus | Verifies the operational states of specified interfaces to ensure they match expected configurations. | interface | failure | Port-Channel100 - Not configured<br>Ethernet49/1 - Not configured |
+| s1-spine1 | Interfaces | VerifyIpVirtualRouterMac | Verifies the IP virtual router MAC address. | - | success | - |
+| s1-spine1 | Interfaces | VerifyL2MTU | Verifies the global L2 MTU of all L2 interfaces. | - | failure | Interface: Ethernet3 - Incorrect MTU configured - Expected: 1500 Actual: 9214<br>Interface: Port-Channel5 - Incorrect MTU configured - Expected: 1500 Actual: 9214 |
+| s1-spine1 | Interfaces | VerifyL3MTU | Verifies the global L3 MTU of all L3 interfaces. | - | failure | Interface: Ethernet2 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Ethernet1 - Incorrect MTU - Expected: 2500 Actual: 9214<br>Interface: Loopback0 - Incorrect MTU - Expected: 1500 Actual: 65535<br>Interface: Loopback1 - Incorrect MTU - Expected: 1500 Actual: 65535<br>Interface: Vlan1006 - Incorrect MTU - Expected: 1500 Actual: 9164<br>Interface: Vlan1199 - Incorrect MTU - Expected: 1500 Actual: 9164<br>Interface: Vlan4093 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan4094 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan3019 - Incorrect MTU - Expected: 1500 Actual: 9214<br>Interface: Vlan3009 - Incorrect MTU - Expected: 1500 Actual: 9214 |
+| s1-spine1 | Interfaces | VerifyLACPInterfacesStatus | Verifies the Link Aggregation Control Protocol (LACP) status of the interface. | - | failure | Interface: Ethernet1 Port-Channel: Port-Channel100 - Not configured |
+| s1-spine1 | Interfaces | VerifyLoopbackCount | Verifies the number of loopback interfaces and their status. | - | failure | Loopback interface(s) count mismatch: Expected 3 Actual: 2 |
+| s1-spine1 | Interfaces | VerifyPortChannels | Verifies there are no inactive ports in all port channels. | - | success | - |
+| s1-spine1 | Interfaces | VerifySVI | Verifies the status of all SVIs. | - | success | - |
+| s1-spine1 | Interfaces | VerifyStormControlDrops | Verifies there are no interface storm-control drop counters. | - | skipped | VerifyStormControlDrops test is not supported on cEOSLab |
+| s1-spine1 | ISIS | VerifyISISGracefulRestart | Verifies the IS-IS graceful restart feature. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS | VerifyISISInterfaceMode | Verifies IS-IS interfaces are running in the correct mode. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS | VerifyISISNeighborCount | Verifies the number of IS-IS neighbors per interface and level. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS | VerifyISISNeighborState | Verifies the health of IS-IS neighbors. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS, Segment-Routing | VerifyISISSegmentRoutingAdjacencySegments | Verifies IS-IS segment routing adjacency segments. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS, Segment-Routing | VerifyISISSegmentRoutingDataplane | Verifies IS-IS segment routing data-plane configuration. | - | skipped | IS-IS not configured |
+| s1-spine1 | ISIS, Segment-Routing | VerifyISISSegmentRoutingTunnels | Verify ISIS-SR tunnels computed by device. | - | skipped | IS-IS-SR not configured |
+| s1-spine1 | LANZ | VerifyLANZ | Verifies if LANZ is enabled. | - | skipped | VerifyLANZ test is not supported on cEOSLab |
+| s1-spine1 | Logging | VerifyLoggingAccounting | Verifies if AAA accounting logs are generated. | - | success | - |
+| s1-spine1 | Logging | VerifyLoggingEntries | Verifies that the expected log string is present in the last specified log messages. | - | failure | Pattern: `.*ACCOUNTING-5-EXEC: cvpadmin ssh.*` - Not found in last 30 alerts log entries<br>Pattern: `.*SPANTREE-6-INTERFACE_ADD:.*` - Not found in last 10 critical log entries |
+| s1-spine1 | Logging | VerifyLoggingErrors | Verifies there are no syslog messages with a severity of ERRORS or higher. | - | failure | Device has reported syslog messages with a severity of ERRORS or higher:<br>Apr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF data AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> Apr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> Apr 29 08:01:29 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: received from neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes <br> <br> |
+| s1-spine1 | Logging | VerifyLoggingHostname | Verifies if logs are generated with the device FQDN. | - | failure | Logs are not generated with the device FQDN |
 | s1-spine1 | Logging | VerifyLoggingHosts | Verifies logging hosts (syslog servers) for a specified VRF. | - | failure | Syslog servers 1.1.1.1, 2.2.2.2 are not configured in VRF default |
+| s1-spine1 | Logging | VerifyLoggingLogsGeneration | Verifies if logs are generated. | - | success | - |
+| s1-spine1 | Logging | VerifyLoggingPersistent | Verifies if logging persistent is enabled and logs are saved in flash. | - | failure | Persistent logging is disabled |
+| s1-spine1 | Logging | VerifyLoggingSourceIntf | Verifies logging source-interface for a specified VRF. | - | failure | Source-interface: Management0 VRF: default - Not configured |
+| s1-spine1 | Logging | VerifyLoggingTimestamp | Verifies if logs are generated with the appropriate timestamp. | - | failure | Logs are not generated with the appropriate timestamp format |
+| s1-spine1 | Logging | VerifySyslogLogging | Verifies if syslog logging is enabled. | - | success | - |
+| s1-spine1 | MLAG | VerifyMlagConfigSanity | Verifies there are no MLAG config-sanity inconsistencies. | - | success | - |
 | s1-spine1 | MLAG | VerifyMlagDualPrimary | Verifies the MLAG dual-primary detection parameters. | - | failure | Dual-primary detection is disabled |
-| s1-spine1 | OSPF | VerifyOSPFMaxLSA | Verifies all OSPF instances did not cross the maximum LSA threshold. | - | skipped | No OSPF instance found. |
-| s1-spine1 | Path-Selection | VerifyPathsHealth | Verifies the path and telemetry state of all paths under router path-selection. | - | skipped | VerifyPathsHealth test is not supported on cEOSLab. |
-| s1-spine1 | Profiles | VerifyTcamProfile | Verifies the device TCAM profile. | - | skipped | VerifyTcamProfile test is not supported on cEOSLab. |
-| s1-spine1 | PTP | VerifyPtpGMStatus | Verifies that the device is locked to a valid PTP Grandmaster. | - | skipped | VerifyPtpGMStatus test is not supported on cEOSLab. |
+| s1-spine1 | MLAG | VerifyMlagInterfaces | Verifies there are no inactive or active-partial MLAG ports. | - | success | - |
+| s1-spine1 | MLAG | VerifyMlagPrimaryPriority | Verifies the configuration of the MLAG primary priority. | - | failure | MLAG primary priority mismatch - Expected: 3276 Actual: 32767 |
+| s1-spine1 | MLAG | VerifyMlagReloadDelay | Verifies the reload-delay parameters of the MLAG configuration. | - | success | - |
+| s1-spine1 | MLAG | VerifyMlagStatus | Verifies the health status of the MLAG configuration. | - | success | - |
+| s1-spine1 | Multicast | VerifyIGMPSnoopingGlobal | Verifies the IGMP snooping global status. | - | success | - |
+| s1-spine1 | Multicast | VerifyIGMPSnoopingVlans | Verifies the IGMP snooping status for the provided VLANs. | - | failure | VLAN10 - Incorrect IGMP state - Expected: disabled Actual: enabled<br>Supplied vlan 12 is not present on the device |
+| s1-spine1 | OSPF | VerifyOSPFMaxLSA | Verifies all OSPF instances did not cross the maximum LSA threshold. | - | skipped | OSPF not configured |
+| s1-spine1 | OSPF | VerifyOSPFNeighborCount | Verifies the number of OSPF neighbors in FULL state is the one we expect. | - | skipped | OSPF not configured |
+| s1-spine1 | OSPF | VerifyOSPFNeighborState | Verifies all OSPF neighbors are in FULL state. | - | skipped | OSPF not configured |
+| s1-spine1 | Path-Selection | VerifyPathsHealth | Verifies the path and telemetry state of all paths under router path-selection. | - | skipped | VerifyPathsHealth test is not supported on cEOSLab |
+| s1-spine1 | Path-Selection | VerifySpecificPath | Verifies the DPS path and telemetry state of an IPv4 peer. | - | skipped | VerifySpecificPath test is not supported on cEOSLab |
+| s1-spine1 | Profiles | VerifyTcamProfile | Verifies the device TCAM profile. | - | skipped | VerifyTcamProfile test is not supported on cEOSLab |
+| s1-spine1 | Profiles | VerifyUnifiedForwardingTableMode | Verifies the device is using the expected UFT mode. | - | skipped | VerifyUnifiedForwardingTableMode test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpGMStatus | Verifies that the device is locked to a valid PTP Grandmaster. | - | skipped | VerifyPtpGMStatus test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpLockStatus | Verifies that the device was locked to the upstream PTP GM in the last minute. | - | skipped | VerifyPtpLockStatus test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpModeStatus | Verifies that the device is configured as a PTP Boundary Clock. | - | skipped | VerifyPtpModeStatus test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpOffset | Verifies that the PTP timing offset is within +/- 1000ns from the master clock. | - | skipped | VerifyPtpOffset test is not supported on cEOSLab |
+| s1-spine1 | PTP | VerifyPtpPortModeStatus | Verifies the PTP interfaces state. | - | skipped | VerifyPtpPortModeStatus test is not supported on cEOSLab |
 | s1-spine1 | Routing | VerifyIPv4RouteNextHops | Verifies the next-hops of the IPv4 prefixes. | - | success | - |
-| s1-spine1 | Security | VerifyBannerLogin | Verifies the login banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the login banner, but found '' instead. |
-| s1-spine1 | Security | VerifyBannerMotd | Verifies the motd banner of a device. | - | failure | Expected '# Copyright (c) 2023-2024 Arista Networks, Inc.<br># Use of this source code is governed by the Apache License 2.0<br># that can be found in the LICENSE file.<br>' as the motd banner, but found '' instead. |
+| s1-spine1 | Routing | VerifyIPv4RouteType | Verifies the route-type of the IPv4 prefixes. | - | failure | Prefix: 10.100.0.12/31 VRF: default - Route not found<br>Prefix: 10.100.1.5/32 VRF: default - Incorrect route type - Expected: iBGP Actual: connected |
+| s1-spine1 | Routing | VerifyRoutingProtocolModel | Verifies the configured routing protocol model. | - | success | - |
+| s1-spine1 | Routing | VerifyRoutingStatus | Verifies the routing status for IPv4/IPv6 unicast, multicast, and IPv6 interfaces (RFC5549). | - | failure | IPv6 unicast routing enabled status mismatch - Expected: True Actual: False |
+| s1-spine1 | Routing | VerifyRoutingTableEntry | Verifies that the provided routes are present in the routing table of a specified VRF. | - | failure | The following route(s) are missing from the routing table of VRF default: 10.1.0.1, 10.1.0.2 |
+| s1-spine1 | Routing | VerifyRoutingTableSize | Verifies the size of the IP routing table of the default VRF. | - | failure | Routing table routes are outside the routes range - Expected: 2 <= to >= 20 Actual: 35 |
+| s1-spine1 | Security | VerifyAPIHttpStatus | Verifies if eAPI HTTP server is disabled globally. | - | success | - |
+| s1-spine1 | Security | VerifyAPIHttpsSSL | Verifies if the eAPI has a valid SSL profile. | - | failure | eAPI HTTPS server SSL profile default is not configured |
+| s1-spine1 | Security | VerifyAPIIPv4Acl | Verifies if eAPI has the right number IPv4 ACL(s) configured for a specified VRF. | - | failure | VRF: default - eAPI IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifyAPIIPv6Acl | Verifies if eAPI has the right number IPv6 ACL(s) configured for a specified VRF. | - | failure | VRF: default - eAPI IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifyAPISSLCertificate | Verifies the eAPI SSL certificate expiry, common subject name, encryption algorithm and key size. | - | success | - |
+| s1-spine1 | Security | VerifyBannerLogin | Verifies the login banner of a device. | - | failure | Login banner is not configured |
+| s1-spine1 | Security | VerifyBannerMotd | Verifies the motd banner of a device. | - | failure | MOTD banner is not configured |
+| s1-spine1 | Security | VerifyHardwareEntropy | Verifies hardware entropy generation is enabled on device. | - | failure | Hardware entropy generation is disabled |
+| s1-spine1 | Security | VerifyIPSecConnHealth | Verifies all IPv4 security connections. | - | failure | No IPv4 security connection configured |
+| s1-spine1 | Security | VerifyIPv4ACL | Verifies the configuration of IPv4 ACLs. | - | failure | ACL name: LabTest - Not configured |
+| s1-spine1 | Security | VerifySSHIPv4Acl | Verifies if the SSHD agent has IPv4 ACL(s) configured. | - | failure | VRF: default - SSH IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifySSHIPv6Acl | Verifies if the SSHD agent has IPv6 ACL(s) configured. | - | failure | VRF: default - SSH IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0 |
+| s1-spine1 | Security | VerifySSHStatus | Verifies if the SSHD agent is disabled in the default VRF. | - | failure | SSHD status for Default VRF is enabled |
+| s1-spine1 | Security | VerifySpecificIPSecConn | Verifies the IPv4 security connections. | - | failure | Peer: 10.255.0.1 VRF: default - Not configured<br>Peer: 10.255.0.2 VRF: default - Not configured |
+| s1-spine1 | Security | VerifyTelnetStatus | Verifies if Telnet is disabled in the default VRF. | - | success | - |
+| s1-spine1 | Services | VerifyDNSLookup | Verifies the DNS name to IP address resolution. | - | success | - |
+| s1-spine1 | Services | VerifyDNSServers | Verifies if the DNS (Domain Name Service) servers are correctly configured. | - | failure | Server 10.14.0.1 VRF: default Priority: 1 - Not configured<br>Server 10.14.0.11 VRF: MGMT Priority: 0 - Not configured |
+| s1-spine1 | Services | VerifyErrdisableRecovery | Verifies the error disable recovery functionality. | - | failure | Reason: acl Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300<br>Reason: bpduguard Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300 |
 | s1-spine1 | Services | VerifyHostname | Verifies the hostname of a device. | - | failure | Incorrect Hostname - Expected: s1-spine1 Actual: leaf1-dc1 |
-| s1-spine1 | SNMP | VerifySnmpContact | Verifies the SNMP contact of a device. | - | failure | SNMP contact is not configured. |
+| s1-spine1 | SNMP | VerifySnmpContact | Verifies the SNMP contact of a device. | - | failure | SNMP contact is not configured |
+| s1-spine1 | SNMP | VerifySnmpErrorCounters | Verifies the SNMP error counters. | - | failure | SNMP counters not found |
+| s1-spine1 | SNMP | VerifySnmpGroup | Verifies the SNMP group configurations for specified version(s). | - | failure | Group: Group1 Version: v1 - Not configured<br>Group: Group2 Version: v3 - Not configured |
+| s1-spine1 | SNMP | VerifySnmpHostLogging | Verifies SNMP logging configurations. | - | failure | SNMP logging is disabled |
+| s1-spine1 | SNMP | VerifySnmpIPv4Acl | Verifies if the SNMP agent has IPv4 ACL(s) configured. | - | failure | VRF: default - Incorrect SNMP IPv4 ACL(s) - Expected: 3 Actual: 0 |
+| s1-spine1 | SNMP | VerifySnmpIPv6Acl | Verifies if the SNMP agent has IPv6 ACL(s) configured. | - | failure | VRF: default - Incorrect SNMP IPv6 ACL(s) - Expected: 3 Actual: 0 |
+| s1-spine1 | SNMP | VerifySnmpLocation | Verifies the SNMP location of a device. | - | failure | SNMP location is not configured |
+| s1-spine1 | SNMP | VerifySnmpNotificationHost | Verifies the SNMP notification host(s) (SNMP manager) configurations. | - | failure | No SNMP host is configured |
+| s1-spine1 | SNMP | VerifySnmpPDUCounters | Verifies the SNMP PDU counters. | - | failure | SNMP counters not found |
+| s1-spine1 | SNMP | VerifySnmpSourceInterface | Verifies SNMP source interfaces. | - | failure | SNMP source interface(s) not configured |
+| s1-spine1 | SNMP | VerifySnmpStatus | Verifies if the SNMP agent is enabled. | - | failure | VRF: default - SNMP agent disabled |
+| s1-spine1 | SNMP | VerifySnmpUser | Verifies the SNMP user configurations. | - | failure | User: test Group: test_group Version: v3 - Not found |
+| s1-spine1 | Software | VerifyEOSExtensions | Verifies that all EOS extensions installed on the device are enabled for boot persistence. | - | success | - |
 | s1-spine1 | Software | VerifyEOSVersion | Verifies the EOS version of the device. | - | failure | EOS version mismatch - Actual: 4.31.0F-33804048.4310F (engineering build) not in Expected: 4.25.4M, 4.26.1F |
+| s1-spine1 | Software | VerifyTerminAttrVersion | Verifies the TerminAttr version of the device. | - | failure | TerminAttr version mismatch - Actual: v1.29.0 not in Expected: v1.13.6, v1.8.0 |
 | s1-spine1 | STP | VerifySTPBlockedPorts | Verifies there is no STP blocked ports. | - | success | - |
-| s1-spine1 | STUN | VerifyStunClient | (Deprecated) Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found. |
-| s1-spine1 | STUN | VerifyStunClientTranslation | Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found.<br>Client 100.64.3.2 Port: 4500 - STUN client translation not found. |
-| s1-spine1 | System | VerifyNTPAssociations | Verifies the Network Time Protocol (NTP) associations. | - | failure | NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Not configured<br>NTP Server: 2.2.2.2 Preferred: False Stratum: 2 - Not configured<br>NTP Server: 3.3.3.3 Preferred: False Stratum: 2 - Not configured |
+| s1-spine1 | STP | VerifySTPCounters | Verifies there is no errors in STP BPDU packets. | - | success | - |
+| s1-spine1 | STP | VerifySTPDisabledVlans | Verifies the STP disabled VLAN(s). | - | failure | VLAN: 6 - Not configured |
+| s1-spine1 | STP | VerifySTPForwardingPorts | Verifies that all interfaces are forwarding for a provided list of VLAN(s). | - | success | - |
+| s1-spine1 | STP | VerifySTPMode | Verifies the configured STP mode for a provided list of VLAN(s). | - | failure | VLAN 10 - Incorrect STP mode - Expected: rapidPvst Actual: mstp<br>VLAN 20 - Incorrect STP mode - Expected: rapidPvst Actual: mstp |
+| s1-spine1 | STP | VerifySTPRootPriority | Verifies the STP root priority for a provided list of VLAN or MST instance ID(s). | - | failure | Instance: MST10 - Not configured<br>Instance: MST20 - Not configured |
+| s1-spine1 | STP | VerifyStpTopologyChanges | Verifies the number of changes across all interfaces in the Spanning Tree Protocol (STP) topology is below a threshold. | - | success | - |
+| s1-spine1 | STUN | VerifyStunClient | (Deprecated) Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found |
+| s1-spine1 | STUN | VerifyStunClientTranslation | Verifies the translation for a source address on a STUN client. | - | failure | Client 172.18.3.2 Port: 4500 - STUN client translation not found<br>Client 100.64.3.2 Port: 4500 - STUN client translation not found |
+| s1-spine1 | STUN | VerifyStunServer | Verifies the STUN server status is enabled and running. | - | failure | STUN server status is disabled and not running |
+| s1-spine1 | System | VerifyAgentLogs | Verifies there are no agent crash reports. | - | success | - |
+| s1-spine1 | System | VerifyCPUUtilization | Verifies whether the CPU utilization is below 75%. | - | success | - |
+| s1-spine1 | System | VerifyCoredump | Verifies there are no core dump files. | - | success | - |
+| s1-spine1 | System | VerifyFileSystemUtilization | Verifies that no partition is utilizing more than 75% of its disk space. | - | success | - |
+| s1-spine1 | System | VerifyMaintenance | Verifies that the device is not currently under or entering maintenance. | - | success | - |
+| s1-spine1 | System | VerifyNTP | Verifies if NTP is synchronised. | - | success | - |
+| s1-spine1 | System | VerifyReloadCause | Verifies the last reload cause of the device. | reload-cause | success | - |
+| s1-spine1 | System | VerifyUptime | Verifies the device uptime. | - | success | - |
 | s1-spine1 | VLAN | VerifyDynamicVlanSource | Verifies dynamic VLAN allocation for specified VLAN sources. | - | failure | Dynamic VLAN source(s) exist but have no VLANs allocated: mlagsync |
-| s1-spine1 | VXLAN | VerifyVxlan1ConnSettings | Verifies the interface vxlan1 source interface and UDP port. | - | success | - |
+| s1-spine1 | VLAN | VerifyVlanInternalPolicy | Verifies the VLAN internal allocation policy and the range of VLANs. | - | failure | VLAN internal allocation policy: ascending - Incorrect end VLAN id configured - Expected: 4094 Actual: 1199 |
+| s1-spine1 | VLAN | VerifyVlanStatus | Verifies the administrative status of specified VLANs. | - | failure | VLAN: Vlan10 - Incorrect administrative status - Expected: suspended Actual: active |
+| s1-spine1 | VXLAN | VerifyVxlan1ConnSettings | Verifies Vxlan1 source interface and UDP port. | - | success | - |
+| s1-spine1 | VXLAN | VerifyVxlan1Interface | Verifies the Vxlan1 interface status. | - | success | - |
+| s1-spine1 | VXLAN | VerifyVxlanConfigSanity | Verifies there are no VXLAN config-sanity inconsistencies. | - | success | - |
+| s1-spine1 | VXLAN | VerifyVxlanVniBinding | Verifies the VNI-VLAN, VNI-VRF bindings of the Vxlan1 interface. | - | failure | Interface: Vxlan1 VNI: 500 - Binding not found |
+| s1-spine1 | VXLAN | VerifyVxlanVtep | Verifies Vxlan1 VTEP peers. | - | failure | The following VTEP peer(s) are missing from the Vxlan1 interface: 10.1.1.5, 10.1.1.6<br>Unexpected VTEP peer(s) on Vxlan1 interface: 10.100.2.3 |

--- a/tests/units/anta_tests/test_logging.py
+++ b/tests/units/anta_tests/test_logging.py
@@ -362,8 +362,8 @@ Mar 12 04:34:01 s1-leaf1 ProcMgr: %PROCMGR-6-PROCESS_TERMINATED: 'SystemInitMoni
         "expected": {
             "result": "failure",
             "messages": [
-                "Pattern: .ACCOUNTING-5-EXEC: cvpadmin ssh. - Not found in last 3 informational log entries",
-                "Pattern: .*ProcMgr worker warm start.* - Not found in last 10 debugging log entries",
+                "Pattern: `.ACCOUNTING-5-EXEC: cvpadmin ssh.` - Not found in last 3 informational log entries",
+                "Pattern: `.*ProcMgr worker warm start.*` - Not found in last 10 debugging log entries",
             ],
         },
     },

--- a/tests/units/result_manager/test__init__.py
+++ b/tests/units/result_manager/test__init__.py
@@ -172,11 +172,11 @@ class TestResultManager:
         assert "results_by_status" not in result_manager.__dict__
 
         # Access the cache
-        assert result_manager.get_total_results() == 30
+        assert result_manager.get_total_results() == 181
 
         # Check the cache is filled with the correct results count
         assert "results_by_status" in result_manager.__dict__
-        assert sum(len(v) for v in result_manager.__dict__["results_by_status"].values()) == 30
+        assert sum(len(v) for v in result_manager.__dict__["results_by_status"].values()) == 181
 
         # Add a new test
         result_manager.add(result=test_result_factory())
@@ -185,50 +185,50 @@ class TestResultManager:
         assert "results_by_status" not in result_manager.__dict__
 
         # Access the cache again
-        assert result_manager.get_total_results() == 31
+        assert result_manager.get_total_results() == 182
 
         # Check the cache is filled again with the correct results count
         assert "results_by_status" in result_manager.__dict__
-        assert sum(len(v) for v in result_manager.__dict__["results_by_status"].values()) == 31
+        assert sum(len(v) for v in result_manager.__dict__["results_by_status"].values()) == 182
 
     def test_get_results(self, result_manager: ResultManager) -> None:
         """Test ResultManager.get_results."""
         # Check for single status
         success_results = result_manager.get_results(status={AntaTestStatus.SUCCESS})
-        assert len(success_results) == 4
+        assert len(success_results) == 43
         assert all(r.result == "success" for r in success_results)
 
         # Check for multiple statuses
         failure_results = result_manager.get_results(status={AntaTestStatus.FAILURE, AntaTestStatus.ERROR})
-        assert len(failure_results) == 17
+        assert len(failure_results) == 104
         assert all(r.result in {"failure", "error"} for r in failure_results)
 
         # Check all results
         all_results = result_manager.get_results()
-        assert len(all_results) == 30
+        assert len(all_results) == 181
 
     def test_get_results_sort_by(self, result_manager: ResultManager) -> None:
         """Test ResultManager.get_results with sort_by."""
         # Check all results with sort_by result
         all_results = result_manager.get_results(sort_by=["result"])
-        assert len(all_results) == 30
-        assert [r.result for r in all_results] == ["error"] * 2 + ["failure"] * 15 + ["skipped"] * 9 + ["success"] * 4
+        assert len(all_results) == 181
+        assert [r.result for r in all_results] == ["error"] * 1 + ["failure"] * 103 + ["skipped"] * 34 + ["success"] * 43
 
         # Check all results with sort_by device (name)
         all_results = result_manager.get_results(sort_by=["name"])
-        assert len(all_results) == 30
+        assert len(all_results) == 181
         assert all_results[0].name == "s1-spine1"
 
         # Check multiple statuses with sort_by categories
         success_skipped_results = result_manager.get_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.SKIPPED}, sort_by=["categories"])
-        assert len(success_skipped_results) == 13
+        assert len(success_skipped_results) == 77
         assert success_skipped_results[0].categories == ["avt"]
         assert success_skipped_results[-1].categories == ["vxlan"]
 
         # Check multiple statuses with sort_by custom_field
         success_skipped_results = result_manager.get_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.SKIPPED}, sort_by=["custom_field"])
-        assert len(success_skipped_results) == 13
-        assert success_skipped_results[-1].test == "VerifyISISNeighborState"
+        assert len(success_skipped_results) == 77
+        assert success_skipped_results[-1].test == "VerifyReloadCause"
 
         # Check all results with bad sort_by
         with pytest.raises(
@@ -242,18 +242,18 @@ class TestResultManager:
     def test_get_total_results(self, result_manager: ResultManager) -> None:
         """Test ResultManager.get_total_results."""
         # Test all results
-        assert result_manager.get_total_results() == 30
+        assert result_manager.get_total_results() == 181
 
         # Test single status
-        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS}) == 4
-        assert result_manager.get_total_results(status={AntaTestStatus.FAILURE}) == 15
-        assert result_manager.get_total_results(status={AntaTestStatus.ERROR}) == 2
-        assert result_manager.get_total_results(status={AntaTestStatus.SKIPPED}) == 9
+        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS}) == 43
+        assert result_manager.get_total_results(status={AntaTestStatus.FAILURE}) == 103
+        assert result_manager.get_total_results(status={AntaTestStatus.ERROR}) == 1
+        assert result_manager.get_total_results(status={AntaTestStatus.SKIPPED}) == 34
 
         # Test multiple statuses
-        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE}) == 19
-        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR}) == 21
-        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED}) == 30
+        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE}) == 146
+        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR}) == 147
+        assert result_manager.get_total_results(status={AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED}) == 181
 
     @pytest.mark.parametrize(
         ("status", "error_status", "ignore_error", "expected_status"),

--- a/tests/units/result_manager/test_files/test_md_report_results.json
+++ b/tests/units/result_manager/test_files/test_md_report_results.json
@@ -1,389 +1,2356 @@
 [
   {
-    "name": "s1-spine1",
-    "test": "VerifyMlagDualPrimary",
-    "categories": [
-      "mlag"
-    ],
-    "description": "Verifies the MLAG dual-primary detection parameters.",
-    "result": "failure",
-    "messages": [
-      "Dual-primary detection is disabled"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyInterfacesStatus",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the operational states of specified interfaces to ensure they match expected configurations.",
+      "result": "failure",
+      "messages": [
+          "Port-Channel100 - Not configured",
+          "Ethernet49/1 - Not configured"
+      ],
+      "custom_field": "interface"
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyHostname",
-    "categories": [
-      "services"
-    ],
-    "description": "Verifies the hostname of a device.",
-    "result": "failure",
-    "messages": [
-      "Incorrect Hostname - Expected: s1-spine1 Actual: leaf1-dc1"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyVlanStatus",
+      "categories": [
+          "vlan"
+      ],
+      "description": "Verifies the administrative status of specified VLANs.",
+      "result": "failure",
+      "messages": [
+          "VLAN: Vlan10 - Incorrect administrative status - Expected: suspended Actual: active"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyBGPAdvCommunities",
-    "categories": [
-      "bgp"
-    ],
-    "description": "Verifies that advertised communities are standard, extended and large for BGP IPv4 peer(s).",
-    "result": "error",
-    "messages": [
-      "show bgp neighbors vrf all has failed: The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model., The command is only supported in the multi-agent routing protocol model."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyReloadCause",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies the last reload cause of the device.",
+      "result": "success",
+      "messages": [],
+      "custom_field": "reload-cause"
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyStunClient",
-    "categories": [
-      "stun"
-    ],
-    "description": "(Deprecated) Verifies the translation for a source address on a STUN client.",
-    "result": "failure",
-    "messages": [
-      "Client 172.18.3.2 Port: 4500 - STUN client translation not found."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyVxlanVniBinding",
+      "categories": [
+          "vxlan"
+      ],
+      "description": "Verifies the VNI-VLAN, VNI-VRF bindings of the Vxlan1 interface.",
+      "result": "failure",
+      "messages": [
+          "Interface: Vxlan1 VNI: 500 - Binding not found"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyBannerLogin",
-    "categories": [
-      "security"
-    ],
-    "description": "Verifies the login banner of a device.",
-    "result": "failure",
-    "messages": [
-      "Expected `# Copyright (c) 2023-2024 Arista Networks, Inc.\n# Use of this source code is governed by the Apache License 2.0\n# that can be found in the LICENSE file.\n` as the login banner, but found `` instead."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyISISNeighborState",
+      "categories": [
+          "isis"
+      ],
+      "description": "Verifies the health of IS-IS neighbors.",
+      "result": "skipped",
+      "messages": [
+          "IS-IS not configured"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyISISNeighborState",
-    "categories": [
-      "isis"
-    ],
-    "description": "Verifies the health of IS-IS neighbors.",
-    "result": "skipped",
-    "messages": [
-      "IS-IS not configured"
-    ],
-    "custom_field": "custom"
+      "name": "s1-spine1",
+      "test": "VerifyMlagStatus",
+      "categories": [
+          "mlag"
+      ],
+      "description": "Verifies the health status of the MLAG configuration.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyEOSVersion",
-    "categories": [
-      "software"
-    ],
-    "description": "Verifies the EOS version of the device.",
-    "result": "failure",
-    "messages": [
-      "EOS version mismatch - Actual: 4.31.0F-33804048.4310F (engineering build) not in Expected: 4.25.4M, 4.26.1F"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyTemperature",
+      "categories": [
+          "hardware"
+      ],
+      "description": "Verifies if the device temperature is within acceptable limits.",
+      "result": "skipped",
+      "messages": [
+          "VerifyTemperature test is not supported on cEOSLab"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyTcamProfile",
-    "categories": [
-      "profiles"
-    ],
-    "description": "Verifies the device TCAM profile.",
-    "result": "skipped",
-    "messages": [
-      "VerifyTcamProfile test is not supported on cEOSLab."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyPtpModeStatus",
+      "categories": [
+          "ptp"
+      ],
+      "description": "Verifies that the device is configured as a PTP Boundary Clock.",
+      "result": "skipped",
+      "messages": [
+          "VerifyPtpModeStatus test is not supported on cEOSLab"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyPathsHealth",
-    "categories": [
-      "path-selection"
-    ],
-    "description": "Verifies the path and telemetry state of all paths under router path-selection.",
-    "result": "skipped",
-    "messages": [
-      "VerifyPathsHealth test is not supported on cEOSLab."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyAcctConsoleMethods",
+      "categories": [
+          "aaa"
+      ],
+      "description": "Verifies the AAA accounting console method lists for different accounting types (system, exec, commands, dot1x).",
+      "result": "failure",
+      "messages": [
+          "AAA console accounting is not configured for commands, exec, system, dot1x"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyBannerMotd",
-    "categories": [
-      "security"
-    ],
-    "description": "Verifies the motd banner of a device.",
-    "result": "failure",
-    "messages": [
-      "Expected `# Copyright (c) 2023-2024 Arista Networks, Inc.\n# Use of this source code is governed by the Apache License 2.0\n# that can be found in the LICENSE file.\n` as the motd banner, but found `` instead."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyL3MTU",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the global L3 MTU of all L3 interfaces.",
+      "result": "failure",
+      "messages": [
+          "Interface: Ethernet2 - Incorrect MTU - Expected: 1500 Actual: 9214",
+          "Interface: Ethernet1 - Incorrect MTU - Expected: 2500 Actual: 9214",
+          "Interface: Loopback0 - Incorrect MTU - Expected: 1500 Actual: 65535",
+          "Interface: Loopback1 - Incorrect MTU - Expected: 1500 Actual: 65535",
+          "Interface: Vlan1006 - Incorrect MTU - Expected: 1500 Actual: 9164",
+          "Interface: Vlan1199 - Incorrect MTU - Expected: 1500 Actual: 9164",
+          "Interface: Vlan4093 - Incorrect MTU - Expected: 1500 Actual: 9214",
+          "Interface: Vlan4094 - Incorrect MTU - Expected: 1500 Actual: 9214",
+          "Interface: Vlan3019 - Incorrect MTU - Expected: 1500 Actual: 9214",
+          "Interface: Vlan3009 - Incorrect MTU - Expected: 1500 Actual: 9214"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyFieldNotice44Resolution",
-    "categories": [
-      "field notices"
-    ],
-    "description": "Verifies that the device is using the correct Aboot version per FN0044.",
-    "result": "skipped",
-    "messages": [
-      "VerifyFieldNotice44Resolution test is not supported on cEOSLab."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyDNSLookup",
+      "categories": [
+          "services"
+      ],
+      "description": "Verifies the DNS name to IP address resolution.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyLoggingHosts",
-    "categories": [
-      "logging"
-    ],
-    "description": "Verifies logging hosts (syslog servers) for a specified VRF.",
-    "result": "failure",
-    "messages": [
-      "Syslog servers 1.1.1.1, 2.2.2.2 are not configured in VRF default"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerRouteRefreshCap",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the route refresh capabilities of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyAVTPathHealth",
-    "categories": [
-      "avt"
-    ],
-    "description": "Verifies the status of all AVT paths for all VRFs.",
-    "result": "skipped",
-    "messages": [
-      "VerifyAVTPathHealth test is not supported on cEOSLab."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyUptime",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies the device uptime.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyTemperature",
-    "categories": [
-      "hardware"
-    ],
-    "description": "Verifies if the device temperature is within acceptable limits.",
-    "result": "skipped",
-    "messages": [
-      "VerifyTemperature test is not supported on cEOSLab."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyAuthenMethods",
+      "categories": [
+          "aaa"
+      ],
+      "description": "Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).",
+      "result": "failure",
+      "messages": [
+          "AAA authentication methods are not configured for login console"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyNTPAssociations",
-    "categories": [
-      "system"
-    ],
-    "description": "Verifies the Network Time Protocol (NTP) associations.",
-    "result": "failure",
-    "messages": [
-      "NTP Server: 1.1.1.1 Preferred: True Stratum: 1 - Not configured",
-      "NTP Server: 2.2.2.2 Preferred: False Stratum: 2 - Not configured",
-      "NTP Server: 3.3.3.3 Preferred: False Stratum: 2 - Not configured"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyHardwareFlowTrackerStatus",
+      "categories": [
+          "flow tracking"
+      ],
+      "description": "Verifies the hardware flow tracking state.",
+      "result": "skipped",
+      "messages": [
+          "VerifyHardwareFlowTrackerStatus test is not supported on cEOSLab"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyDynamicVlanSource",
-    "categories": [
-      "vlan"
-    ],
-    "description": "Verifies dynamic VLAN allocation for specified VLAN sources.",
-    "result": "failure",
-    "messages": [
-      "Dynamic VLAN source(s) exist but have no VLANs allocated: mlagsync"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyTransceiversManufacturers",
+      "categories": [
+          "hardware"
+      ],
+      "description": "Verifies if all the transceivers come from approved manufacturers.",
+      "result": "skipped",
+      "messages": [
+          "VerifyTransceiversManufacturers test is not supported on cEOSLab"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyActiveCVXConnections",
-    "categories": [
-      "cvx"
-    ],
-    "description": "Verifies the number of active CVX Connections.",
-    "result": "error",
-    "messages": [
-      "show cvx connections brief has failed: Unavailable command (controller not ready) (at token 2: 'connections')"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyPtpPortModeStatus",
+      "categories": [
+          "ptp"
+      ],
+      "description": "Verifies the PTP interfaces state.",
+      "result": "skipped",
+      "messages": [
+          "VerifyPtpPortModeStatus test is not supported on cEOSLab"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyIPv4RouteNextHops",
-    "categories": [
-      "routing"
-    ],
-    "description": "Verifies the next-hops of the IPv4 prefixes.",
-    "result": "success",
-    "messages": [],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyTacacsServerGroups",
+      "categories": [
+          "aaa"
+      ],
+      "description": "Verifies if the provided TACACS server group(s) are configured.",
+      "result": "failure",
+      "messages": [
+          "No TACACS server group(s) are configured"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyVxlan1ConnSettings",
-    "categories": [
-      "vxlan"
-    ],
-    "description": "Verifies the interface vxlan1 source interface and UDP port.",
-    "result": "success",
-    "messages": [],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyISISSegmentRoutingDataplane",
+      "categories": [
+          "isis",
+          "segment-routing"
+      ],
+      "description": "Verifies IS-IS segment routing data-plane configuration.",
+      "result": "skipped",
+      "messages": [
+          "IS-IS not configured"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyStunClientTranslation",
-    "categories": [
-      "stun"
-    ],
-    "description": "Verifies the translation for a source address on a STUN client.",
-    "result": "failure",
-    "messages": [
-      "Client 172.18.3.2 Port: 4500 - STUN client translation not found.",
-      "Client 100.64.3.2 Port: 4500 - STUN client translation not found."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyReachability",
+      "categories": [
+          "connectivity"
+      ],
+      "description": "Test network reachability to one or many destination IP(s).",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyPtpGMStatus",
-    "categories": [
-      "ptp"
-    ],
-    "description": "Verifies that the device is locked to a valid PTP Grandmaster.",
-    "result": "skipped",
-    "messages": [
-      "VerifyPtpGMStatus test is not supported on cEOSLab."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerGroup",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP peer group of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyRunningConfigDiffs",
-    "categories": [
-      "configuration"
-    ],
-    "description": "Verifies there is no difference between the running-config and the startup-config.",
-    "result": "success",
-    "messages": [],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyErrdisableRecovery",
+      "categories": [
+          "services"
+      ],
+      "description": "Verifies the error disable recovery functionality.",
+      "result": "failure",
+      "messages": [
+          "Reason: acl Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300",
+          "Reason: bpduguard Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyBFDPeersHealth",
-    "categories": [
-      "bfd"
-    ],
-    "description": "Verifies the health of IPv4 BFD peers across all VRFs.",
-    "result": "failure",
-    "messages": [
-      "No IPv4 BFD peers are configured for any VRF."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyAcctDefaultMethods",
+      "categories": [
+          "aaa"
+      ],
+      "description": "Verifies the AAA accounting default method lists for different accounting types (system, exec, commands, dot1x).",
+      "result": "failure",
+      "messages": [
+          "AAA default accounting is not configured for commands, exec, system, dot1x"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyIPProxyARP",
-    "categories": [
-      "interfaces"
-    ],
-    "description": "Verifies if Proxy ARP is enabled.",
-    "result": "failure",
-    "messages": [
-      "Interface: Ethernet1 - Proxy-ARP disabled",
-      "Interface: Ethernet2 - Proxy-ARP disabled"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyTacacsServers",
+      "categories": [
+          "aaa"
+      ],
+      "description": "Verifies TACACS servers are configured for a specified VRF.",
+      "result": "failure",
+      "messages": [
+          "No TACACS servers are configured"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifySnmpContact",
-    "categories": [
-      "snmp"
-    ],
-    "description": "Verifies the SNMP contact of a device.",
-    "result": "failure",
-    "messages": [
-      "SNMP contact is not configured."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifySpecificPath",
+      "categories": [
+          "path-selection"
+      ],
+      "description": "Verifies the DPS path and telemetry state of an IPv4 peer.",
+      "result": "skipped",
+      "messages": [
+          "VerifySpecificPath test is not supported on cEOSLab"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyLLDPNeighbors",
-    "categories": [
-      "connectivity"
-    ],
-    "description": "Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors.",
-    "result": "failure",
-    "messages": [
-      "Port: Ethernet1 Neighbor: DC1-SPINE1 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine1-dc1.fun.aristanetworks.com/Ethernet3",
-      "Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine2-dc1.fun.aristanetworks.com/Ethernet3"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyInterfaceUtilization",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies that the utilization of interfaces is below a certain threshold.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyAcctConsoleMethods",
-    "categories": [
-      "aaa"
-    ],
-    "description": "Verifies the AAA accounting console method lists for different accounting types (system, exec, commands, dot1x).",
-    "result": "failure",
-    "messages": [
-      "AAA console accounting is not configured for commands, exec, system, dot1x"
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyL2MTU",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the global L2 MTU of all L2 interfaces.",
+      "result": "failure",
+      "messages": [
+          "Interface: Ethernet3 - Incorrect MTU configured - Expected: 1500 Actual: 9214",
+          "Interface: Port-Channel5 - Incorrect MTU configured - Expected: 1500 Actual: 9214"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyOSPFMaxLSA",
-    "categories": [
-      "ospf"
-    ],
-    "description": "Verifies all OSPF instances did not cross the maximum LSA threshold.",
-    "result": "skipped",
-    "messages": [
-      "No OSPF instance found."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyCoredump",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies there are no core dump files.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifySTPBlockedPorts",
-    "categories": [
-      "stp"
-    ],
-    "description": "Verifies there is no STP blocked ports.",
-    "result": "success",
-    "messages": [],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifyISISGracefulRestart",
+      "categories": [
+          "isis"
+      ],
+      "description": "Verifies the IS-IS graceful restart feature.",
+      "result": "skipped",
+      "messages": [
+          "IS-IS not configured"
+      ],
+      "custom_field": null
   },
   {
-    "name": "s1-spine1",
-    "test": "VerifyLANZ",
-    "categories": [
-      "lanz"
-    ],
-    "description": "Verifies if LANZ is enabled.",
-    "result": "skipped",
-    "messages": [
-      "VerifyLANZ test is not supported on cEOSLab."
-    ],
-    "custom_field": null
+      "name": "s1-spine1",
+      "test": "VerifySSHStatus",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if the SSHD agent is disabled in the default VRF.",
+      "result": "failure",
+      "messages": [
+          "SSHD status for Default VRF is enabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyTacacsSourceIntf",
+      "categories": [
+          "aaa"
+      ],
+      "description": "Verifies TACACS source-interface for a specified VRF.",
+      "result": "failure",
+      "messages": [
+          "VRF: MGMT Source Interface: Management0 - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMcsClientMounts",
+      "categories": [
+          "cvx"
+      ],
+      "description": "Verify if all MCS client mounts are in mountStateMountComplete.",
+      "result": "failure",
+      "messages": [
+          "MCS Client mount states are not present"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIGMPSnoopingGlobal",
+      "categories": [
+          "multicast"
+      ],
+      "description": "Verifies the IGMP snooping global status.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyISISNeighborCount",
+      "categories": [
+          "isis"
+      ],
+      "description": "Verifies the number of IS-IS neighbors per interface and level.",
+      "result": "skipped",
+      "messages": [
+          "IS-IS not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyGreenTCounters",
+      "categories": [
+          "greent"
+      ],
+      "description": "Verifies if the GreenT counters are incremented.",
+      "result": "failure",
+      "messages": [
+          "GreenT counters are not incremented"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBFDSpecificPeers",
+      "categories": [
+          "bfd"
+      ],
+      "description": "Verifies the state of IPv4 BFD peer sessions.",
+      "result": "failure",
+      "messages": [
+          "Peer: 192.0.255.8 VRF: default - Not found",
+          "Peer: 192.0.255.7 VRF: default - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIllegalLACP",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies there are no illegal LACP packets in all port channels.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyCVXClusterStatus",
+      "categories": [
+          "cvx"
+      ],
+      "description": "Verifies the CVX Server Cluster status.",
+      "result": "failure",
+      "messages": [
+          "CVX Server status is not enabled",
+          "CVX Server is not a cluster"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeersHealthRibd",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the health of all the BGP peers.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyOSPFNeighborState",
+      "categories": [
+          "ospf"
+      ],
+      "description": "Verifies all OSPF neighbors are in FULL state.",
+      "result": "skipped",
+      "messages": [
+          "OSPF not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyEOSExtensions",
+      "categories": [
+          "software"
+      ],
+      "description": "Verifies that all EOS extensions installed on the device are enabled for boot persistence.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingTimestamp",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies if logs are generated with the appropriate timestamp.",
+      "result": "failure",
+      "messages": [
+          "Logs are not generated with the appropriate timestamp format"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpNotificationHost",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies the SNMP notification host(s) (SNMP manager) configurations.",
+      "result": "failure",
+      "messages": [
+          "No SNMP host is configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyPathsHealth",
+      "categories": [
+          "path-selection"
+      ],
+      "description": "Verifies the path and telemetry state of all paths under router path-selection.",
+      "result": "skipped",
+      "messages": [
+          "VerifyPathsHealth test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAPIHttpsSSL",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if the eAPI has a valid SSL profile.",
+      "result": "failure",
+      "messages": [
+          "eAPI HTTPS server SSL profile default is not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMlagDualPrimary",
+      "categories": [
+          "mlag"
+      ],
+      "description": "Verifies the MLAG dual-primary detection parameters.",
+      "result": "failure",
+      "messages": [
+          "Dual-primary detection is disabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyEVPNType5Routes",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies EVPN Type-5 routes for given IP prefixes and VNIs.",
+      "result": "failure",
+      "messages": [
+          "Prefix: 192.168.10.0/24 VNI: 10 - No EVPN Type-5 routes found",
+          "Prefix: 192.168.20.0/24 VNI: 20 - No EVPN Type-5 routes found",
+          "Prefix: 192.168.30.0/24 VNI: 30 - No EVPN Type-5 routes found",
+          "Prefix: 192.168.40.0/24 VNI: 40 - No EVPN Type-5 routes found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySTPCounters",
+      "categories": [
+          "stp"
+      ],
+      "description": "Verifies there is no errors in STP BPDU packets.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMlagConfigSanity",
+      "categories": [
+          "mlag"
+      ],
+      "description": "Verifies there are no MLAG config-sanity inconsistencies.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySVI",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the status of all SVIs.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAVTPathHealth",
+      "categories": [
+          "avt"
+      ],
+      "description": "Verifies the status of all AVT paths for all VRFs.",
+      "result": "skipped",
+      "messages": [
+          "VerifyAVTPathHealth test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPExchangedRoutes",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the advertised and received routes of BGP IPv4 peer(s).",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.255.5 VRF: default Advertised route: 192.0.254.5/32 - Not found",
+          "Peer: 172.30.255.5 VRF: default Received route: 192.0.255.4/32 - Not found",
+          "Peer: 172.30.255.1 VRF: default Advertised route: 192.0.255.1/32 - Not found",
+          "Peer: 172.30.255.1 VRF: default Advertised route: 192.0.254.5/32 - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySTPForwardingPorts",
+      "categories": [
+          "stp"
+      ],
+      "description": "Verifies that all interfaces are forwarding for a provided list of VLAN(s).",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyInterfaceErrors",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies that the interfaces error counters are equal to zero.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyISISInterfaceMode",
+      "categories": [
+          "isis"
+      ],
+      "description": "Verifies IS-IS interfaces are running in the correct mode.",
+      "result": "skipped",
+      "messages": [
+          "IS-IS not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyEnvironmentCooling",
+      "categories": [
+          "hardware"
+      ],
+      "description": "Verifies the status of power supply fans and all fan trays.",
+      "result": "skipped",
+      "messages": [
+          "VerifyEnvironmentCooling test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpGroup",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies the SNMP group configurations for specified version(s).",
+      "result": "failure",
+      "messages": [
+          "Group: Group1 Version: v1 - Not configured",
+          "Group: Group2 Version: v3 - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBFDPeersHealth",
+      "categories": [
+          "bfd"
+      ],
+      "description": "Verifies the health of IPv4 BFD peers across all VRFs.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLLDPNeighbors",
+      "categories": [
+          "connectivity"
+      ],
+      "description": "Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors.",
+      "result": "failure",
+      "messages": [
+          "Port: Ethernet1 Neighbor: DC1-SPINE1 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine1-dc1.fun.aristanetworks.com/Ethernet3",
+          "Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: spine2-dc1.fun.aristanetworks.com/Ethernet3"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyFieldNotice44Resolution",
+      "categories": [
+          "field notices"
+      ],
+      "description": "Verifies that the device is using the correct Aboot version per FN0044.",
+      "result": "skipped",
+      "messages": [
+          "VerifyFieldNotice44Resolution test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpErrorCounters",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies the SNMP error counters.",
+      "result": "failure",
+      "messages": [
+          "SNMP counters not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPRouteECMP",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP IPv4 route ECMP paths.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyUnifiedForwardingTableMode",
+      "categories": [
+          "profiles"
+      ],
+      "description": "Verifies the device is using the expected UFT mode.",
+      "result": "skipped",
+      "messages": [
+          "VerifyUnifiedForwardingTableMode test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpContact",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies the SNMP contact of a device.",
+      "result": "failure",
+      "messages": [
+          "SNMP contact is not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpLocation",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies the SNMP location of a device.",
+      "result": "failure",
+      "messages": [
+          "SNMP location is not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBannerLogin",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies the login banner of a device.",
+      "result": "failure",
+      "messages": [
+          "Login banner is not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyVxlanConfigSanity",
+      "categories": [
+          "vxlan"
+      ],
+      "description": "Verifies there are no VXLAN config-sanity inconsistencies.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerCount",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the count of BGP peers for given address families.",
+      "result": "failure",
+      "messages": [
+          "AFI: ipv4 SAFI: unicast VRF: PROD - VRF not configured",
+          "AFI: ipv4 SAFI: multicast VRF: DEV - VRF not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeersHealth",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the health of BGP peers for given address families.",
+      "result": "failure",
+      "messages": [
+          "AFI: ipv6 SAFI: unicast VRF: DEV - VRF not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyRunningConfigDiffs",
+      "categories": [
+          "configuration"
+      ],
+      "description": "Verifies there is no difference between the running-config and the startup-config.",
+      "result": "failure",
+      "messages": [
+          "--- flash:/startup-config\n+++ system:/running-config\n@@ -18,6 +18,7 @@\n hostname leaf1-dc1\n ip name-server vrf MGMT 10.14.0.1\n dns domain fun.aristanetworks.com\n+ip host vitthal 192.168.66.220\n !\n platform tfa\n    personality arfa\n"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyNTP",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies if NTP is synchronised.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyEnvironmentPower",
+      "categories": [
+          "hardware"
+      ],
+      "description": "Verifies the power supplies status.",
+      "result": "skipped",
+      "messages": [
+          "VerifyEnvironmentPower test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAVTSpecificPath",
+      "categories": [
+          "avt"
+      ],
+      "description": "Verifies the Adaptive Virtual Topology (AVT) path.",
+      "result": "skipped",
+      "messages": [
+          "VerifyAVTSpecificPath test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAuthzMethods",
+      "categories": [
+          "aaa"
+      ],
+      "description": "Verifies the AAA authorization method lists for different authorization types (commands, exec).",
+      "result": "failure",
+      "messages": [
+          "AAA authorization methods local, none, logging are not matching for commands, exec"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpHostLogging",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies SNMP logging configurations.",
+      "result": "failure",
+      "messages": [
+          "SNMP logging is disabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingLogsGeneration",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies if logs are generated.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyDNSServers",
+      "categories": [
+          "services"
+      ],
+      "description": "Verifies if the DNS (Domain Name Service) servers are correctly configured.",
+      "result": "failure",
+      "messages": [
+          "Server 10.14.0.1 VRF: default Priority: 1 - Not configured",
+          "Server 10.14.0.11 VRF: MGMT Priority: 0 - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingHostname",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies if logs are generated with the device FQDN.",
+      "result": "failure",
+      "messages": [
+          "Logs are not generated with the device FQDN"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyTcamProfile",
+      "categories": [
+          "profiles"
+      ],
+      "description": "Verifies the device TCAM profile.",
+      "result": "skipped",
+      "messages": [
+          "VerifyTcamProfile test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAPIHttpStatus",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if eAPI HTTP server is disabled globally.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyInterfaceIPv4",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the interface IPv4 addresses.",
+      "result": "failure",
+      "messages": [
+          "Interface: Ethernet2 - IP address mismatch - Expected: 172.30.11.1/31 Actual: 10.100.0.11/31",
+          "Interface: Ethernet2 - Secondary IP address is not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingSourceIntf",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies logging source-interface for a specified VRF.",
+      "result": "failure",
+      "messages": [
+          "Source-interface: Management0 VRF: default - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyRoutingProtocolModel",
+      "categories": [
+          "routing"
+      ],
+      "description": "Verifies the configured routing protocol model.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPRedistribution",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP redistribution.",
+      "result": "error",
+      "messages": [
+          "show bgp instance vrf all has failed: Invalid requested version for ModelMetaClass: no such revision 4, most current is 3"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMlagInterfaces",
+      "categories": [
+          "mlag"
+      ],
+      "description": "Verifies there are no inactive or active-partial MLAG ports.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpSourceInterface",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies SNMP source interfaces.",
+      "result": "failure",
+      "messages": [
+          "SNMP source interface(s) not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyEVPNType2Route",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the EVPN Type-2 routes for a given IPv4 or MAC address and VNI.",
+      "result": "failure",
+      "messages": [
+          "Address: 192.168.20.102 VNI: 10020 - No EVPN Type-2 route",
+          "Address: aa:c1:ab:5d:b4:1e VNI: 10010 - No EVPN Type-2 route"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpStatus",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies if the SNMP agent is enabled.",
+      "result": "failure",
+      "messages": [
+          "VRF: default - SNMP agent disabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyActiveCVXConnections",
+      "categories": [
+          "cvx"
+      ],
+      "description": "Verifies the number of active CVX Connections.",
+      "result": "failure",
+      "messages": [
+          "'show cvx connections brief' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'connections')"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySTPRootPriority",
+      "categories": [
+          "stp"
+      ],
+      "description": "Verifies the STP root priority for a provided list of VLAN or MST instance ID(s).",
+      "result": "failure",
+      "messages": [
+          "Instance: MST10 - Not configured",
+          "Instance: MST20 - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerTtlMultiHops",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP TTL and max-ttl-hops count for BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: 172.30.11.2 VRF: test - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpPDUCounters",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies the SNMP PDU counters.",
+      "result": "failure",
+      "messages": [
+          "SNMP counters not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyRunningConfigLines",
+      "categories": [
+          "configuration"
+      ],
+      "description": "Search the Running-Config for the given RegEx patterns.",
+      "result": "failure",
+      "messages": [
+          "Following patterns were not found: '^enable password.*$', 'bla bla'"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyPtpGMStatus",
+      "categories": [
+          "ptp"
+      ],
+      "description": "Verifies that the device is locked to a valid PTP Grandmaster.",
+      "result": "skipped",
+      "messages": [
+          "VerifyPtpGMStatus test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIpVirtualRouterMac",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the IP virtual router MAC address.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerASNCap",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the four octet ASN capability of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIPProxyARP",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies if Proxy ARP is enabled.",
+      "result": "failure",
+      "messages": [
+          "Interface: Ethernet1 - Proxy-ARP disabled",
+          "Interface: Ethernet2 - Proxy-ARP disabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingPersistent",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies if logging persistent is enabled and logs are saved in flash.",
+      "result": "failure",
+      "messages": [
+          "Persistent logging is disabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMlagPrimaryPriority",
+      "categories": [
+          "mlag"
+      ],
+      "description": "Verifies the configuration of the MLAG primary priority.",
+      "result": "failure",
+      "messages": [
+          "MLAG primary priority mismatch - Expected: 3276 Actual: 32767"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyStunServer",
+      "categories": [
+          "stun"
+      ],
+      "description": "Verifies the STUN server status is enabled and running.",
+      "result": "failure",
+      "messages": [
+          "STUN server status is disabled and not running"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyOSPFNeighborCount",
+      "categories": [
+          "ospf"
+      ],
+      "description": "Verifies the number of OSPF neighbors in FULL state is the one we expect.",
+      "result": "skipped",
+      "messages": [
+          "OSPF not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyRoutingTableEntry",
+      "categories": [
+          "routing"
+      ],
+      "description": "Verifies that the provided routes are present in the routing table of a specified VRF.",
+      "result": "failure",
+      "messages": [
+          "The following route(s) are missing from the routing table of VRF default: 10.1.0.1, 10.1.0.2"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAdverseDrops",
+      "categories": [
+          "hardware"
+      ],
+      "description": "Verifies there are no adverse drops on DCS-7280 and DCS-7500 family switches.",
+      "result": "skipped",
+      "messages": [
+          "VerifyAdverseDrops test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyISISSegmentRoutingAdjacencySegments",
+      "categories": [
+          "isis",
+          "segment-routing"
+      ],
+      "description": "Verifies IS-IS segment routing adjacency segments.",
+      "result": "skipped",
+      "messages": [
+          "IS-IS not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIPv4ACL",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies the configuration of IPv4 ACLs.",
+      "result": "failure",
+      "messages": [
+          "ACL name: LabTest - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyOSPFMaxLSA",
+      "categories": [
+          "ospf"
+      ],
+      "description": "Verifies all OSPF instances did not cross the maximum LSA threshold.",
+      "result": "skipped",
+      "messages": [
+          "OSPF not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPNlriAcceptance",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies that all received NLRI are accepted for all AFI/SAFI configured for BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 10.100.0.128 VRF: default - Not found",
+          "Peer: 2001:db8:1::2 VRF: default - Not found",
+          "Peer: fe80::2%Et1 VRF: default - Not found",
+          "Peer: fe80::2%Et1 VRF: default - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyCPUUtilization",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies whether the CPU utilization is below 75%.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyDynamicVlanSource",
+      "categories": [
+          "vlan"
+      ],
+      "description": "Verifies dynamic VLAN allocation for specified VLAN sources.",
+      "result": "failure",
+      "messages": [
+          "Dynamic VLAN source(s) exist but have no VLANs allocated: mlagsync"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyEnvironmentSystemCooling",
+      "categories": [
+          "hardware"
+      ],
+      "description": "Verifies the device's system cooling status.",
+      "result": "skipped",
+      "messages": [
+          "VerifyEnvironmentSystemCooling test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyHardwareEntropy",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies hardware entropy generation is enabled on device.",
+      "result": "failure",
+      "messages": [
+          "Hardware entropy generation is disabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySpecificIPSecConn",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies the IPv4 security connections.",
+      "result": "failure",
+      "messages": [
+          "Peer: 10.255.0.1 VRF: default - Not configured",
+          "Peer: 10.255.0.2 VRF: default - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingHosts",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies logging hosts (syslog servers) for a specified VRF.",
+      "result": "failure",
+      "messages": [
+          "Syslog servers 1.1.1.1, 2.2.2.2 are not configured in VRF default"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPTimers",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the timers of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: 172.30.11.5 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLANZ",
+      "categories": [
+          "lanz"
+      ],
+      "description": "Verifies if LANZ is enabled.",
+      "result": "skipped",
+      "messages": [
+          "VerifyLANZ test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySTPMode",
+      "categories": [
+          "stp"
+      ],
+      "description": "Verifies the configured STP mode for a provided list of VLAN(s).",
+      "result": "failure",
+      "messages": [
+          "VLAN 10 - Incorrect STP mode - Expected: rapidPvst Actual: mstp",
+          "VLAN 20 - Incorrect STP mode - Expected: rapidPvst Actual: mstp"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyPtpOffset",
+      "categories": [
+          "ptp"
+      ],
+      "description": "Verifies that the PTP timing offset is within +/- 1000ns from the master clock.",
+      "result": "skipped",
+      "messages": [
+          "VerifyPtpOffset test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpUser",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies the SNMP user configurations.",
+      "result": "failure",
+      "messages": [
+          "User: test Group: test_group Version: v3 - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAVTRole",
+      "categories": [
+          "avt"
+      ],
+      "description": "Verifies the AVT role of a device.",
+      "result": "skipped",
+      "messages": [
+          "VerifyAVTRole test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyVlanInternalPolicy",
+      "categories": [
+          "vlan"
+      ],
+      "description": "Verifies the VLAN internal allocation policy and the range of VLANs.",
+      "result": "failure",
+      "messages": [
+          "VLAN internal allocation policy: ascending - Incorrect end VLAN id configured - Expected: 4094 Actual: 1199"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyTelnetStatus",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if Telnet is disabled in the default VRF.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyHostname",
+      "categories": [
+          "services"
+      ],
+      "description": "Verifies the hostname of a device.",
+      "result": "failure",
+      "messages": [
+          "Incorrect Hostname - Expected: s1-spine1 Actual: leaf1-dc1"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerRouteLimit",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies maximum routes and warning limit for BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyVxlan1Interface",
+      "categories": [
+          "vxlan"
+      ],
+      "description": "Verifies the Vxlan1 interface status.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyZeroTouch",
+      "categories": [
+          "configuration"
+      ],
+      "description": "Verifies ZeroTouch is disabled.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerMPCaps",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the multiprotocol capabilities of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: default - ipv4MplsLabels not found",
+          "Interface: Ethernet1 VRF: default - ipv4MplsVpn not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBFDPeersIntervals",
+      "categories": [
+          "bfd"
+      ],
+      "description": "Verifies the timers of IPv4 BFD peer sessions.",
+      "result": "failure",
+      "messages": [
+          "Peer: 192.0.255.8 VRF: default - Not found",
+          "Peer: 192.0.255.7 VRF: default - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyVxlan1ConnSettings",
+      "categories": [
+          "vxlan"
+      ],
+      "description": "Verifies Vxlan1 source interface and UDP port.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyRoutingStatus",
+      "categories": [
+          "routing"
+      ],
+      "description": "Verifies the routing status for IPv4/IPv6 unicast, multicast, and IPv6 interfaces (RFC5549).",
+      "result": "failure",
+      "messages": [
+          "IPv6 unicast routing enabled status mismatch - Expected: True Actual: False"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMlagReloadDelay",
+      "categories": [
+          "mlag"
+      ],
+      "description": "Verifies the reload-delay parameters of the MLAG configuration.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIPv4RouteNextHops",
+      "categories": [
+          "routing"
+      ],
+      "description": "Verifies the next-hops of the IPv4 prefixes.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerMD5Auth",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the MD5 authentication and state of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: 172.30.11.5 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: default - Session does not have MD5 authentication enabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySSHIPv6Acl",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if the SSHD agent has IPv6 ACL(s) configured.",
+      "result": "failure",
+      "messages": [
+          "VRF: default - SSH IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySTPBlockedPorts",
+      "categories": [
+          "stp"
+      ],
+      "description": "Verifies there is no STP blocked ports.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingErrors",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies there are no syslog messages with a severity of ERRORS or higher.",
+      "result": "failure",
+      "messages": [
+          "Device has reported syslog messages with a severity of ERRORS or higher:\nApr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF data AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes \n Apr 29 08:01:27 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: sent to neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes \n Apr 29 08:01:29 leaf1-dc1 Bgp: %BGP-3-NOTIFICATION: received from neighbor 10.100.4.5 (VRF guest AS 65102) 6/7 (Cease/connection collision resolution) 0 bytes \n \n"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyInterfacesSpeed",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the speed, lanes, auto-negotiation status, and mode as full duplex for interfaces.",
+      "result": "failure",
+      "messages": [
+          "Interface: Ethernet2 - Bandwidth mismatch - Expected: 10.0Gbps Actual: 1Gbps",
+          "Interface: Ethernet3 - Bandwidth mismatch - Expected: 100.0Gbps Actual: 1Gbps",
+          "Interface: Ethernet3 - Auto-negotiation mismatch - Expected: success Actual: unknown",
+          "Interface: Ethernet3 - Data lanes count mismatch - Expected: 1 Actual: 0",
+          "Interface: Ethernet2 - Bandwidth mismatch - Expected: 2.5Gbps Actual: 1Gbps"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyInterfaceErrDisabled",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies there are no interfaces in the errdisabled state.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyPortChannels",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies there are no inactive ports in all port channels.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoopbackCount",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the number of loopback interfaces and their status.",
+      "result": "failure",
+      "messages": [
+          "Loopback interface(s) count mismatch: Expected 3 Actual: 2"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerSession",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the session state of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 10.1.0.1 VRF: default - Not found",
+          "Peer: 10.1.0.2 VRF: default - Not found",
+          "Peer: 10.1.255.2 VRF: DEV - Not found",
+          "Peer: 10.1.255.4 VRF: DEV - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Vlan3499 VRF: PROD - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyISISSegmentRoutingTunnels",
+      "categories": [
+          "isis",
+          "segment-routing"
+      ],
+      "description": "Verify ISIS-SR tunnels computed by device.",
+      "result": "skipped",
+      "messages": [
+          "IS-IS-SR not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerSessionRibd",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the session state of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 10.1.0.1 VRF: default - Not found",
+          "Peer: 10.1.255.4 VRF: DEV - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpIPv6Acl",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies if the SNMP agent has IPv6 ACL(s) configured.",
+      "result": "failure",
+      "messages": [
+          "VRF: default - Incorrect SNMP IPv6 ACL(s) - Expected: 3 Actual: 0"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingEntries",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies that the expected log string is present in the last specified log messages.",
+      "result": "failure",
+      "messages": [
+          "Pattern: `.*ACCOUNTING-5-EXEC: cvpadmin ssh.*` - Not found in last 30 alerts log entries",
+          "Pattern: `.*SPANTREE-6-INTERFACE_ADD:.*` - Not found in last 10 critical log entries"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyManagementCVX",
+      "categories": [
+          "cvx"
+      ],
+      "description": "Verifies the management CVX global status.",
+      "result": "failure",
+      "messages": [
+          "Management CVX status is not valid: Expected: enabled Actual: disabled"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyStormControlDrops",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies there are no interface storm-control drop counters.",
+      "result": "skipped",
+      "messages": [
+          "VerifyStormControlDrops test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIPv4RouteType",
+      "categories": [
+          "routing"
+      ],
+      "description": "Verifies the route-type of the IPv4 prefixes.",
+      "result": "failure",
+      "messages": [
+          "Prefix: 10.100.0.12/31 VRF: default - Route not found",
+          "Prefix: 10.100.1.5/32 VRF: default - Incorrect route type - Expected: iBGP Actual: connected"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyVxlanVtep",
+      "categories": [
+          "vxlan"
+      ],
+      "description": "Verifies Vxlan1 VTEP peers.",
+      "result": "failure",
+      "messages": [
+          "The following VTEP peer(s) are missing from the Vxlan1 interface: 10.1.1.5, 10.1.1.6",
+          "Unexpected VTEP peer(s) on Vxlan1 interface: 10.100.2.3"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyStunClientTranslation",
+      "categories": [
+          "stun"
+      ],
+      "description": "Verifies the translation for a source address on a STUN client.",
+      "result": "failure",
+      "messages": [
+          "Client 172.18.3.2 Port: 4500 - STUN client translation not found",
+          "Client 100.64.3.2 Port: 4500 - STUN client translation not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAPISSLCertificate",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies the eAPI SSL certificate expiry, common subject name, encryption algorithm and key size.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyStunClient",
+      "categories": [
+          "stun"
+      ],
+      "description": "(Deprecated) Verifies the translation for a source address on a STUN client.",
+      "result": "failure",
+      "messages": [
+          "Client 172.18.3.2 Port: 4500 - STUN client translation not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyTransceiversTemperature",
+      "categories": [
+          "hardware"
+      ],
+      "description": "Verifies if all the transceivers are operating at an acceptable temperature.",
+      "result": "skipped",
+      "messages": [
+          "VerifyTransceiversTemperature test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyPtpLockStatus",
+      "categories": [
+          "ptp"
+      ],
+      "description": "Verifies that the device was locked to the upstream PTP GM in the last minute.",
+      "result": "skipped",
+      "messages": [
+          "VerifyPtpLockStatus test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyStpTopologyChanges",
+      "categories": [
+          "stp"
+      ],
+      "description": "Verifies the number of changes across all interfaces in the Spanning Tree Protocol (STP) topology is below a threshold.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyEOSVersion",
+      "categories": [
+          "software"
+      ],
+      "description": "Verifies the EOS version of the device.",
+      "result": "failure",
+      "messages": [
+          "EOS version mismatch - Actual: 4.31.0F-33804048.4310F (engineering build) not in Expected: 4.25.4M, 4.26.1F"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBannerMotd",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies the motd banner of a device.",
+      "result": "failure",
+      "messages": [
+          "MOTD banner is not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySSHIPv4Acl",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if the SSHD agent has IPv4 ACL(s) configured.",
+      "result": "failure",
+      "messages": [
+          "VRF: default - SSH IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLACPInterfacesStatus",
+      "categories": [
+          "interfaces"
+      ],
+      "description": "Verifies the Link Aggregation Control Protocol (LACP) status of the interface.",
+      "result": "failure",
+      "messages": [
+          "Interface: Ethernet1 Port-Channel: Port-Channel100 - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIGMPSnoopingVlans",
+      "categories": [
+          "multicast"
+      ],
+      "description": "Verifies the IGMP snooping status for the provided VLANs.",
+      "result": "failure",
+      "messages": [
+          "VLAN10 - Incorrect IGMP state - Expected: disabled Actual: enabled",
+          "Supplied vlan 12 is not present on the device"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMaintenance",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies that the device is not currently under or entering maintenance.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyFieldNotice72Resolution",
+      "categories": [
+          "field notices"
+      ],
+      "description": "Verifies if the device is exposed to FN0072, and if the issue has been mitigated.",
+      "result": "skipped",
+      "messages": [
+          "VerifyFieldNotice72Resolution test is not supported on cEOSLab"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyRoutingTableSize",
+      "categories": [
+          "routing"
+      ],
+      "description": "Verifies the size of the IP routing table of the default VRF.",
+      "result": "failure",
+      "messages": [
+          "Routing table routes are outside the routes range - Expected: 2 <= to >= 20 Actual: 35"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPSpecificPeers",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the health of specific BGP peer(s) for given address families.",
+      "result": "failure",
+      "messages": [
+          "AFI: evpn Peer: 10.1.0.1 - Not configured",
+          "AFI: evpn Peer: 10.1.0.2 - Not configured",
+          "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.254.1 - Not configured",
+          "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.0 - Not configured",
+          "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.2 - Not configured",
+          "AFI: ipv4 SAFI: unicast VRF: default Peer: 10.1.255.4 - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySnmpIPv4Acl",
+      "categories": [
+          "snmp"
+      ],
+      "description": "Verifies if the SNMP agent has IPv4 ACL(s) configured.",
+      "result": "failure",
+      "messages": [
+          "VRF: default - Incorrect SNMP IPv4 ACL(s) - Expected: 3 Actual: 0"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerDropStats",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP NLRI drop statistics of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBFDPeersRegProtocols",
+      "categories": [
+          "bfd"
+      ],
+      "description": "Verifies the registered routing protocol of IPv4 BFD peer sessions.",
+      "result": "failure",
+      "messages": [
+          "Peer: 192.0.255.7 VRF: default - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyIPSecConnHealth",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies all IPv4 security connections.",
+      "result": "failure",
+      "messages": [
+          "No IPv4 security connection configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPPeerUpdateErrors",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP update error counters of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyFileSystemUtilization",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies that no partition is utilizing more than 75% of its disk space.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAPIIPv6Acl",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if eAPI has the right number IPv6 ACL(s) configured for a specified VRF.",
+      "result": "failure",
+      "messages": [
+          "VRF: default - eAPI IPv6 ACL(s) count mismatch - Expected: 3 Actual: 0"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyLoggingAccounting",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies if AAA accounting logs are generated.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyMcsServerMounts",
+      "categories": [
+          "cvx"
+      ],
+      "description": "Verify if all MCS server mounts are in a MountComplete state.",
+      "result": "failure",
+      "messages": [
+          "'show cvx mounts' failed on s1-spine1: Unavailable command (controller not ready) (at token 2: 'mounts')"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyGreenT",
+      "categories": [
+          "greent"
+      ],
+      "description": "Verifies if a GreenT policy other than the default is created.",
+      "result": "failure",
+      "messages": [
+          "No GreenT policy is created"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBgpRouteMaps",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP inbound and outbound route-maps of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.1 VRF: default - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found",
+          "Interface: Ethernet1 VRF: MGMT - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAPIIPv4Acl",
+      "categories": [
+          "security"
+      ],
+      "description": "Verifies if eAPI has the right number IPv4 ACL(s) configured for a specified VRF.",
+      "result": "failure",
+      "messages": [
+          "VRF: default - eAPI IPv4 ACL(s) count mismatch - Expected: 3 Actual: 0"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPRoutePaths",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies BGP IPv4 route paths.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyBGPAdvCommunities",
+      "categories": [
+          "bgp"
+      ],
+      "description": "Verifies the advertised communities of BGP peers.",
+      "result": "failure",
+      "messages": [
+          "Peer: 172.30.11.17 VRF: default - Not found",
+          "Peer: 172.30.11.21 VRF: MGMT - Not found",
+          "Peer: fd00:dc:1::1 VRF: default - Not found"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyTerminAttrVersion",
+      "categories": [
+          "software"
+      ],
+      "description": "Verifies the TerminAttr version of the device.",
+      "result": "failure",
+      "messages": [
+          "TerminAttr version mismatch - Actual: v1.29.0 not in Expected: v1.13.6, v1.8.0"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySTPDisabledVlans",
+      "categories": [
+          "stp"
+      ],
+      "description": "Verifies the STP disabled VLAN(s).",
+      "result": "failure",
+      "messages": [
+          "VLAN: 6 - Not configured"
+      ],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifySyslogLogging",
+      "categories": [
+          "logging"
+      ],
+      "description": "Verifies if syslog logging is enabled.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
+  },
+  {
+      "name": "s1-spine1",
+      "test": "VerifyAgentLogs",
+      "categories": [
+          "system"
+      ],
+      "description": "Verifies there are no agent crash reports.",
+      "result": "success",
+      "messages": [],
+      "custom_field": null
   }
 ]


### PR DESCRIPTION
# Description

Special characters from failure messages should be escaped properly in Markdown

Fixes #1090

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
