### PR TITLE
feat(anta.tests): extend VerifyAuthenMethods with policy and authz co…

### DIFF
--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -159,10 +159,15 @@ class VerifyTacacsServerGroups(AntaTest):
 class VerifyAuthenMethods(AntaTest):
     """Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).
 
+    Optionally verifies the AAA authentication policy flags (on-success log, on-failure log)
+    and the AAA authorization console setting.
+
     Expected Results
     ----------------
     * Success: The test will pass if the provided AAA authentication method list is matching in the configured authentication types.
-    * Failure: The test will fail if the provided AAA authentication method list is NOT matching in the configured authentication types.
+      If optional policy flags are provided, those must also match.
+    * Failure: The test will fail if the provided AAA authentication method list is NOT matching in the configured authentication types,
+      or if any provided optional policy flag does not match the running configuration.
 
     Examples
     --------
@@ -177,11 +182,17 @@ class VerifyAuthenMethods(AntaTest):
             - login
             - enable
             - dot1x
+          auth_success_log: true
+          auth_failure_log: true
+          authz_console: true
     ```
     """
 
     categories: ClassVar[list[str]] = ["aaa"]
-    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show aaa methods authentication", revision=1)]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
+        AntaCommand(command="show aaa methods authentication", revision=1),
+        AntaCommand(command="show running-config | section aaa", ofmt="text"),
+    ]
 
     class Input(AntaTest.Input):
         """Input model for the VerifyAuthenMethods test."""
@@ -190,6 +201,30 @@ class VerifyAuthenMethods(AntaTest):
         """List of AAA authentication methods. Methods should be in the right order."""
         types: set[Literal["login", "enable", "dot1x"]]
         """List of authentication types to verify."""
+        auth_success_log: bool | None = None
+        """If set, verify whether ``aaa authentication policy on-success log`` is configured."""
+        auth_failure_log: bool | None = None
+        """If set, verify whether ``aaa authentication policy on-failure log`` is configured."""
+        authz_console: bool | None = None
+        """If set, verify whether ``aaa authorization console`` is configured."""
+
+    def _check_policy_flags(self) -> None:
+        """Check optional authentication policy and authorization console flags against the running config."""
+        policy_checks = [
+            (self.inputs.auth_success_log, "aaa authentication policy on-success log"),
+            (self.inputs.auth_failure_log, "aaa authentication policy on-failure log"),
+            (self.inputs.authz_console, "aaa authorization console"),
+        ]
+        if any(expected is not None for expected, _ in policy_checks):
+            config_lines = self.instance_commands[1].text_output.splitlines()
+            for expected, line in policy_checks:
+                if expected is None:
+                    continue
+                present = any(line in config_line for config_line in config_lines)
+                if expected and not present:
+                    self.result.is_failure(f"'{line}' is not configured")
+                elif not expected and present:
+                    self.result.is_failure(f"'{line}' is configured but should not be")
 
     @AntaTest.anta_test
     def test(self) -> None:
@@ -210,10 +245,15 @@ class VerifyAuthenMethods(AntaTest):
                     return
             not_matching.extend(auth_type for methods in v.values() if methods["methods"] != self.inputs.methods)
 
-        if not not_matching:
-            self.result.is_success()
-        else:
+        if not_matching:
             self.result.is_failure(f"AAA authentication methods {', '.join(self.inputs.methods)} are not matching for {', '.join(not_matching)}")
+            return
+
+        self.result.is_success()
+
+        # Check optional authentication policy and authorization console flags.
+        # is_failure() will override is_success() above if any check fails.
+        self._check_policy_flags()
 
 
 class VerifyAuthzMethods(AntaTest):

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -32,6 +32,9 @@ anta.tests.aaa:
         - login
         - enable
         - dot1x
+      auth_success_log: true
+      auth_failure_log: true
+      authz_console: true
   - VerifyAuthzMethods:
       # Verifies the AAA authorization method lists for different authorization types (commands, exec).
       methods:

--- a/tests/units/anta_tests/test_aaa.py
+++ b/tests/units/anta_tests/test_aaa.py
@@ -161,7 +161,8 @@ DATA: AntaUnitTestData = {
                 "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "login": {"methods": ["group tacacs+", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
-            }
+            },
+            "",
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
         "expected": {"result": AntaTestStatus.SUCCESS},
@@ -172,7 +173,8 @@ DATA: AntaUnitTestData = {
                 "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "login": {"methods": ["group tacacs+", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
-            }
+            },
+            "",
         ],
         "inputs": {"methods": ["radius"], "types": ["dot1x"]},
         "expected": {"result": AntaTestStatus.SUCCESS},
