### PR TITLE
fix(anta.tests): Update VerifyTemperature to support a failure_margin as input

### DIFF
--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -92,6 +92,8 @@ class VerifyTemperature(AntaTest):
 
         check_temp_sensors: bool = False
         """If True, also verifies the hardware status and temperature of individual sensors."""
+        failure_margin: PositiveInteger = Field(default=5)
+        """Proactive failure margin threshold. The test will fail if the over heat threshold is weaker than the current temperature threshold plus this margin."""
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
     @AntaTest.anta_test
@@ -122,7 +124,9 @@ class VerifyTemperature(AntaTest):
             if sensor["hwStatus"] != "ok":
                 self.result.is_failure(f"Sensor: {sensor['name']} Description: {sensor_desc} - Invalid hardware status - Expected: ok Actual: {sensor['hwStatus']}")
             # Verify sensor current temperature
-            if (act_temp := sensor["currentTemperature"]) + 5 >= (over_heat_threshold := sensor["overheatThreshold"]):
+            if (act_temp := sensor["currentTemperature"]) + self.inputs.failure_margin >= (
+                over_heat_threshold := sensor["overheatThreshold"]
+            ):  # TODO: Need to confirm actual temp
                 self.result.is_failure(
                     f"Sensor: {sensor['name']} Description: {sensor_desc} - Temperature is getting high - Current: {act_temp} "
                     f"Overheat Threshold: {over_heat_threshold}"

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -93,7 +93,7 @@ class VerifyTemperature(AntaTest):
         check_temp_sensors: bool = False
         """If True, also verifies the hardware status and temperature of individual sensors."""
         failure_margin: PositiveInteger = Field(default=5)
-        """Proactive failure margin threshold. The test will fail if the over heat threshold is weaker than the current temperature threshold plus this margin."""
+        """Proactive failure margin in °C. The test will fail if the over heat threshold is weaker than the current temperature plus this margin."""
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
     @AntaTest.anta_test
@@ -124,12 +124,10 @@ class VerifyTemperature(AntaTest):
             if sensor["hwStatus"] != "ok":
                 self.result.is_failure(f"Sensor: {sensor['name']} Description: {sensor_desc} - Invalid hardware status - Expected: ok Actual: {sensor['hwStatus']}")
             # Verify sensor current temperature
-            if (act_temp := sensor["currentTemperature"]) + self.inputs.failure_margin >= (
-                over_heat_threshold := sensor["overheatThreshold"]
-            ):  # TODO: Need to confirm actual temp
+            if (act_temp := sensor["currentTemperature"]) + self.inputs.failure_margin >= (over_heat_threshold := sensor["overheatThreshold"]):
                 self.result.is_failure(
-                    f"Sensor: {sensor['name']} Description: {sensor_desc} - Temperature is getting high - Current: {act_temp} "
-                    f"Overheat Threshold: {over_heat_threshold}"
+                    f"Sensor: {sensor['name']} Description: {sensor_desc} - Temperature is getting high - Expected: < {over_heat_threshold}°C "
+                    f"(currentTemperature: {act_temp}°C  + Margin: {self.inputs.failure_margin}°C) Actual: {act_temp}°C"
                 )
 
 

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -124,9 +124,9 @@ class VerifyTemperature(AntaTest):
             if sensor["hwStatus"] != "ok":
                 self.result.is_failure(f"Sensor: {sensor['name']} Description: {sensor_desc} - Invalid hardware status - Expected: ok Actual: {sensor['hwStatus']}")
             # Verify sensor current temperature
-            if (act_temp := sensor["currentTemperature"]) + self.inputs.failure_margin >= (over_heat_threshold := sensor["overheatThreshold"]):
+            if (act_temp := sensor["currentTemperature"]) + self.inputs.failure_margin > (over_heat_threshold := sensor["overheatThreshold"]):
                 self.result.is_failure(
-                    f"Sensor: {sensor['name']} Description: {sensor_desc} - Temperature is getting high - Expected: < {over_heat_threshold}°C "
+                    f"Sensor: {sensor['name']} Description: {sensor_desc} - Temperature is getting high - Expected: <= {over_heat_threshold}°C "
                     f"(currentTemperature: {act_temp}°C  + Margin: {self.inputs.failure_margin}°C) Actual: {act_temp}°C"
                 )
 

--- a/anta/tests/hardware.py
+++ b/anta/tests/hardware.py
@@ -93,7 +93,7 @@ class VerifyTemperature(AntaTest):
         check_temp_sensors: bool = False
         """If True, also verifies the hardware status and temperature of individual sensors."""
         failure_margin: PositiveInteger = Field(default=5)
-        """Proactive failure margin in °C. The test will fail if the over heat threshold is weaker than the current temperature plus this margin."""
+        """"Proactive failure margin in °C. The test will fail if the current temperature is above the overheat threshold minus this margin."""
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
     @AntaTest.anta_test
@@ -124,10 +124,12 @@ class VerifyTemperature(AntaTest):
             if sensor["hwStatus"] != "ok":
                 self.result.is_failure(f"Sensor: {sensor['name']} Description: {sensor_desc} - Invalid hardware status - Expected: ok Actual: {sensor['hwStatus']}")
             # Verify sensor current temperature
-            if (act_temp := sensor["currentTemperature"]) + self.inputs.failure_margin > (over_heat_threshold := sensor["overheatThreshold"]):
+            overheat_threshold = sensor["overheatThreshold"]
+            effective_threshold = overheat_threshold - self.inputs.failure_margin
+            if (act_temp := sensor["currentTemperature"]) > effective_threshold:
                 self.result.is_failure(
-                    f"Sensor: {sensor['name']} Description: {sensor_desc} - Temperature is getting high - Expected: <= {over_heat_threshold}°C "
-                    f"(currentTemperature: {act_temp}°C  + Margin: {self.inputs.failure_margin}°C) Actual: {act_temp}°C"
+                    f"Sensor: {sensor['name']} Description: {sensor_desc} - Temperature is getting high - Expected: <= {effective_threshold:.2f}°C "
+                    f"(Overheat: {overheat_threshold:.2f}°C - Margin: {self.inputs.failure_margin}°C) Actual: {act_temp:.2f}°C"
                 )
 
 

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -348,13 +348,13 @@ DATA: AntaUnitTestDataDict = {
             "result": AntaTestStatus.FAILURE,
             "messages": [
                 "Sensor: TempSensor1 Description: Cpu temp sensor - Temperature is getting high - "
-                "Expected: <= 90.0°C (currentTemperature: 93.85271955304604°C  + Margin: 5°C) Actual: 93.85271955304604°C",
+                "Expected: <= 85.00°C (Overheat: 90.00°C - Margin: 5°C) Actual: 93.85°C",
                 "Sensor: TempSensor2 Description: Switch card temp sensor - Temperature is getting high - "
-                "Expected: <= 75.0°C (currentTemperature: 74.875°C  + Margin: 5°C) Actual: 74.875°C",
+                "Expected: <= 70.00°C (Overheat: 75.00°C - Margin: 5°C) Actual: 74.88°C",
             ],
         },
     },
