### PR TITLE
feat: Add support for proxy_bypass httpx

### DIFF
--- a/anta/device.py
+++ b/anta/device.py
@@ -21,7 +21,7 @@ import asynceapi
 from anta import __DEBUG__
 from anta.logger import anta_log_exception, exc_to_str
 from anta.models import AntaCommand
-from anta.settings import ANTA_HTTPX_SETTINGS
+from anta.settings import get_httpx_settings
 from asynceapi._types import EapiComplexCommand
 
 if TYPE_CHECKING:
@@ -395,7 +395,7 @@ class AsyncEOSDevice(AntaDevice):
         self.enable = enable
         self._enable_password = enable_password
         self._session: asynceapi.Device = asynceapi.Device(
-            host=host, port=port, username=username, password=password, proto=proto, timeout=timeout, trust_env=ANTA_HTTPX_SETTINGS.trust_env
+            host=host, port=port, username=username, password=password, proto=proto, timeout=timeout, trust_env=get_httpx_settings().trust_env
         )
         ssh_params: dict[str, Any] = {}
         if insecure:

--- a/anta/device.py
+++ b/anta/device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2026 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """ANTA Device Abstraction Module."""
@@ -128,6 +128,8 @@ class AntaDevice(ABC):
         For informational/logging purposes only. Can be used by the runner to verify that
         the total potential connections of a run do not exceed the system file descriptor limit.
         This does **not** affect the actual device configuration. None if not available.
+    trust_env : bool
+        default is True, trust the proxy/no_proxy env variable from os. used by httpx.
     """
 
     def __init__(self, name: str, tags: set[str] | None = None, *, disable_cache: bool = False) -> None:
@@ -153,6 +155,7 @@ class AntaDevice(ABC):
         self.cache: AntaCache | None = None
         # Keeping cache_locks for backward compatibility.
         self.cache_locks: defaultdict[str, asyncio.Lock] | None = None
+        self.trust_env: bool = True
 
         # Initialize cache if not disabled
         if not disable_cache:
@@ -201,6 +204,7 @@ class AntaDevice(ABC):
         yield "is_online", self.is_online
         yield "established", self.established
         yield "disable_cache", self.cache is None
+        yield "trust_env", self.trust_env
 
     def __repr__(self) -> str:
         """Return a printable representation of an AntaDevice."""
@@ -210,7 +214,8 @@ class AntaDevice(ABC):
             f"hw_model={self.hw_model!r}, "
             f"is_online={self.is_online!r}, "
             f"established={self.established!r}, "
-            f"disable_cache={self.cache is None!r})"
+            f"disable_cache={self.cache is None!r},"
+            f"trust_env={self.trust_env!r})"
         )
 
     @abstractmethod
@@ -344,6 +349,7 @@ class AsyncEOSDevice(AntaDevice):
         enable: bool = False,
         insecure: bool = False,
         disable_cache: bool = False,
+        trust_env: bool = True,
     ) -> None:
         """Instantiate an AsyncEOSDevice.
 
@@ -375,6 +381,8 @@ class AsyncEOSDevice(AntaDevice):
             Disable SSH Host Key validation.
         disable_cache
             Disable caching for all commands for this device.
