### PR TITLE
feat(anta): Enhanced VerifyLoggingErrors to support the last N of units

### DIFF
--- a/anta/tests/logging.py
+++ b/anta/tests/logging.py
@@ -433,7 +433,7 @@ class VerifyLoggingErrors(AntaTest):
         last_number_time_units: Annotated[int, Field(ge=1, le=9999)] | None = None
         """Number of time units to look in the logging buffers.
 
-        The actual duration is determined based on the selected `time_unit` (e.g. 5 "days", 10 "minutes")."""
+        The actual duration is determined based on the selected `time_unit` (e.g. 5 days, 10 minutes)."""
         time_unit: Literal["days", "hours", "minutes", "seconds"] = "days"
         """Unit of time to be used with `last_number_time_units`."""
 

--- a/tests/units/anta_tests/test_logging.py
+++ b/tests/units/anta_tests/test_logging.py
@@ -186,6 +186,11 @@ DATA: AntaUnitTestDataDict = {
         "inputs": {"last_number_time_units": 10, "time_unit": "hours"},
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
+    (VerifyLoggingErrors, "success-only-time-unit"): {
+        "eos_data": [""],
+        "inputs": {"last_number_time_units": 9999},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
     (VerifyLoggingErrors, "failure"): {
         "eos_data": [
             "Aug  2 19:57:42 DC1-LEAF1A Mlag: %FWK-3-SOCKET_CLOSE_REMOTE: Connection to Mlag (pid:27200) at tbt://192.168.0.1:4432/+n closed by peer (EOF)"

--- a/tests/units/anta_tests/test_logging.py
+++ b/tests/units/anta_tests/test_logging.py
@@ -181,6 +181,11 @@ DATA: AntaUnitTestDataDict = {
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA accounting logs are not generated"]},
     },
     (VerifyLoggingErrors, "success"): {"eos_data": [""], "expected": {"result": AntaTestStatus.SUCCESS}},
+    (VerifyLoggingErrors, "success-last-n-units"): {
+        "eos_data": [""],
+        "inputs": {"last_number_time_units": 10, "time_unit": "hours"},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
     (VerifyLoggingErrors, "failure"): {
         "eos_data": [
             "Aug  2 19:57:42 DC1-LEAF1A Mlag: %FWK-3-SOCKET_CLOSE_REMOTE: Connection to Mlag (pid:27200) at tbt://192.168.0.1:4432/+n closed by peer (EOF)"


### PR DESCRIPTION
# Description
Enhanced VerifyLoggingErrors to support the last N of units

Fixes #1309

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
