### PR TITLE
fix(anta): Remove anta.cli import from anta._runner

### DIFF
--- a/anta/_runner.py
+++ b/anta/_runner.py
@@ -433,7 +433,7 @@ class AntaRunner:
             device_list_str = ", ".join(sorted(ctx.devices_unreachable_at_setup))
             logger.info("%d devices found unreachable after connection attempts: %s", ctx.total_devices_unreachable, device_list_str)
 
-        logger.info("%d devices ultimately selected for testing", ctx.total_devices_selected_for_testing)
+        logger.info("%d devices selected for testing", ctx.total_devices_selected_for_testing)
         logger.info("%d total tests scheduled across all selected devices", ctx.total_tests_scheduled)
 
         # Log debugs for runner settings

--- a/anta/_runner.py
+++ b/anta/_runner.py
@@ -426,12 +426,12 @@ class AntaRunner:
         logger.info("Initial inventory contains %s devices", ctx.total_devices_in_inventory)
 
         if ctx.total_devices_filtered_by_tags > 0:
-            device_list_str = f": {', '.join(sorted(ctx.devices_filtered_at_setup))}"
-            logger.info("%d devices excluded by name/tag filters%s", ctx.total_devices_filtered_by_tags, device_list_str)
+            device_list_str = ", ".join(sorted(ctx.devices_filtered_at_setup))
+            logger.info("%d devices excluded by name/tag filters: %s", ctx.total_devices_filtered_by_tags, device_list_str)
 
         if ctx.total_devices_unreachable > 0:
-            device_list_str = f": {', '.join(sorted(ctx.devices_unreachable_at_setup))}"
-            logger.info("%d devices found unreachable after connection attempts%s", ctx.total_devices_unreachable, device_list_str)
+            device_list_str = ", ".join(sorted(ctx.devices_unreachable_at_setup))
+            logger.info("%d devices found unreachable after connection attempts: %s", ctx.total_devices_unreachable, device_list_str)
 
         logger.info("%d devices ultimately selected for testing", ctx.total_devices_selected_for_testing)
         logger.info("%d total tests scheduled across all selected devices", ctx.total_tests_scheduled)

--- a/anta/_runner.py
+++ b/anta/_runner.py
@@ -414,9 +414,11 @@ class AntaRunner:
         for coro in coros:
             # Get the AntaTest instance from the coroutine locals, can be in `args` when decorated
             coro_locals = getcoroutinelocals(coro)
-            test = coro_locals.get("self") or coro_locals.get("args", (None))[0]
+            test = coro_locals.get("self") or coro_locals.get("args")
             if isinstance(test, AntaTest):
                 ctx.manager.add(test.result)
+            elif test and isinstance(test, tuple) and isinstance(test[0], AntaTest):
+                ctx.manager.add(test[0].result)
             else:
                 logger.error("Coroutine %s does not have an AntaTest instance.", coro)
             coro.close()

--- a/asynceapi/device.py
+++ b/asynceapi/device.py
@@ -51,7 +51,6 @@ class Device(httpx.AsyncClient):
     httpx.AsyncClient, so any initialization options can be passed directly.
     """
 
-    auth = None
     EAPI_COMMAND_API_URL = "/command-api"
     EAPI_OFMT_OPTIONS = ("json", "text")
     EAPI_DEFAULT_OFMT = "json"
@@ -103,10 +102,8 @@ class Device(httpx.AsyncClient):
         kwargs.setdefault("base_url", httpx.URL(f"{proto}://{self.host}:{self.port}"))
         kwargs.setdefault("verify", False)
 
-        if username and password:
-            self.auth = httpx.BasicAuth(username, password)
-
-        kwargs.setdefault("auth", self.auth)
+        auth_object = httpx.BasicAuth(username, password) if username and password else None
+        kwargs.setdefault("auth", auth_object)
 
         super().__init__(**kwargs)
         self.headers["Content-Type"] = "application/json-rpc"

--- a/tests/units/test__runner.py
+++ b/tests/units/test__runner.py
@@ -317,6 +317,25 @@ class TestAntaRunner:
         for line in expected_output:
             assert line in caplog.text
 
+    async def test_log_run_information_filters(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test AntaRunner._log_run_information with filters."""
+        caplog.set_level(logging.INFO)
+
+        inventory = AntaInventory.parse(filename=DATA_DIR / "test_inventory_with_tags.yml", username="anta", password="anta")
+        catalog = AntaCatalog.parse(filename=DATA_DIR / "test_catalog_with_tags.yml")
+        runner = AntaRunner()
+        filters = AntaRunFilters(devices={"spine1"})
+        await runner.run(inventory, catalog, filters=filters, dry_run=True)
+
+        expected_output = [
+            "Initial inventory contains 3 devices",
+            "2 devices excluded by name/tag filters: leaf1, leaf2",
+            "1 devices ultimately selected for testing",
+            "9 total tests scheduled across all selected devices",
+        ]
+        for line in expected_output:
+            assert line in caplog.text
+
     async def test_log_run_information_concurrency_limit(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test AntaRunner._log_run_information with higher tests count than concurrency limit."""
         caplog.set_level(logging.WARNING)

--- a/tests/units/test__runner.py
+++ b/tests/units/test__runner.py
@@ -311,7 +311,7 @@ class TestAntaRunner:
 
         expected_output = [
             "Initial inventory contains 3 devices",
-            "3 devices ultimately selected for testing",
+            "3 devices selected for testing",
             "27 total tests scheduled across all selected devices",
         ]
         for line in expected_output:
@@ -330,7 +330,7 @@ class TestAntaRunner:
         expected_output = [
             "Initial inventory contains 3 devices",
             "2 devices excluded by name/tag filters: leaf1, leaf2",
-            "1 devices ultimately selected for testing",
+            "1 devices selected for testing",
             "9 total tests scheduled across all selected devices",
         ]
         for line in expected_output:
@@ -391,7 +391,7 @@ class TestAntaRunner:
             "Initial inventory contains 3 devices",
             "1 devices excluded by name/tag filters: leaf1",
             "1 devices found unreachable after connection attempts: leaf2",
-            "1 devices ultimately selected for testing",
+            "1 devices selected for testing",
             "0 total tests scheduled across all selected devices",
         ]
         for line in expected_output:

--- a/tests/units/test__runner.py
+++ b/tests/units/test__runner.py
@@ -310,11 +310,9 @@ class TestAntaRunner:
         await runner.run(inventory, catalog, dry_run=True)
 
         expected_output = [
-            "ANTA NRFU Dry Run Information",
-            "Devices:",
-            "  Total in initial inventory: 3",
-            "  Selected for testing: 3",
-            "Total number of selected tests: 27",
+            "Initial inventory contains 3 devices",
+            "3 devices ultimately selected for testing",
+            "27 total tests scheduled across all selected devices",
         ]
         for line in expected_output:
             assert line in caplog.text


### PR DESCRIPTION
# Description

Remove the use of `anta.cli.console` in the runner to avoid being dependant of `anta.cli` when using ANTA as a library.

Fixes #1226 

# Checklist:

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