+        trust_env
+            default is True, trust the proxy/no_proxy env variable from os. used by httpx.
         """
         if host is None:
             message = "'host' is required to create an AsyncEOSDevice"
@@ -392,8 +400,9 @@ class AsyncEOSDevice(AntaDevice):
             logger.error(message)
             raise ValueError(message)
         self.enable = enable
+        self.trust_env = trust_env
         self._enable_password = enable_password
-        self._session: asynceapi.Device = asynceapi.Device(host=host, port=port, username=username, password=password, proto=proto, timeout=timeout)
+        self._session: asynceapi.Device = asynceapi.Device(trust_env=trust_env, host=host, port=port, username=username, password=password, proto=proto, timeout=timeout)
         ssh_params: dict[str, Any] = {}
         if insecure:
             ssh_params["known_hosts"] = None
@@ -413,6 +422,7 @@ class AsyncEOSDevice(AntaDevice):
         yield ("eapi_port", self._session.port)
         yield ("username", self._ssh_opts.username)
         yield ("enable", self.enable)
+        yield ("trust_env", self.trust_env)
         yield ("insecure", self._ssh_opts.known_hosts is None)
         if __DEBUG__:
             _ssh_opts = vars(self._ssh_opts).copy()
@@ -436,6 +446,7 @@ class AsyncEOSDevice(AntaDevice):
             f"eapi_port={self._session.port!r}, "
             f"username={self._ssh_opts.username!r}, "
             f"enable={self.enable!r}, "
+            f"trust_env={self.trust_env!r}, "
             f"insecure={self._ssh_opts.known_hosts is None!r})"
         )
 

--- a/anta/device.py
+++ b/anta/device.py
@@ -21,7 +21,7 @@ import asynceapi
 from anta import __DEBUG__
 from anta.logger import anta_log_exception, exc_to_str
 from anta.models import AntaCommand
-from anta.settings import AntaHttpxSettings
+from anta.settings import ANTA_HTTPX_SETTINGS
 from asynceapi._types import EapiComplexCommand
 
 if TYPE_CHECKING:
@@ -329,14 +329,6 @@ class AsyncEOSDevice(AntaDevice):
         Tags for this device.
     """
 
