### PR TITLE
feat(anta.tests): Add VerifyMgmtIdleTimeout to security tests

### DIFF
--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import ClassVar
 
+from anta import GITHUB_SUGGESTION
 from anta.custom_types import PositiveInteger
 from anta.input_models.security import ACL, APISSLCertificate, IPSecPeer, IPSecPeers
 from anta.models import AntaCommand, AntaTemplate, AntaTest
@@ -771,7 +772,7 @@ class VerifyMgmtIdleTimeout(AntaTest):
         """Input model for the VerifyMgmtIdleTimeout test."""
 
         max_idle_timeout: int = 10
-        """Maximum allowed idle timeout in minutes. Defaults to 10."""
+        """Maximum allowed idle timeout in minutes."""
 
     @AntaTest.anta_test
     def test(self) -> None:
@@ -787,7 +788,11 @@ class VerifyMgmtIdleTimeout(AntaTest):
         if console_line is None or "none" in console_line:
             self.result.is_failure("Management console idle-timeout is not configured")
         else:
-            value = int(console_line.split(":")[1].strip().split()[0])
+            try:
+                value = int(console_line.split(":")[1].strip().split()[0])
+            except (IndexError, ValueError):
+                self.result.is_error(f"Unable to parse 'show management console' output. {GITHUB_SUGGESTION}")
+                return
             if value > max_timeout:
                 self.result.is_failure(f"Management console idle-timeout is {value} minutes (max allowed: {max_timeout} minutes)")
 
@@ -802,7 +807,11 @@ class VerifyMgmtIdleTimeout(AntaTest):
         if ssh_line is None:
             self.result.is_failure("Management SSH idle-timeout is not configured")
         else:
-            value = int(ssh_line.split(":")[1].strip().split()[0])
+            try:
+                value = int(ssh_line.split(":")[1].strip().split()[0])
+            except (IndexError, ValueError):
+                self.result.is_error(f"Unable to parse 'show management ssh' output. {GITHUB_SUGGESTION}")
+                return
             if value > max_timeout:
                 self.result.is_failure(f"Management SSH idle-timeout is {value} minutes (max allowed: {max_timeout} minutes)")
 

--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -764,7 +764,7 @@ class VerifyMgmtIdleTimeout(AntaTest):
 
     categories: ClassVar[list[str]] = ["security"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
-        AntaCommand(command="show management console", ofmt="text"),
+        AntaCommand(command="show running-config | section management console", ofmt="text"),
         AntaCommand(command="show management ssh", ofmt="text"),
     ]
 
@@ -781,17 +781,17 @@ class VerifyMgmtIdleTimeout(AntaTest):
         max_timeout = self.inputs.max_idle_timeout
 
         # Check management console idle-timeout.
-        # Expected output line: "Timeout    : 10 minutes (configured), 10 minutes (active)"
-        # When not configured:  "Timeout    : none"
+        # Expected output line: "   idle-timeout 10"
+        # When management console is not configured, the output is empty.
         console_output = self.instance_commands[0].text_output
-        console_line = next((line for line in console_output.splitlines() if line.strip().startswith("Timeout")), None)
-        if console_line is None or "none" in console_line:
+        console_line = next((line for line in console_output.splitlines() if "idle-timeout" in line), None)
+        if console_line is None:
             self.result.is_failure("Management console idle-timeout is not configured")
         else:
             try:
-                value = int(console_line.split(":")[1].strip().split()[0])
+                value = int(console_line.split()[-1])
             except (IndexError, ValueError):
-                self.result.is_error(f"Unable to parse 'show management console' output. {GITHUB_SUGGESTION}")
+                self.result.is_error(f"Unable to parse 'show running-config | section management console' output. {GITHUB_SUGGESTION}")
                 return
             if value > max_timeout:
                 self.result.is_failure(f"Management console idle-timeout is {value} minutes (max allowed: {max_timeout} minutes)")

--- a/anta/tests/security.py
+++ b/anta/tests/security.py
@@ -744,6 +744,69 @@ class VerifySpecificIPSecConn(AntaTest):
                     result.is_failure("Connection not found")
 
 
