### PR TITLE
fix(anta.tests): False positives in VerifyReachability

### DIFF
--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -93,7 +93,7 @@ class VerifyReachability(AntaTest):
     def _is_host_reachable(self, host: Host, message: str) -> None:
         """Check if a host is reachable."""
         # Retrieve the received packet count
-        pattern = re.compile(r"(\d+)(?=\s)\s+received")
+        pattern = re.compile(r"(\d{1,20})\s+received")
         received_packets = int(next(iter(pattern.findall(message)), 0))
 
         # Verifies the network is reachable

--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -93,7 +93,7 @@ class VerifyReachability(AntaTest):
     def _is_host_reachable(self, host: Host, message: str) -> None:
         """Check if a host is reachable."""
         # Retrieve the received packet count
-        pattern = re.compile(r"(\d+)\s+received")
+        pattern = re.compile(r"(?>(\d+))\s+received")
         received_packets = int(next(iter(pattern.findall(message)), 0))
 
         # Verifies the network is reachable

--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -93,7 +93,7 @@ class VerifyReachability(AntaTest):
     def _is_host_reachable(self, host: Host, message: str) -> None:
         """Check if a host is reachable."""
         # Retrieve the received packet count
-        pattern = re.compile(r"(?>(\d+))\s+received")
+        pattern = re.compile(r"(\d+)(?=\s)\s+received")
         received_packets = int(next(iter(pattern.findall(message)), 0))
 
         # Verifies the network is reachable

--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -92,7 +92,7 @@ class VerifyReachability(AntaTest):
 
     def _is_host_reachable(self, host: Host, message: str) -> None:
         """Check if a host is reachable."""
-        # Retrieve the received packet count
+        # Retrieve the received packet count, limiting the number of digits to avoid ReDoS vulnerability. Thanks to Sonar!
         pattern = re.compile(r"(\d{1,20})\s+received")
         received_packets = int(next(iter(pattern.findall(message)), 0))
 

--- a/anta/tests/connectivity.py
+++ b/anta/tests/connectivity.py
@@ -90,14 +90,14 @@ class VerifyReachability(AntaTest):
             for host in self.inputs.hosts
         ]
 
-    def _is_host_reachable(self, host: Host, *, is_reachable: bool) -> None:
+    def _is_host_reachable(self, host: Host, message: str) -> None:
         """Check if a host is reachable."""
         # Verifies the network is reachable
-        if host.reachable and not is_reachable:
+        if host.reachable and f"{host.repeat} received" not in message:
             self.result.is_failure(f"{host} - Unreachable")
 
-        # Verifies the network is unreachable.
-        if not host.reachable and is_reachable:
+        # Verifies the network is unreachable
+        if not host.reachable and f"{host.repeat} received" in message:
             self.result.is_failure(f"{host} - Destination is expected to be unreachable but found reachable")
 
     @AntaTest.anta_test
@@ -107,8 +107,11 @@ class VerifyReachability(AntaTest):
 
         for command, host in zip(self.instance_commands, self.inputs.hosts):
             message = command.json_output["messages"][0]
-            match = re.search(r"(100|[1-9]?\d)%\s*packet loss", message, re.IGNORECASE)
-            if not match:
+
+            # Extract the command failure details
+            repeat_count = "|".join(str(i) for i in range(host.repeat + 1))
+            pattern = re.compile(rf"(?:{repeat_count})\s+received")
+            if not pattern.search(message):
                 # Test fail if reachable check is true and network is unreachable
                 if "Network is unreachable" in message and host.reachable:
                     self.result.is_failure(f"{host} - Unreachable")
@@ -121,13 +124,8 @@ class VerifyReachability(AntaTest):
                 self.result.is_failure(f"Command '{command.command}' has not been collected and has not returned an error - Message: '{message.rstrip()}'")
                 continue
 
-            # Extract the packet loss percentage to determine reachability
-            is_reachable: bool = False
-            if int(match.group(1)) < 100:  # noqa: PLR2004
-                is_reachable = True
-
             # Verify the reachability
-            self._is_host_reachable(host, is_reachable=is_reachable)
+            self._is_host_reachable(host, message)
 
 
 class VerifyLLDPNeighbors(AntaTest):

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -242,6 +242,27 @@ DATA: AntaUnitTestDataDict = {
         ],
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: 10.0.0.1 VRF: default - Unreachable"]},
     },
