### PR TITLE
ci: Make release note label lookup exact

### DIFF
--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -26,12 +26,20 @@ runs:
         fi
 
         label="$(printf '%s' "$PR_TITLE" | cut -d ':' -f 1 | tr -d ' ')"
+        rn_label="rn: $label"
+        encoded_rn_label="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$rn_label")"
+
         if [[ "$AUTO_CREATE_LABEL" == "true" ]]; then
-          existing_label="$(gh label list -L 100 --search "rn:" --json name -q '.[] | select(.name | startswith("rn: ")) | .name' | grep -Fx "rn: $label" || true)"
-          if [[ -z "$existing_label" ]]; then
-            gh label create "rn: $label"
+          if ! gh api "repos/{owner}/{repo}/labels/$encoded_rn_label" --silent 2>/dev/null; then
+            label_create_error="${RUNNER_TEMP:-.}/label_create_error"
+            if ! gh label create "$rn_label" 2>"$label_create_error"; then
+              if ! grep -Fq "already exists" "$label_create_error"; then
+                cat "$label_create_error" >&2
+                exit 1
+              fi
+            fi
           fi
         fi
 
-        gh pr edit "$PR_NUMBER" --add-label "rn: $label"
+        gh pr edit "$PR_NUMBER" --add-label "$rn_label"
       shell: bash


### PR DESCRIPTION
## Summary
- replace broad release-note label listing with an exact label API lookup
- URL-encode the release-note label before using it as a REST path segment
- keep label creation tolerant of an already-existing label race

## Testing
- uv run pre-commit run zizmor --files .github/actions/rn-pr-labeler-action/action.yml
- uv run python -c 'import yaml; yaml.safe_load(open(".github/actions/rn-pr-labeler-action/action.yml")); print("ok")'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved PR labeling workflow efficiency and reliability for automated release notes label management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->