### PR TITLE
ci: migrate Codecov from flags to components

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,17 +15,32 @@ coverage:
         threshold: 0%
 
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "reach,diff,components,files"
   behavior: default
   require_changes: true
 
-flags:
-  anta:
-    paths:
-      - anta/
-  asynceapi:
-    paths:
-      - asynceapi/
+component_management:
+  individual_components:
+    - component_id: cli
+      name: CLI
+      paths:
+        - "anta/cli/**"
+    - component_id: asynceapi
+      name: asynceapi
+      paths:
+        - "asynceapi/**"
+    - component_id: anta_core
+      name: ANTA Core
+      paths:
+        - "anta/**"
+        - "!anta/cli/**"
+        - "!anta/tests/**"
+        - "!anta/input_models/**"
+    - component_id: anta_tests
+      name: ANTA Tests
+      paths:
+        - "anta/tests/**"
+        - "anta/input_models/**"
 
 ignore:
   - "tests/**/*"

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,5 +27,4 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
-          flags: anta,asynceapi
           fail_ci_if_error: true


### PR DESCRIPTION
Codecov recommends using components instead of flags for new repository setups, and components match ANTA's source-area coverage grouping better than upload-time flags.

Recommendation: https://docs.codecov.com/docs/components

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->