### PR TITLE
fix(anta): ANTA NRFU table columns are reversed

### DIFF
--- a/anta/reporter/__init__.py
+++ b/anta/reporter/__init__.py
@@ -213,7 +213,7 @@ class ReportTable:
 
             state = self._color_result(result.result)
             message = self._split_list_to_txt_list(result.messages) if len(result.messages) > 0 else ""
-            renderables = [categories, test, device, result.description, state, message]
+            renderables = [categories, device, test, result.description, state, message]
             table.add_row(*renderables)
 
         for result in manager.results:


### PR DESCRIPTION
## Description

<!-- PR description !-->

Fixes #1515 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)

<img width="1112" height="423" alt="Screenshot 2026-06-20 at 8 36 15 PM" src="https://github.com/user-attachments/assets/453206c9-f91c-451f-9c78-c7ffc819b0a1" />
<img width="1053" height="445" alt="Screenshot 2026-06-20 at 8 37 03 PM" src="https://github.com/user-attachments/assets/87a7aeb7-5806-4972-8453-95c160ea7506" />
<img width="1137" height="338" alt="Screenshot 2026-06-22 at 10 24 55 AM" src="https://github.com/user-attachments/assets/e0342775-d9be-4964-844b-48192e59bda0" />