+    (VerifyReachability, "failure-network-unreachable"): {
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "repeat": 1}]},
+        "eos_data": [{"messages": ["ping: connect: Network is unreachable\n"]}],
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: 10.0.0.1 VRF: default - Unreachable"]},
+    },
+    (VerifyReachability, "success-network-unreachable-and-reachable-false"): {
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "repeat": 1, "reachable": False}]},
+        "eos_data": [{"messages": ["ping: connect: Network is unreachable\n"]}],
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
+    (VerifyReachability, "failure-source-ip-not-bind"): {
+        "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "10.0.1.2", "repeat": 1}]},
+        "eos_data": [{"messages": ["ping: bind: Cannot assign requested address\n"]}],
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                "Command 'ping vrf default 10.0.0.1 source 10.0.1.2 size 100 repeat 1' has not been collected and has not returned an error - "
+                "Message: 'ping: bind: Cannot assign requested address'"
+            ],
+        },
+    },
     (VerifyLLDPNeighbors, "success"): {
         "eos_data": [
             {

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -162,7 +162,10 @@ DATA: AntaUnitTestDataDict = {
                 ]
             },
         ],
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: 10.0.0.11 Source: 10.0.0.5 VRF: default - Unreachable"]},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Host: 10.0.0.11 Source: 10.0.0.5 VRF: default - Packet loss detected - Transmitted: 2 Received: 0"],
+        },
     },
     (VerifyReachability, "failure-ipv6"): {
         "eos_data": [
@@ -174,7 +177,10 @@ DATA: AntaUnitTestDataDict = {
             }
         ],
         "inputs": {"hosts": [{"destination": "fd12:3456:789a:1::2", "source": "fd12:3456:789a:1::1"}]},
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: fd12:3456:789a:1::2 Source: fd12:3456:789a:1::1 VRF: default - Unreachable"]},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Host: fd12:3456:789a:1::2 Source: fd12:3456:789a:1::1 VRF: default - Packet loss detected - Transmitted: 2 Received: 0"],
+        },
     },
     (VerifyReachability, "failure-interface"): {
         "inputs": {"hosts": [{"destination": "10.0.0.11", "source": "Management0"}, {"destination": "10.0.0.2", "source": "Management0"}]},
@@ -195,7 +201,10 @@ DATA: AntaUnitTestDataDict = {
                 ]
             },
         ],
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: 10.0.0.11 Source: Management0 VRF: default - Unreachable"]},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Host: 10.0.0.11 Source: Management0 VRF: default - Packet loss detected - Transmitted: 2 Received: 0"],
+        },
     },
     (VerifyReachability, "failure-size"): {
         "inputs": {"hosts": [{"destination": "10.0.0.1", "source": "Management0", "repeat": 5, "size": 1501, "df_bit": True}]},
@@ -210,7 +219,10 @@ DATA: AntaUnitTestDataDict = {
                 ]
             }
         ],
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: 10.0.0.1 Source: Management0 VRF: default - Unreachable"]},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Host: 10.0.0.1 Source: Management0 VRF: default - Packet loss detected - Transmitted: 5 Received: 0"],
+        },
     },
     (VerifyReachability, "failure-expected-unreachable"): {
         "eos_data": [
@@ -240,7 +252,7 @@ DATA: AntaUnitTestDataDict = {
                 ]
             }
         ],
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: 10.0.0.1 VRF: default - Unreachable"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Host: 10.0.0.1 VRF: default - Packet loss detected - Transmitted: 1 Received: 0"]},
     },
     (VerifyReachability, "failure-network-unreachable"): {
         "inputs": {"hosts": [{"destination": "10.0.0.1", "repeat": 1}]},
@@ -258,8 +270,8 @@ DATA: AntaUnitTestDataDict = {
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": [
-                "Command 'ping vrf default 10.0.0.1 source 10.0.1.2 size 100 repeat 1' has not been collected and has not returned an error - "
-                "Message: 'ping: bind: Cannot assign requested address'"
+                "Ping command 'ping vrf default 10.0.0.1 source 10.0.1.2 size 100 repeat 1' failed with an unexpected message: "
+                "'ping: bind: Cannot assign requested address'"
             ],
         },
     },


### PR DESCRIPTION
# Description

If the source IP is not present on any interfaces, EOS will output the following:

DC1-LEAF1A#ping vrf default fd12:3456:789a:1::2 source fd12:3456:789a:1::1 size 100 df-bit repeat 2
ping: bind icmp socket: Cannot assign requested address
DC1-LEAF1A#ping vrf default 8.8.8.8 source 1.2.3.4
ping: bind: Cannot assign requested address

Fixes #1241 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)