-    (VerifyTemperature, "failure-status-high-temp"): {
+    (VerifyTemperature, "failure-temperature-status"): {
         "eos_data": [
             {
                 "systemStatus": "temperatureCritical",
@@ -447,7 +447,7 @@ DATA: AntaUnitTestDataDict = {
             "messages": ["Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureCritical"],
         },
     },
-    (VerifyTemperature, "failure-status"): {
+    (VerifyTemperature, "failure-all"): {
         "eos_data": [
             {
                 "systemStatus": "temperatureCritical",
@@ -540,11 +540,9 @@ DATA: AntaUnitTestDataDict = {
             "messages": [
                 "Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureCritical",
                 "Sensor: TempSensorP1/1 Description: Hotspot - Invalid hardware status - Expected: ok Actual: failed",
-                "Sensor: TempSensorP1/1 Description: Hotspot - Temperature is getting high - "
-                "Expected: <= 55.0°C (currentTemperature: 54.0°C  + Margin: 5°C) Actual: 54.0°C",
+                "Sensor: TempSensorP1/1 Description: Hotspot - Temperature is getting high - Expected: <= 50.00°C (Overheat: 55.00°C - Margin: 5°C) Actual: 54.00°C",
                 "Sensor: TempSensorP1/2 Description: Inlet - Invalid hardware status - Expected: ok Actual: failed",
-                "Sensor: TempSensorP2/2 Description: Inlet - Temperature is getting high - "
-                "Expected: <= 60.0°C (currentTemperature: 59.0°C  + Margin: 5°C) Actual: 59.0°C",
+                "Sensor: TempSensorP2/2 Description: Inlet - Temperature is getting high - Expected: <= 55.00°C (Overheat: 60.00°C - Margin: 5°C) Actual: 59.00°C",
             ],
         },
     },

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -345,8 +345,11 @@ DATA: AntaUnitTestDataDict = {
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": [
-                "Sensor: TempSensor1 Description: Cpu temp sensor - Temperature is getting high - Current: 93.85271955304604 Overheat Threshold: 90.0",
-                "Sensor: TempSensor2 Description: Switch card temp sensor - Temperature is getting high - Current: 74.875 Overheat Threshold: 75.0",
+                "Sensor: TempSensor1 Description: Cpu temp sensor - Temperature is getting high - Expected: < 90.0°C "
+                "(currentTemperature: 93.85271955304604°C  + Margin: 5°C) Actual: 93.85271955304604°C",
+                "Sensor: TempSensor2 Description: Switch card temp sensor - Temperature is getting high - Expected: < 75.0°C "
+                "(currentTemperature: 74.875°C  + Margin: 5°C)"
+                " Actual: 74.875°C",
             ],
         },
     },
@@ -536,9 +539,11 @@ DATA: AntaUnitTestDataDict = {
             "messages": [
                 "Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureCritical",
                 "Sensor: TempSensorP1/1 Description: Hotspot - Invalid hardware status - Expected: ok Actual: failed",
-                "Sensor: TempSensorP1/1 Description: Hotspot - Temperature is getting high - Current: 54.0 Overheat Threshold: 55.0",
+                "Sensor: TempSensorP1/1 Description: Hotspot - Temperature is getting high - Expected: < 55.0°C (currentTemperature: 54.0°C  + Margin: 5°C)"
+                " Actual: 54.0°C",
                 "Sensor: TempSensorP1/2 Description: Inlet - Invalid hardware status - Expected: ok Actual: failed",
-                "Sensor: TempSensorP2/2 Description: Inlet - Temperature is getting high - Current: 59.0 Overheat Threshold: 60.0",
+                "Sensor: TempSensorP2/2 Description: Inlet - Temperature is getting high - Expected: < 60.0°C (currentTemperature: 59.0°C  + Margin: 5°C)"
+                " Actual: 59.0°C",
             ],
         },
     },

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -345,11 +345,10 @@ DATA: AntaUnitTestDataDict = {
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": [
-                "Sensor: TempSensor1 Description: Cpu temp sensor - Temperature is getting high - Expected: < 90.0°C "
-                "(currentTemperature: 93.85271955304604°C  + Margin: 5°C) Actual: 93.85271955304604°C",
-                "Sensor: TempSensor2 Description: Switch card temp sensor - Temperature is getting high - Expected: < 75.0°C "
-                "(currentTemperature: 74.875°C  + Margin: 5°C)"
-                " Actual: 74.875°C",
+                "Sensor: TempSensor1 Description: Cpu temp sensor - Temperature is getting high - "
+                "Expected: <= 90.0°C (currentTemperature: 93.85271955304604°C  + Margin: 5°C) Actual: 93.85271955304604°C",
+                "Sensor: TempSensor2 Description: Switch card temp sensor - Temperature is getting high - "
+                "Expected: <= 75.0°C (currentTemperature: 74.875°C  + Margin: 5°C) Actual: 74.875°C",
             ],
         },
     },
@@ -539,11 +538,11 @@ DATA: AntaUnitTestDataDict = {
             "messages": [
                 "Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureCritical",
                 "Sensor: TempSensorP1/1 Description: Hotspot - Invalid hardware status - Expected: ok Actual: failed",
-                "Sensor: TempSensorP1/1 Description: Hotspot - Temperature is getting high - Expected: < 55.0°C (currentTemperature: 54.0°C  + Margin: 5°C)"
-                " Actual: 54.0°C",
+                "Sensor: TempSensorP1/1 Description: Hotspot - Temperature is getting high - "
+                "Expected: <= 55.0°C (currentTemperature: 54.0°C  + Margin: 5°C) Actual: 54.0°C",
                 "Sensor: TempSensorP1/2 Description: Inlet - Invalid hardware status - Expected: ok Actual: failed",
-                "Sensor: TempSensorP2/2 Description: Inlet - Temperature is getting high - Expected: < 60.0°C (currentTemperature: 59.0°C  + Margin: 5°C)"
-                " Actual: 59.0°C",
+                "Sensor: TempSensorP2/2 Description: Inlet - Temperature is getting high - "
+                "Expected: <= 60.0°C (currentTemperature: 59.0°C  + Margin: 5°C) Actual: 59.0°C",
             ],
         },
     },

--- a/tests/units/anta_tests/test_hardware.py
+++ b/tests/units/anta_tests/test_hardware.py
@@ -437,6 +437,7 @@ DATA: AntaUnitTestDataDict = {
                 ],
             }
         ],
+        "inputs": {"failure_margin": 6},
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": ["Device temperature exceeds acceptable limits - Expected: temperatureOk Actual: temperatureCritical"],


### PR DESCRIPTION
# Description
Update VerifyTemperature to support a failure_margin as input

Fixes #1279

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
