### PR TITLE
feat(anta.tests): Enhance VerifyLLDPNeighbors to support hostname and FQDN as per input mode

### DIFF
--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -148,6 +148,7 @@ anta.tests.configuration:
 anta.tests.connectivity:
   - VerifyLLDPNeighbors:
       # Verifies the connection status of the specified LLDP (Link Layer Discovery Protocol) neighbors.
+      require_fqdn: False
       neighbors:
         - port: Ethernet1
           neighbor_device: DC1-SPINE1
@@ -156,7 +157,7 @@ anta.tests.connectivity:
           neighbor_device: DC1-SPINE2
           neighbor_port: Ethernet1
   - VerifyLLDPNeighbors:
-      strict_mode: True
+      require_fqdn: True
       neighbors:
         - port: Ethernet1
           neighbor_device: DC1-SPINE1.local.com

--- a/tests/units/anta_tests/test_connectivity.py
+++ b/tests/units/anta_tests/test_connectivity.py
@@ -284,7 +284,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73a0.fc18",
-                                "systemName": "DC1-SPINE1",
+                                "systemName": "DC1-SPINE1.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -299,7 +299,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73f7.d138",
-                                "systemName": "DC1-SPINE2",
+                                "systemName": "DC1-SPINE2.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -313,14 +313,15 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {
+            "require_fqdn": False,
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
-            ]
+            ],
         },
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
-    (VerifyLLDPNeighbors, "success-strict-mode-enabled"): {
+    (VerifyLLDPNeighbors, "success-require-fqdn"): {
         "eos_data": [
             {
                 "lldpNeighbors": {
@@ -348,7 +349,7 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {
-            "strict_mode": True,
+            "require_fqdn": True,
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1.local.com", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2.local.com", "neighbor_port": "Ethernet1"},
@@ -365,7 +366,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73a0.fc18",
-                                "systemName": "DC1-SPINE1",
+                                "systemName": "DC1-SPINE1.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -376,7 +377,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73f7.d138",
-                                "systemName": "DC1-SPINE2",
+                                "systemName": "DC1-SPINE2.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -389,7 +390,7 @@ DATA: AntaUnitTestData = {
                 }
             }
         ],
-        "inputs": {"neighbors": [{"port": "Ethernet1", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"}]},
+        "inputs": {"require_fqdn": False, "neighbors": [{"port": "Ethernet1", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"}]},
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
     (VerifyLLDPNeighbors, "failure-port-not-configured"): {
@@ -401,7 +402,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73a0.fc18",
-                                "systemName": "DC1-SPINE1",
+                                "systemName": "DC1-SPINE1.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -415,10 +416,11 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {
+            "require_fqdn": False,
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
-            ]
+            ],
         },
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - Port not found"]},
     },
@@ -431,7 +433,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73a0.fc18",
-                                "systemName": "DC1-SPINE1",
+                                "systemName": "DC1-SPINE1.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -446,10 +448,11 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {
+            "require_fqdn": False,
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
-            ]
+            ],
         },
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Port: Ethernet2 Neighbor: DC1-SPINE2 Neighbor Port: Ethernet1 - No LLDP neighbors"]},
     },
@@ -462,7 +465,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73a0.fc18",
-                                "systemName": "DC1-SPINE1",
+                                "systemName": "DC1-SPINE1.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -477,7 +480,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73f7.d138",
-                                "systemName": "DC1-SPINE2",
+                                "systemName": "DC1-SPINE2.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet2",
@@ -491,10 +494,11 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {
+            "require_fqdn": False,
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
-            ]
+            ],
         },
         "expected": {
             "result": AntaTestStatus.FAILURE,
@@ -510,7 +514,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73a0.fc18",
-                                "systemName": "DC1-SPINE1",
+                                "systemName": "DC1-SPINE1.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet2",
@@ -525,11 +529,12 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {
+            "require_fqdn": False,
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet3", "neighbor_device": "DC1-SPINE3", "neighbor_port": "Ethernet1"},
-            ]
+            ],
         },
         "expected": {
             "result": AntaTestStatus.FAILURE,
@@ -549,7 +554,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73a0.fc18",
-                                "systemName": "DC1-SPINE1",
+                                "systemName": "DC1-SPINE1.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -560,7 +565,7 @@ DATA: AntaUnitTestData = {
                             {
                                 "chassisIdType": "macAddress",
                                 "chassisId": "001c.73f7.d138",
-                                "systemName": "DC1-SPINE2",
+                                "systemName": "DC1-SPINE2.local.com",
                                 "neighborInterfaceInfo": {
                                     "interfaceIdType": "interfaceName",
                                     "interfaceId": "Ethernet1",
@@ -573,13 +578,13 @@ DATA: AntaUnitTestData = {
                 }
             }
         ],
-        "inputs": {"neighbors": [{"port": "Ethernet1", "neighbor_device": "DC1-SPINE3", "neighbor_port": "Ethernet1"}]},
+        "inputs": {"require_fqdn": False, "neighbors": [{"port": "Ethernet1", "neighbor_device": "DC1-SPINE3", "neighbor_port": "Ethernet1"}]},
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": ["Port: Ethernet1 Neighbor: DC1-SPINE3 Neighbor Port: Ethernet1 - Wrong LLDP neighbors: DC1-SPINE1/Ethernet1, DC1-SPINE2/Ethernet1"],
         },
     },
