### PR TITLE
fix(anta.tests): VerifyOSPFNeighborState displays the wrong failure message

### DIFF
--- a/anta/tests/routing/ospf.py
+++ b/anta/tests/routing/ospf.py
@@ -58,7 +58,7 @@ class VerifyOSPFNeighborState(AntaTest):
                 interfaces = [(neighbor["routerId"], state) for neighbor in neighbors if (state := neighbor["adjacencyState"]) != "full"]
                 for interface in interfaces:
                     self.result.is_failure(
-                        f"Instance: {instance} VRF: {vrf} Interface: {interface[0]} - Incorrect adjacency state - Expected: Full Actual: {interface[1]}"
+                        f"Instance: {instance} VRF: {vrf} Neighbor ID: {interface[0]} - Incorrect adjacency state - Expected: Full Actual: {interface[1]}"
                     )
 
         # If OSPF neighbors are not configured on device, test skipped.

--- a/tests/units/anta_tests/routing/test_ospf.py
+++ b/tests/units/anta_tests/routing/test_ospf.py
@@ -127,8 +127,8 @@ DATA: AntaUnitTestDataDict = {
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": [
-                "Instance: 666 VRF: default Interface: 7.7.7.7 - Incorrect adjacency state - Expected: Full Actual: 2-way",
-                "Instance: 777 VRF: BLAH Interface: 8.8.8.8 - Incorrect adjacency state - Expected: Full Actual: down",
+                "Instance: 666 VRF: default Neighbor ID: 7.7.7.7 - Incorrect adjacency state - Expected: Full Actual: 2-way",
+                "Instance: 777 VRF: BLAH Neighbor ID: 8.8.8.8 - Incorrect adjacency state - Expected: Full Actual: down",
             ],
         },
     },


### PR DESCRIPTION
# Description

The current failure message:

Instance: 100 VRF: default Interface: 10.1.0.1 - Incorrect adjacency state - Expected: full Actual: exchStart which is incorrect since 10.1.0.1 is the router ID of its neighbor, not the interface.

It should be:
Instance: 100 VRF: default Neighbor ID: 10.1.0.1 - Incorrect adjacency state - Expected: full Actual: exchStart

Fixes #1204 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
