### PR TITLE
Feat(anta): Prevent duplicate insertion in inventory

### DIFF
--- a/anta/device.py
+++ b/anta/device.py
@@ -359,7 +359,7 @@ class AsyncEOSDevice(AntaDevice):
         enable_password
             Password used to gain privileged access on EOS.
         port
-            eAPI port. Defaults to 80 is proto is 'http' or 443 if proto is 'https'.
+            eAPI port. Defaults to 80 if 'proto' is 'http' or 443 if proto is 'https'.
         ssh_port
             SSH port.
         tags
@@ -390,8 +390,8 @@ class AsyncEOSDevice(AntaDevice):
             message = f"'password' is required to instantiate device '{self.name}'"
             logger.error(message)
             raise ValueError(message)
-        self.enable = enable
-        self._enable_password = enable_password
+        self.enable: bool = enable
+        self._enable_password: str | None = enable_password
         self._session: asynceapi.Device = asynceapi.Device(host=host, port=port, username=username, password=password, proto=proto, timeout=timeout)
         ssh_params: dict[str, Any] = {}
         if insecure:


### PR DESCRIPTION
# Description

The goal is to prevent an AntaInventory to contain multiple "clashing" instances of an AsyncEOSDevice.

This is tough because we use name for the inventory key but we don't use it to check unicity - __eq__ only uses _session.host and _session.port
The implementation introduces a hidden dict on AntaInventory to keep track of the already present devices by AntaDevice class type, mapping their hash to the device object

The duplication detection is done when __setitem__ is called

The issue is that if an AntaDevice modifies its keys, the inventory is not aware of this and it implies some magic for __setitem__ and __delitem__ which is unsavory and not yet 100% optimal.

Looking for thoughts on this one :)

Maybe another (non breaking) approach is better. 

Fixes #818

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