-    _httpx_settings: AntaHttpxSettings | None = None
-
-    @classmethod
-    def _get_httpx_settings(cls) -> AntaHttpxSettings:
-        if cls._httpx_settings is None:
-            cls._httpx_settings = AntaHttpxSettings()
-        return cls._httpx_settings
-
     def __init__(  # noqa: PLR0913
         self,
         host: str,
@@ -403,7 +395,7 @@ class AsyncEOSDevice(AntaDevice):
         self.enable = enable
         self._enable_password = enable_password
         self._session: asynceapi.Device = asynceapi.Device(
-            trust_env=self._get_httpx_settings().trust_env, host=host, port=port, username=username, password=password, proto=proto, timeout=timeout
+            host=host, port=port, username=username, password=password, proto=proto, timeout=timeout, trust_env=ANTA_HTTPX_SETTINGS.trust_env
         )
         ssh_params: dict[str, Any] = {}
         if insecure:

--- a/anta/device.py
+++ b/anta/device.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Arista Networks, Inc.
+# Copyright (c) 2023-2026 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """ANTA Device Abstraction Module."""
@@ -402,7 +402,9 @@ class AsyncEOSDevice(AntaDevice):
         self.enable = enable
         self.trust_env = trust_env
         self._enable_password = enable_password
-        self._session: asynceapi.Device = asynceapi.Device(trust_env=trust_env, host=host, port=port, username=username, password=password, proto=proto, timeout=timeout)
+        self._session: asynceapi.Device = asynceapi.Device(
+            trust_env=trust_env, host=host, port=port, username=username, password=password, proto=proto, timeout=timeout
+        )
         ssh_params: dict[str, Any] = {}
         if insecure:
             ssh_params["known_hosts"] = None

--- a/anta/device.py
+++ b/anta/device.py
@@ -21,6 +21,7 @@ import asynceapi
 from anta import __DEBUG__
 from anta.logger import anta_log_exception, exc_to_str
 from anta.models import AntaCommand
+from anta.settings import AntaHttpxSettings
 from asynceapi._types import EapiComplexCommand
 
 if TYPE_CHECKING:
@@ -128,8 +129,6 @@ class AntaDevice(ABC):
         For informational/logging purposes only. Can be used by the runner to verify that
         the total potential connections of a run do not exceed the system file descriptor limit.
         This does **not** affect the actual device configuration. None if not available.
-    trust_env : bool
-        default is True, trust the proxy/no_proxy env variable from os. used by httpx.
     """
 
     def __init__(self, name: str, tags: set[str] | None = None, *, disable_cache: bool = False) -> None:
@@ -155,7 +154,6 @@ class AntaDevice(ABC):
         self.cache: AntaCache | None = None
         # Keeping cache_locks for backward compatibility.
         self.cache_locks: defaultdict[str, asyncio.Lock] | None = None
-        self.trust_env: bool = True
 
         # Initialize cache if not disabled
         if not disable_cache:
@@ -204,7 +202,6 @@ class AntaDevice(ABC):
         yield "is_online", self.is_online
         yield "established", self.established
         yield "disable_cache", self.cache is None
-        yield "trust_env", self.trust_env
 
     def __repr__(self) -> str:
         """Return a printable representation of an AntaDevice."""
@@ -214,8 +211,7 @@ class AntaDevice(ABC):
             f"hw_model={self.hw_model!r}, "
             f"is_online={self.is_online!r}, "
             f"established={self.established!r}, "
-            f"disable_cache={self.cache is None!r},"
-            f"trust_env={self.trust_env!r})"
+            f"disable_cache={self.cache is None!r})"
         )
 
     @abstractmethod
@@ -333,6 +329,14 @@ class AsyncEOSDevice(AntaDevice):
         Tags for this device.
     """
 
+    _httpx_settings: AntaHttpxSettings | None = None
+
+    @classmethod
+    def _get_httpx_settings(cls) -> AntaHttpxSettings:
+        if cls._httpx_settings is None:
+            cls._httpx_settings = AntaHttpxSettings()
+        return cls._httpx_settings
+
     def __init__(  # noqa: PLR0913
         self,
         host: str,
@@ -349,7 +353,6 @@ class AsyncEOSDevice(AntaDevice):
         enable: bool = False,
         insecure: bool = False,
         disable_cache: bool = False,
-        trust_env: bool = True,
     ) -> None:
         """Instantiate an AsyncEOSDevice.
 
@@ -381,8 +384,6 @@ class AsyncEOSDevice(AntaDevice):
             Disable SSH Host Key validation.
         disable_cache
             Disable caching for all commands for this device.
-        trust_env
-            default is True, trust the proxy/no_proxy env variable from os. used by httpx.
         """
         if host is None:
             message = "'host' is required to create an AsyncEOSDevice"
@@ -400,10 +401,9 @@ class AsyncEOSDevice(AntaDevice):
             logger.error(message)
             raise ValueError(message)
         self.enable = enable
-        self.trust_env = trust_env
         self._enable_password = enable_password
         self._session: asynceapi.Device = asynceapi.Device(
-            trust_env=trust_env, host=host, port=port, username=username, password=password, proto=proto, timeout=timeout
+            trust_env=self._get_httpx_settings().trust_env, host=host, port=port, username=username, password=password, proto=proto, timeout=timeout
         )
         ssh_params: dict[str, Any] = {}
         if insecure:
@@ -424,7 +424,6 @@ class AsyncEOSDevice(AntaDevice):
         yield ("eapi_port", self._session.port)
         yield ("username", self._ssh_opts.username)
         yield ("enable", self.enable)
-        yield ("trust_env", self.trust_env)
         yield ("insecure", self._ssh_opts.known_hosts is None)
         if __DEBUG__:
             _ssh_opts = vars(self._ssh_opts).copy()
@@ -448,7 +447,6 @@ class AsyncEOSDevice(AntaDevice):
             f"eapi_port={self._session.port!r}, "
             f"username={self._ssh_opts.username!r}, "
             f"enable={self.enable!r}, "
-            f"trust_env={self.trust_env!r}, "
             f"insecure={self._ssh_opts.known_hosts is None!r})"
         )
 

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 Arista Networks, Inc.
+# Copyright (c) 2023-2026 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """Inventory module for ANTA."""
@@ -187,7 +187,7 @@ class AntaInventory(dict[str, AntaDevice]):
         enable: bool = False,
         insecure: bool = False,
         disable_cache: bool = False,
