### PR TITLE
ci: upgrade codecov action to v7

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -24,7 +24,7 @@ jobs:
           name: pytest-coverage
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
           flags: anta,asynceapi


### PR DESCRIPTION
## Summary
- Upgrade codecov/codecov-action from v6.0.1 to v7.0.0
- Pin the action by the v7.0.0 commit SHA

## Testing
- pre-commit run --files .github/workflows/codecov.yml