### PR TITLE
fix(anta.cli): Wrong type for dry-run flag

### DIFF
--- a/anta/cli/nrfu/__init__.py
+++ b/anta/cli/nrfu/__init__.py
@@ -105,7 +105,7 @@ HIDE_STATUS.remove("unset")
 @click.option(
     "--dry-run",
     help="Run anta nrfu command but stop before starting to execute the tests. Considers all devices as connected.",
-    type=str,
+    type=bool,
     show_envvar=True,
     is_flag=True,
     default=False,


### PR DESCRIPTION
cf title.

basically starting click 8.3 it was converted to `str` which fails later when we do `if dry_run` when its value is `"False"`