-        trust_env: bool = True
+        trust_env: bool = True,
     ) -> AntaInventory:
         """Create an AntaInventory instance from an inventory file.
 

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2026 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 """Inventory module for ANTA."""
@@ -187,6 +187,7 @@ class AntaInventory(dict[str, AntaDevice]):
         enable: bool = False,
         insecure: bool = False,
         disable_cache: bool = False,
+        trust_env: bool = True
     ) -> AntaInventory:
         """Create an AntaInventory instance from an inventory file.
 
@@ -212,6 +213,8 @@ class AntaInventory(dict[str, AntaDevice]):
             Disable SSH Host Key validation.
         disable_cache
             Disable cache globally.
+        trust_env
+            default is True, trust the proxy/no_proxy env variable from os. used by httpx.
 
         Raises
         ------
@@ -234,6 +237,7 @@ class AntaInventory(dict[str, AntaDevice]):
             "timeout": timeout,
             "insecure": insecure,
             "disable_cache": disable_cache,
+            "trust_env": trust_env,
         }
 
         try:

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -187,7 +187,6 @@ class AntaInventory(dict[str, AntaDevice]):
         enable: bool = False,
         insecure: bool = False,
         disable_cache: bool = False,
-        trust_env: bool = True,
     ) -> AntaInventory:
         """Create an AntaInventory instance from an inventory file.
 
@@ -213,8 +212,6 @@ class AntaInventory(dict[str, AntaDevice]):
             Disable SSH Host Key validation.
         disable_cache
             Disable cache globally.
-        trust_env
-            default is True, trust the proxy/no_proxy env variable from os. used by httpx.
 
         Raises
         ------
@@ -237,7 +234,6 @@ class AntaInventory(dict[str, AntaDevice]):
             "timeout": timeout,
             "insecure": insecure,
             "disable_cache": disable_cache,
-            "trust_env": trust_env,
         }
 
         try:

--- a/anta/settings.py
+++ b/anta/settings.py
@@ -110,5 +110,5 @@ class AntaHttpxSettings(BaseSettings):
     trust_env: bool = Field(default=DEFAULT_HTTPX_TRUST_ENV)
 
 
-# Initializing the httpx settings as these settings are the same across all devices so we can use a module-level singleton
 ANTA_HTTPX_SETTINGS = AntaHttpxSettings()
+"""Module-level singleton for the HTTPX client settings, shared across all AsyncEOSDevice instances."""

--- a/anta/settings.py
+++ b/anta/settings.py
@@ -22,6 +22,9 @@ DEFAULT_MAX_CONCURRENCY = 50000
 DEFAULT_NOFILE = 16384
 """Default value for the maximum number of open file descriptors for the ANTA process."""
 
+DEFAULT_HTTPX_TRUST_ENV = True
+"""Default value for the trust_env parameter in httpx."""
+
 
 class AntaRunnerSettings(BaseSettings):
     """Environment variables for configuring the ANTA runner.
@@ -87,3 +90,21 @@ class AntaRunnerSettings(BaseSettings):
     def file_descriptor_limit(self) -> PositiveInt:
         """The maximum number of file descriptors available to the process."""
         return self._file_descriptor_limit