@@ -183,7 +185,8 @@ DATA: AntaUnitTestData = {
                 "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
-            }
+            },
+            "",
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods are not configured for login console"]},
@@ -194,7 +197,8 @@ DATA: AntaUnitTestData = {
                 "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "login": {"methods": ["group radius", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
-            }
+            },
+            "",
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login console"]},
@@ -205,10 +209,90 @@ DATA: AntaUnitTestData = {
                 "loginAuthenMethods": {"default": {"methods": ["group radius", "local"]}, "login": {"methods": ["group tacacs+", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
-            }
+            },
+            "",
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login"]},
+    },
+    (VerifyAuthenMethods, "success-policy-flags"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {"default": {"methods": ["group radius", "local"]}, "login": {"methods": ["group radius", "local"]}},
+                "enableAuthenMethods": {"default": {"methods": ["group radius", "local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
+            },
+            "aaa authentication policy on-success log\naaa authentication policy on-failure log\naaa authorization console\n",
+        ],
+        "inputs": {
+            "methods": ["radius", "local"],
+            "types": ["login"],
+            "auth_success_log": True,
+            "auth_failure_log": True,
+            "authz_console": True,
+        },
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
+    (VerifyAuthenMethods, "failure-policy-success-log-missing"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {"default": {"methods": ["group radius", "local"]}, "login": {"methods": ["group radius", "local"]}},
+                "enableAuthenMethods": {"default": {"methods": ["group radius", "local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
+            },
+            "aaa authentication policy on-failure log\naaa authorization console\n",
+        ],
+        "inputs": {
+            "methods": ["radius", "local"],
+            "types": ["login"],
+            "auth_success_log": True,
+            "auth_failure_log": True,
+            "authz_console": True,
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["'aaa authentication policy on-success log' is not configured"],
+        },
+    },
+    (VerifyAuthenMethods, "failure-authz-console-missing"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {"default": {"methods": ["group radius", "local"]}, "login": {"methods": ["group radius", "local"]}},
+                "enableAuthenMethods": {"default": {"methods": ["group radius", "local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
+            },
+            "aaa authentication policy on-success log\naaa authentication policy on-failure log\n",
+        ],
+        "inputs": {
+            "methods": ["radius", "local"],
+            "types": ["login"],
+            "auth_success_log": True,
+            "auth_failure_log": True,
+            "authz_console": True,
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["'aaa authorization console' is not configured"],
+        },
+    },
+    (VerifyAuthenMethods, "failure-authz-console-present-when-not-expected"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {"default": {"methods": ["group radius", "local"]}, "login": {"methods": ["group radius", "local"]}},
+                "enableAuthenMethods": {"default": {"methods": ["group radius", "local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
+            },
+            "aaa authorization console\n",
+        ],
+        "inputs": {
+            "methods": ["radius", "local"],
+            "types": ["login"],
+            "authz_console": False,
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["'aaa authorization console' is configured but should not be"],
+        },
     },
     (VerifyAuthzMethods, "success"): {
         "eos_data": [

--- a/tests/units/cli/get/test_commands.py
+++ b/tests/units/cli/get/test_commands.py
@@ -589,7 +589,7 @@ def test_get_commands(
             "anta.tests.aaa",
             None,
             None,
-            4,
+            5,
             id="Get unique commands, filter on module",
         ),
         pytest.param(


### PR DESCRIPTION
  ## Summary

  - Adds three optional inputs to `VerifyAuthenMethods` to cover AAA configuration lines
    that previously had no dedicated ANTA test:
    - `auth_success_log` — verifies `aaa authentication policy on-success log`
    - `auth_failure_log` — verifies `aaa authentication policy on-failure log`
    - `authz_console`    — verifies `aaa authorization console`
  - Adds a second command (`show running-config | section aaa`) to support the new checks
  - Extracts policy logic into `_check_policy_flags()` to satisfy the cyclomatic complexity limit (C901)
  - Updates `tests/units/cli/get/test_commands.py` unique command count for `anta.tests.aaa` (4 → 5)

  ## Backwards compatibility

  All three new inputs default to `None`. When not provided, the second command output is
  fetched but not evaluated — behaviour is identical to the existing test for all current callers.

  ## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have run pre-commit for code linting and typing (`pre-commit run`) — all hooks pass
  - [x] I have made corresponding changes to the documentation — docstring and `examples/tests.yaml` updated
  - [x] I have added tests that prove my fix is effective or that my feature works — 4 new unit test cases
  - [x] New and existing unit tests pass locally with my changes (`tox -e py312`) — 1969 passed, 1 skipped

  🤖 Generated with [Claude Code](https://claude.com/claude-code)