### PR TITLE
fix(anta.tests): Added fix for VerifyErrdisableRecovery errors out when timer interval is N/A

### DIFF
--- a/anta/tests/services.py
+++ b/anta/tests/services.py
@@ -229,10 +229,14 @@ class VerifyErrdisableRecovery(AntaTest):
                 self.result.is_failure(f"{error_reason} - Not found")
                 continue
 
-            if not all(
-                [
-                    error_reason.status == (act_status := reason_output["status"]),
-                    error_reason.interval == (act_interval := int(reason_output["interval"])),
-                ]
-            ):
-                self.result.is_failure(f"{error_reason} - Incorrect configuration - Status: {act_status} Interval: {act_interval}")
+            if (act_interval := reason_output["interval"]) == "N/A":
+                self.result.is_failure(f"{error_reason} - Interval is not configurable")
+                continue
+
+            if error_reason.status != (act_status := reason_output["status"]):
+                self.result.is_failure(f"Reason: {error_reason.reason} - Invalid status - Expected: {error_reason.status} Actual: {act_status}")
+
+            if error_reason.interval != int(act_interval):
+                self.result.is_failure(
+                    f"Reason: {error_reason.reason} - Incorrect interval - Expected: {error_reason.interval} second(s) Actual: {act_interval} second(s)"
+                )

--- a/tests/units/anta_tests/test_services.py
+++ b/tests/units/anta_tests/test_services.py
@@ -126,7 +126,7 @@ DATA: AntaUnitTestDataDict = {
         "inputs": {"reasons": [{"reason": "acl", "interval": 300}, {"reason": "arp-inspection", "interval": 30}]},
         "expected": {
             "result": AntaTestStatus.FAILURE,
-            "messages": ["Reason: acl Status: Enabled Interval: 300 - Incorrect configuration - Status: Disabled Interval: 300"],
+            "messages": ["Reason: acl - Invalid status - Expected: Enabled Actual: Disabled"],
         },
     },
     (VerifyErrdisableRecovery, "failure-interval-not-ok"): {
@@ -139,7 +139,20 @@ DATA: AntaUnitTestDataDict = {
         "inputs": {"reasons": [{"reason": "acl", "interval": 30}, {"reason": "arp-inspection", "interval": 30}]},
         "expected": {
             "result": AntaTestStatus.FAILURE,
-            "messages": ["Reason: acl Status: Enabled Interval: 30 - Incorrect configuration - Status: Enabled Interval: 300"],
+            "messages": ["Reason: acl - Incorrect interval - Expected: 30 second(s) Actual: 300 second(s)"],
+        },
+    },
+    (VerifyErrdisableRecovery, "failure-interval-not-configurable"): {
+        "eos_data": [
+            "\n                Errdisable Reason              Timer Status   Timer Interval\n                ------------------------------ "
+            "----------------- --------------\n                acl                            Enabled                  300\n                "
+            "bpduguard                      Disabled                  N/A\n                arp-inspection                 Enabled   "
+            "               30\n            "
+        ],
+        "inputs": {"reasons": [{"reason": "bpduguard", "interval": 30, "status": "Disabled"}]},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Reason: bpduguard Status: Disabled Interval: 30 - Interval is not configurable"],
         },
     },
     (VerifyErrdisableRecovery, "failure-all-type"): {
@@ -153,8 +166,9 @@ DATA: AntaUnitTestDataDict = {
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": [
-                "Reason: acl Status: Enabled Interval: 30 - Incorrect configuration - Status: Disabled Interval: 300",
-                "Reason: arp-inspection Status: Enabled Interval: 300 - Incorrect configuration - Status: Enabled Interval: 30",
+                "Reason: acl - Invalid status - Expected: Enabled Actual: Disabled",
+                "Reason: acl - Incorrect interval - Expected: 30 second(s) Actual: 300 second(s)",
+                "Reason: arp-inspection - Incorrect interval - Expected: 300 second(s) Actual: 30 second(s)",
                 "Reason: tapagg Status: Enabled Interval: 30 - Not found",
             ],
         },


### PR DESCRIPTION
# Description
Added fix for VerifyErrdisableRecovery errors out when timer interval is N/A

Fixes #1296

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