+class VerifyMgmtIdleTimeout(AntaTest):
+    """Verifies that the management console and SSH idle-timeout are configured and within the allowed limit.
+
+    Expected Results
+    ----------------
+    * Success: The test will pass if both management console and SSH idle-timeout are configured and do not exceed the maximum allowed value.
+    * Failure: The test will fail if either idle-timeout is not configured or exceeds the maximum allowed value.
+
+    Examples
+    --------
+    ```yaml
+    anta.tests.security:
+      - VerifyMgmtIdleTimeout:
+          max_idle_timeout: 10
+    ```
+    """
+
+    categories: ClassVar[list[str]] = ["security"]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
+        AntaCommand(command="show management console", ofmt="text"),
+        AntaCommand(command="show management ssh", ofmt="text"),
+    ]
+
+    class Input(AntaTest.Input):
+        """Input model for the VerifyMgmtIdleTimeout test."""
+
+        max_idle_timeout: int = 10
+        """Maximum allowed idle timeout in minutes. Defaults to 10."""
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        """Main test function for VerifyMgmtIdleTimeout."""
+        self.result.is_success()
+        max_timeout = self.inputs.max_idle_timeout
+
+        # Check management console idle-timeout.
+        # Expected output line: "Timeout    : 10 minutes (configured), 10 minutes (active)"
+        # When not configured:  "Timeout    : none"
+        console_output = self.instance_commands[0].text_output
+        console_line = next((line for line in console_output.splitlines() if line.strip().startswith("Timeout")), None)
+        if console_line is None or "none" in console_line:
+            self.result.is_failure("Management console idle-timeout is not configured")
+        else:
+            value = int(console_line.split(":")[1].strip().split()[0])
+            if value > max_timeout:
+                self.result.is_failure(f"Management console idle-timeout is {value} minutes (max allowed: {max_timeout} minutes)")
+
+        # Check management SSH idle-timeout.
+        # Expected output line: "SSH idle connection timeout   : 10"
+        # When not configured, this line is absent.
+        ssh_output = self.instance_commands[1].text_output
+        ssh_line = next(
+            (line for line in ssh_output.splitlines() if "idle" in line.lower() and "timeout" in line.lower()),
+            None,
+        )
+        if ssh_line is None:
+            self.result.is_failure("Management SSH idle-timeout is not configured")
+        else:
+            value = int(ssh_line.split(":")[1].strip().split()[0])
+            if value > max_timeout:
+                self.result.is_failure(f"Management SSH idle-timeout is {value} minutes (max allowed: {max_timeout} minutes)")
+
+
 class VerifySSHFIPSRestrictions(AntaTest):
     """Verifies that FIPS restrictions are enabled in management SSH.
 

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -1180,6 +1180,9 @@ anta.tests.security:
               action: permit icmp any any
             - sequence: 20
               action: permit tcp any any range 5900 5910
+  - VerifyMgmtIdleTimeout:
+      # Verifies that the management console and SSH idle-timeout are configured and within the allowed limit.
+      max_idle_timeout: 10
   - VerifySSHFIPSRestrictions:
       # Verifies that FIPS restrictions are enabled in management SSH.
   - VerifySSHIPv4Acl:

--- a/tests/units/anta_tests/test_security.py
+++ b/tests/units/anta_tests/test_security.py
@@ -24,6 +24,7 @@ from anta.tests.security import (
     VerifyHardwareEntropy,
     VerifyIPSecConnHealth,
     VerifyIPv4ACL,
+    VerifyMgmtIdleTimeout,
     VerifySpecificIPSecConn,
     VerifySSHFIPSRestrictions,
     VerifySSHIPv4Acl,
@@ -1195,6 +1196,50 @@ DATA: AntaUnitTestData = {
                 },
             ],
         },
+    },
+    (VerifyMgmtIdleTimeout, "success"): {
+        "eos_data": [
+            "Timeout    : 10 minutes (configured), 10 minutes (active)\n\n",
+            "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
+            "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 10\n\n",
+        ],
+        "inputs": {"max_idle_timeout": 10},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
+    (VerifyMgmtIdleTimeout, "failure-console-not-configured"): {
+        "eos_data": [
+            "Timeout    : none\n\n",
+            "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
+            "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 10\n\n",
+        ],
+        "inputs": {"max_idle_timeout": 10},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Management console idle-timeout is not configured"]},
+    },
+    (VerifyMgmtIdleTimeout, "failure-console-exceeds"): {
+        "eos_data": [
+            "Timeout    : 15 minutes (configured), 15 minutes (active)\n\n",
+            "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
+            "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 10\n\n",
+        ],
+        "inputs": {"max_idle_timeout": 10},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Management console idle-timeout is 15 minutes (max allowed: 10 minutes)"]},
+    },
+    (VerifyMgmtIdleTimeout, "failure-ssh-not-configured"): {
+        "eos_data": [
+            "Timeout    : 10 minutes (configured), 10 minutes (active)\n\n",
+            "SSHD status for Default VRF is enabled\nSSH connection limit is 50\nSSH per host connection limit is 20\nFIPS status: disabled\n\n",
+        ],
+        "inputs": {"max_idle_timeout": 10},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Management SSH idle-timeout is not configured"]},
+    },
+    (VerifyMgmtIdleTimeout, "failure-ssh-exceeds"): {
+        "eos_data": [
+            "Timeout    : 10 minutes (configured), 10 minutes (active)\n\n",
+            "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
+            "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 15\n\n",
+        ],
+        "inputs": {"max_idle_timeout": 10},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Management SSH idle-timeout is 15 minutes (max allowed: 10 minutes)"]},
     },
     (VerifySSHFIPSRestrictions, "success"): {
         "eos_data": ["SSHD status for Default VRF is enabled\nSSH connection limit is 50\nSSH per host connection limit is 20\nFIPS status: enabled\n\n"],

--- a/tests/units/anta_tests/test_security.py
+++ b/tests/units/anta_tests/test_security.py
@@ -1199,7 +1199,7 @@ DATA: AntaUnitTestData = {
     },
     (VerifyMgmtIdleTimeout, "success"): {
         "eos_data": [
-            "Timeout    : 10 minutes (configured), 10 minutes (active)\n\n",
+            "management console\n   idle-timeout 10\n!\n",
             "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
             "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 10\n\n",
         ],
@@ -1208,7 +1208,7 @@ DATA: AntaUnitTestData = {
     },
     (VerifyMgmtIdleTimeout, "failure-console-not-configured"): {
         "eos_data": [
-            "Timeout    : none\n\n",
+            "",
             "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
             "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 10\n\n",
         ],
@@ -1217,7 +1217,7 @@ DATA: AntaUnitTestData = {
     },
     (VerifyMgmtIdleTimeout, "failure-console-exceeds"): {
         "eos_data": [
-            "Timeout    : 15 minutes (configured), 15 minutes (active)\n\n",
+            "management console\n   idle-timeout 15\n!\n",
             "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
             "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 10\n\n",
         ],
@@ -1226,7 +1226,7 @@ DATA: AntaUnitTestData = {
     },
     (VerifyMgmtIdleTimeout, "failure-ssh-not-configured"): {
         "eos_data": [
-            "Timeout    : 10 minutes (configured), 10 minutes (active)\n\n",
+            "management console\n   idle-timeout 10\n!\n",
             "SSHD status for Default VRF is enabled\nSSH connection limit is 50\nSSH per host connection limit is 20\nFIPS status: disabled\n\n",
         ],
         "inputs": {"max_idle_timeout": 10},
@@ -1234,7 +1234,7 @@ DATA: AntaUnitTestData = {
     },
     (VerifyMgmtIdleTimeout, "failure-ssh-exceeds"): {
         "eos_data": [
-            "Timeout    : 10 minutes (configured), 10 minutes (active)\n\n",
+            "management console\n   idle-timeout 10\n!\n",
             "SSHD status for Default VRF is enabled\nSSH connection limit is 50\n"
             "SSH per host connection limit is 20\nFIPS status: disabled\nSSH idle connection timeout   : 15\n\n",
         ],


### PR DESCRIPTION
# Description

  Adds `VerifyMgmtIdleTimeout` to `anta/tests/security.py` to verify that
  management console and SSH idle-timeout are both configured and do not exceed
  a configurable maximum (default: 10 minutes).

  The test parses the text output of two commands:
  - `show management console` — checks the `Timeout` line
  - `show management ssh` — checks for an SSH idle connection timeout line

  It fails independently for each interface if the timeout is absent or exceeds
  `max_idle_timeout`.

  **Test behavior:**
  - **Success:** Both console and SSH idle-timeout are configured and ≤ `max_idle_timeout`
  - **Failure:** Either interface has no idle-timeout configured, or the configured value exceeds the maximum

  No existing test in `anta/tests/security.py` covered management session
  idle-timeout for either interface.

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have run pre-commit for code linting and typing (`pre-commit run`)
  - [ ] I have made corresponding changes to the documentation
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