-    (VerifyLLDPNeighbors, "failure-strict-mode-enabled"): {
+    (VerifyLLDPNeighbors, "failure-require-fqdn"): {
         "eos_data": [
             {
                 "lldpNeighbors": {
@@ -607,7 +612,7 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {
-            "strict_mode": True,
+            "require_fqdn": True,
             "neighbors": [
                 {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1.domain.com", "neighbor_port": "Ethernet1"},
                 {"port": "Ethernet2", "neighbor_device": "DC1-SPINE2.domain.com", "neighbor_port": "Ethernet1"},
@@ -618,6 +623,46 @@ DATA: AntaUnitTestData = {
             "messages": [
                 "Port: Ethernet1 Neighbor: DC1-SPINE1.domain.com Neighbor Port: Ethernet1 - Wrong LLDP neighbors: DC1-SPINE1.local.com/Ethernet1",
                 "Port: Ethernet2 Neighbor: DC1-SPINE2.domain.com Neighbor Port: Ethernet1 - Wrong LLDP neighbors: DC1-SPINE2.local.com/Ethernet1",
+            ],
+        },
+    },
+    (VerifyLLDPNeighbors, "failure-require-fqdn-mismatch"): {
+        "eos_data": [
+            {
+                "lldpNeighbors": {
+                    "Ethernet1": {
+                        "lldpNeighborInfo": [
+                            {
+                                "systemName": "DC1-SPINE1",
+                                "neighborInterfaceInfo": {
+                                    "interfaceId_v2": "Ethernet1",
+                                },
+                            }
+                        ]
+                    },
+                    "Ethernet2": {
+                        "lldpNeighborInfo": [
+                            {
+                                "systemName": "DC1-SPINE2.local.com",
+                                "neighborInterfaceInfo": {
+                                    "interfaceId_v2": "Ethernet1",
+                                },
+                            }
+                        ]
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "require_fqdn": True,
+            "neighbors": [
+                {"port": "Ethernet1", "neighbor_device": "DC1-SPINE1.domain.com", "neighbor_port": "Ethernet1"},
+            ],
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                "Port: Ethernet1 Neighbor: DC1-SPINE1.domain.com Neighbor Port: Ethernet1 - Wrong LLDP neighbors: DC1-SPINE1/Ethernet1",
             ],
         },
     },


### PR DESCRIPTION
# Description

Enhance VerifyLLDPNeighbors to support hostname and FQDN as per input mode

Fixes #1341 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
