### PR TITLE
bump: Update code to support pytest-asyncio v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
   "pre-commit>=3.3.3",
   "pylint-pydantic>=0.2.4",
   "pylint>=2.17.5",
-  "pytest-asyncio>=0.21.1",
+  "pytest-asyncio>=1.0.0",
   "pytest-cov>=4.1.0",
   "pytest-dependency",
   "pytest-codspeed>=2.2.0",

--- a/tests/benchmark/test_anta.py
+++ b/tests/benchmark/test_anta.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 def test_anta_dry_run(
     benchmark: BenchmarkFixture,
-    event_loop: asyncio.AbstractEventLoop,
     catalog: AntaCatalog,
     inventory: AntaInventory,
     request: pytest.FixtureRequest,
@@ -42,7 +41,7 @@ def test_anta_dry_run(
     def _() -> None:
         results.reset()
         catalog.clear_indexes()
-        event_loop.run_until_complete(main(results, inventory, catalog, dry_run=True))
+        asyncio.run(main(results, inventory, catalog, dry_run=True))
 
     logging.disable(logging.NOTSET)
 
@@ -58,7 +57,6 @@ def test_anta_dry_run(
 @respx.mock  # Mock eAPI responses
 def test_anta(
     benchmark: BenchmarkFixture,
-    event_loop: asyncio.AbstractEventLoop,
     catalog: AntaCatalog,
     inventory: AntaInventory,
     request: pytest.FixtureRequest,
@@ -75,7 +73,7 @@ def test_anta(
     def _() -> None:
         results.reset()
         catalog.clear_indexes()
-        event_loop.run_until_complete(main(results, inventory, catalog))
+        asyncio.run(main(results, inventory, catalog))
 
     logging.disable(logging.NOTSET)
 


### PR DESCRIPTION
# Description

Bump pytest-asyncio minimum version to v1.0.0 and update benchmarks. New version doesn't support the `event_loop` fixture anymore: https://pytest-asyncio.readthedocs.io/en/stable/how-to-guides/migrate_from_0_21.html

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