+
+
+class AntaHttpxSettings(BaseSettings):
+    """Environment variables for configuring the ANTA AsyncEOSDevices.
+
+    When initialized, relevant environment variables are loaded. If not set, default values are used.
+
+    Attributes
+    ----------
+    trust_env : bool
+        Environment variable: ANTA_HTTPX_TRUST_ENV
+
+        Trust the proxy/no_proxy env variable from os. Defaults to True.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="ANTA_HTTPX_")
+
+    trust_env: bool = Field(default=DEFAULT_HTTPX_TRUST_ENV)

--- a/anta/settings.py
+++ b/anta/settings.py
@@ -23,7 +23,7 @@ DEFAULT_NOFILE = 16384
 """Default value for the maximum number of open file descriptors for the ANTA process."""
 
 DEFAULT_HTTPX_TRUST_ENV = True
-"""Default value for the trust_env parameter in httpx."""
+"""Default value for the trust_env parameter of the HTTPX client."""
 
 
 class AntaRunnerSettings(BaseSettings):
@@ -93,7 +93,7 @@ class AntaRunnerSettings(BaseSettings):
 
 
 class AntaHttpxSettings(BaseSettings):
-    """Environment variables for configuring the ANTA AsyncEOSDevices.
+    """Environment variables for configuring the ANTA HTTPX client.
 
     When initialized, relevant environment variables are loaded. If not set, default values are used.
 
@@ -102,9 +102,13 @@ class AntaHttpxSettings(BaseSettings):
     trust_env : bool
         Environment variable: ANTA_HTTPX_TRUST_ENV
 
-        Trust the proxy/no_proxy env variable from os. Defaults to True.
+        Set to False to disable the use of environment variables by the HTTPX client. Defaults to True.
     """
 
     model_config = SettingsConfigDict(env_prefix="ANTA_HTTPX_")
 
     trust_env: bool = Field(default=DEFAULT_HTTPX_TRUST_ENV)
+
+
+# Initializing the httpx settings as these settings are the same across all devices so we can use a module-level singleton
+ANTA_HTTPX_SETTINGS = AntaHttpxSettings()

--- a/anta/settings.py
+++ b/anta/settings.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from functools import cache
 
-from pydantic import Field, PositiveInt, PrivateAttr, model_validator
+from pydantic import Field, PositiveInt, PrivateAttr, ValidationError, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from anta.logger import exc_to_str
@@ -110,5 +111,22 @@ class AntaHttpxSettings(BaseSettings):
     trust_env: bool = Field(default=DEFAULT_HTTPX_TRUST_ENV)
 
 
-ANTA_HTTPX_SETTINGS = AntaHttpxSettings()
-"""Module-level singleton for the HTTPX client settings, shared across all AsyncEOSDevice instances."""
+@cache
+def get_httpx_settings() -> AntaHttpxSettings:
+    """Return the cached ANTA HTTPX settings loaded from environment variables.
+
+    Returns
+    -------
+    AntaHttpxSettings
+        The HTTPX settings instance populated from `ANTA_HTTPX_*` environment variables.
+
+    Raises
+    ------
+    ValueError
+        If any `ANTA_HTTPX_*` environment variable has an invalid value.
+    """
+    try:
+        return AntaHttpxSettings()
+    except ValidationError as exc:
+        msg = f"Failed to load ANTA HTTPX settings. Check ANTA_HTTPX_* environment variables: {exc_to_str(exc)}"
+        raise ValueError(msg) from exc

--- a/docs/advanced_usages/env-vars.md
+++ b/docs/advanced_usages/env-vars.md
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2023-2026 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+
+ANTA exposes several environment variables that allow you to configure its behavior without modifying code or CLI flags. These variables are read at startup.
+
+## Summary
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `ANTA_HTTPX_TRUST_ENV` | `true` | Allow the HTTPX client to read proxy settings from the environment |
+
+---
+
+## `ANTA_HTTPX_TRUST_ENV`
+
+Controls whether the HTTPX client reads proxy configuration from the environment (e.g. `HTTP_PROXY`, `HTTPS_PROXY`). Set to `false` to disable this behavior.
+
+```bash
+export ANTA_HTTPX_TRUST_ENV=false
+anta nrfu table
+```
+
+---

--- a/docs/advanced_usages/env-vars.md
+++ b/docs/advanced_usages/env-vars.md
@@ -3,20 +3,23 @@
   ~ Use of this source code is governed by the Apache License 2.0
   ~ that can be found in the LICENSE file.
   -->
+---
 
-ANTA exposes several environment variables that allow you to configure its behavior without modifying code or CLI flags. These variables are read at startup.
+ANTA exposes several environment variables that allow you to configure its behavior. These variables are automatically read during the initialization and preparation phases, ensuring the environment is configured correctly before any tests are executed.
 
 ## Summary
 
-| Variable | Default | Description |
-| -------- | ------- | ----------- |
-| `ANTA_HTTPX_TRUST_ENV` | `true` | Allow the HTTPX client to read proxy settings from the environment |
+| Variable | Default | Consumed By | Description |
+| -------- | ------- | ----------- | ----------- |
+| `ANTA_HTTPX_TRUST_ENV` | `true` | AsyncEOSDevice | Configures the `trust_env` parameter for the underlying HTTPX client. When false, HTTPX ignores environment variables for proxy and SSL settings. See the [HTTPX documentation](https://www.python-httpx.org/environment_variables/) for details. |
 
 ---
 
-## `ANTA_HTTPX_TRUST_ENV`
+## Example Usage
 
-Controls whether the HTTPX client reads proxy configuration from the environment (e.g. `HTTP_PROXY`, `HTTPS_PROXY`). Set to `false` to disable this behavior.
+The examples below show common scenarios where environment variables can be used to adjust ANTA's behavior.
+
+### Disabling proxy environment variable passthrough
 
 ```bash
 export ANTA_HTTPX_TRUST_ENV=false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,6 +188,7 @@ nav:
       - Caching in ANTA: advanced_usages/caching.md
       - Developing ANTA tests: advanced_usages/custom-tests.md
       - ANTA as a Python Library: advanced_usages/as-python-lib.md
+      - Environmental Variables: advanced_usages/env-vars.md
   - Tests Documentation:
       - Overview: api/tests.md
       - AAA: api/tests/aaa.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -188,7 +188,7 @@ nav:
       - Caching in ANTA: advanced_usages/caching.md
       - Developing ANTA tests: advanced_usages/custom-tests.md
       - ANTA as a Python Library: advanced_usages/as-python-lib.md
-      - Environmental Variables: advanced_usages/env-vars.md
+      - Environment Variables: advanced_usages/env-vars.md
   - Tests Documentation:
       - Overview: api/tests.md
       - AAA: api/tests/aaa.md

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -142,12 +142,10 @@ class TestAntaHttpxSettings:
         httpx_settings = AntaHttpxSettings()
         assert httpx_settings.trust_env is False
 
+    @pytest.mark.skipif(os.name != "posix", reason="Cannot run this test on Windows")
     def test_env_var_attached_to_session(self, setenvvar: pytest.MonkeyPatch) -> None:
         """Test setting for ANTA AsyncEOSDevices settings."""
         setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "False")
-        # For Windows user, setting USERNAME because asyncssh uses getpass to check the username and
-        # if none of the following env var is set: LOGNAME, USER, LNAME, USERNAME
-        setenvvar.setenv("USERNAME", "test")
         # Overriding `_httpx_settings` here because environment variables are loaded as a one-time operation,
         # and we must capture the above injected variables before `AsyncEOSDevice` class instantiation.
         AsyncEOSDevice._httpx_settings = None

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -13,7 +13,8 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
-from anta.settings import DEFAULT_MAX_CONCURRENCY, DEFAULT_NOFILE, AntaRunnerSettings
+from anta.device import AsyncEOSDevice
+from anta.settings import DEFAULT_HTTPX_TRUST_ENV, DEFAULT_MAX_CONCURRENCY, DEFAULT_NOFILE, AntaHttpxSettings, AntaRunnerSettings
 
 if os.name == "posix":
     # The function is not defined on non-POSIX system
@@ -125,3 +126,24 @@ class TestAntaRunnerSettings:
             assert "Failed to set file descriptor soft limit for the current ANTA process" in caplog.records[-1].getMessage()
 
             setrlimit_mock.assert_called_once_with(resource.RLIMIT_NOFILE, (666, 131072))  # pyright: ignore[reportPossiblyUnboundVariable]
+
+
+class TestAntaHttpxSettings:
+    """Tests for the AntaHttpxSettings class."""
+
+    def test_defaults(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Test defaults for ANTA HTTPX settings."""
+        httpx_settings = AntaHttpxSettings()
+        assert httpx_settings.trust_env == DEFAULT_HTTPX_TRUST_ENV
+
+    def test_env_var(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Test setting for ANTA HTTPX settings."""
+        setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "False")
+        httpx_settings = AntaHttpxSettings()
+        assert httpx_settings.trust_env is False
+
+    def test_env_var_attached_to_session(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Test setting for ANTA AsyncEOSDevices settings."""
+        setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "False")
+        device = AsyncEOSDevice(host="test", username="test", password="test")
+        assert device._session.trust_env is False

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -14,7 +14,7 @@ import pytest
 from pydantic import ValidationError
 
 from anta.device import AsyncEOSDevice
-from anta.settings import ANTA_HTTPX_SETTINGS, DEFAULT_HTTPX_TRUST_ENV, DEFAULT_MAX_CONCURRENCY, DEFAULT_NOFILE, AntaHttpxSettings, AntaRunnerSettings
+from anta.settings import DEFAULT_HTTPX_TRUST_ENV, DEFAULT_MAX_CONCURRENCY, DEFAULT_NOFILE, AntaHttpxSettings, AntaRunnerSettings, get_httpx_settings
 
 if os.name == "posix":
     # The function is not defined on non-POSIX system
@@ -143,8 +143,10 @@ class TestAntaHttpxSettings:
         assert httpx_settings.trust_env is False
 
     @pytest.mark.skipif(os.name != "posix", reason="Cannot run this test on Windows")
-    def test_env_var_attached_to_session(self) -> None:
+    def test_env_var_attached_to_session(self, setenvvar: pytest.MonkeyPatch) -> None:
         """Test that the trust_env value from ANTA_HTTPX_SETTINGS singleton is passed to the asynceapi.Device session."""
-        with patch.object(ANTA_HTTPX_SETTINGS, "trust_env", new=False):
-            device = AsyncEOSDevice(host="test", username="test", password="test", port=80)
-            assert device._session.trust_env is False
+        get_httpx_settings.cache_clear()
+        setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "False")
+        device = AsyncEOSDevice(host="test", username="test", password="test", port=80)
+        assert device._session.trust_env is False
+        get_httpx_settings.cache_clear()

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -14,7 +14,7 @@ import pytest
 from pydantic import ValidationError
 
 from anta.device import AsyncEOSDevice
-from anta.settings import DEFAULT_HTTPX_TRUST_ENV, DEFAULT_MAX_CONCURRENCY, DEFAULT_NOFILE, AntaHttpxSettings, AntaRunnerSettings
+from anta.settings import ANTA_HTTPX_SETTINGS, DEFAULT_HTTPX_TRUST_ENV, DEFAULT_MAX_CONCURRENCY, DEFAULT_NOFILE, AntaHttpxSettings, AntaRunnerSettings
 
 if os.name == "posix":
     # The function is not defined on non-POSIX system
@@ -143,11 +143,8 @@ class TestAntaHttpxSettings:
         assert httpx_settings.trust_env is False
 
     @pytest.mark.skipif(os.name != "posix", reason="Cannot run this test on Windows")
-    def test_env_var_attached_to_session(self, setenvvar: pytest.MonkeyPatch) -> None:
+    def test_env_var_attached_to_session(self) -> None:
         """Test setting for ANTA AsyncEOSDevices settings."""
-        setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "False")
-        # Overriding `_httpx_settings` here because environment variables are loaded as a one-time operation,
-        # and we must capture the above injected variables before `AsyncEOSDevice` class instantiation.
-        AsyncEOSDevice._httpx_settings = None
-        device = AsyncEOSDevice(host="test", username="test", password="test", port=80)
-        assert device._session.trust_env is False
+        with patch.object(ANTA_HTTPX_SETTINGS, "trust_env", new=False):
+            device = AsyncEOSDevice(host="test", username="test", password="test", port=80)
+            assert device._session.trust_env is False

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -132,19 +132,19 @@ class TestAntaHttpxSettings:
     """Tests for the AntaHttpxSettings class."""
 
     def test_defaults(self, setenvvar: pytest.MonkeyPatch) -> None:
-        """Test defaults for ANTA HTTPX settings."""
+        """Test that AntaHttpxSettings uses default values when no environment variables are set."""
         httpx_settings = AntaHttpxSettings()
         assert httpx_settings.trust_env == DEFAULT_HTTPX_TRUST_ENV
 
     def test_env_var(self, setenvvar: pytest.MonkeyPatch) -> None:
-        """Test setting for ANTA HTTPX settings."""
+        """Test that the ANTA_HTTPX_TRUST_ENV environment variable overrides the default trust_env value."""
         setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "False")
         httpx_settings = AntaHttpxSettings()
         assert httpx_settings.trust_env is False
 
     @pytest.mark.skipif(os.name != "posix", reason="Cannot run this test on Windows")
     def test_env_var_attached_to_session(self) -> None:
-        """Test setting for ANTA AsyncEOSDevices settings."""
+        """Test that the trust_env value from ANTA_HTTPX_SETTINGS singleton is passed to the asynceapi.Device session."""
         with patch.object(ANTA_HTTPX_SETTINGS, "trust_env", new=False):
             device = AsyncEOSDevice(host="test", username="test", password="test", port=80)
             assert device._session.trust_env is False

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -145,5 +145,11 @@ class TestAntaHttpxSettings:
     def test_env_var_attached_to_session(self, setenvvar: pytest.MonkeyPatch) -> None:
         """Test setting for ANTA AsyncEOSDevices settings."""
         setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "False")
-        device = AsyncEOSDevice(host="test", username="test", password="test")
+        # For Windows user, setting USERNAME because asyncssh uses getpass to check the username and
+        # if none of the following env var is set: LOGNAME, USER, LNAME, USERNAME
+        setenvvar.setenv("USERNAME", "test")
+        # Overriding `_httpx_settings` here because environment variables are loaded as a one-time operation,
+        # and we must capture the above injected variables before `AsyncEOSDevice` class instantiation.
+        AsyncEOSDevice._httpx_settings = None
+        device = AsyncEOSDevice(host="test", username="test", password="test", port=80)
         assert device._session.trust_env is False

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -150,3 +150,11 @@ class TestAntaHttpxSettings:
         device = AsyncEOSDevice(host="test", username="test", password="test", port=80)
         assert device._session.trust_env is False
         get_httpx_settings.cache_clear()
+
+    def test_validation_error(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Test that get_httpx_settings raises ValueError when an env var is invalid."""
+        get_httpx_settings.cache_clear()
+        setenvvar.setenv("ANTA_HTTPX_TRUST_ENV", "not_a_valid_bool")
+        with pytest.raises(ValueError, match=r"Failed to load ANTA HTTPX settings\. Check ANTA_HTTPX_\* environment variables:"):
+            get_httpx_settings()
+        get_httpx_settings.cache_clear()


### PR DESCRIPTION
# Description

Add support for trust_env of httpx at runtime using the ANTA_HTTPX_TRUST_ENV environement variable.

Fixes #1466 

# Checklist:

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
