### PR TITLE
ci: Bump min version of click for doc-snippets

### DIFF
--- a/.github/workflows/code-testing.yml
+++ b/.github/workflows/code-testing.yml
@@ -158,7 +158,9 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: pip install -e ".[cli]" --group doc
+        run: |
+          # Keep generated CLI snippets stable with Click's optional subcommand rendering.
+          pip install -e ".[cli]" "click>=8.4.2" --group doc
       - name: "Check generated CLI doc snippets"
         run: |
           python docs/scripts/generate_doc_snippets.py

--- a/.github/workflows/code-testing.yml
+++ b/.github/workflows/code-testing.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Keep generated CLI snippets stable with Click's optional subcommand rendering.
-          pip install -e ".[cli]" "click>=8.4.2" --group doc
+          pip install -e ".[cli]" "click~=8.4.2" --group doc
       - name: "Check generated CLI doc snippets"
         run: |
           python docs/scripts/generate_doc_snippets.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,4 +146,6 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - anta[cli]
+          # Keep generated CLI snippets stable with Click's optional subcommand rendering.
+          - click~=8.4.2
           - pydantic-settings

--- a/docs/snippets/anta_nrfu_help.txt
+++ b/docs/snippets/anta_nrfu_help.txt
@@ -1,5 +1,5 @@
 $ anta nrfu --help
-Usage: anta nrfu [OPTIONS] COMMAND [ARGS]...
+Usage: anta nrfu [OPTIONS] [COMMAND] [ARGS]...
 
   Run ANTA tests on selected inventory devices.
 


### PR DESCRIPTION
## Description

Click 8.4.2 comes with this https://github.com/pallets/click/pull/3507 PR which is correct but breaks our checking of CLI snippets in documentation :)

This PR requires min version of click to be 8.4.2 for pre-commit hook `doc-snippets` and for the associated workflow so that we keep in sync without requiring everyone to move to the latest and greatest click. (we are on 8.3 today).

We may consider bumping click to 8.4.2 but thats a bit of stretch only to make our documentation correct.

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated CLI help snippets so the `COMMAND` argument is shown as optional (`[COMMAND]`) when appropriate.
  * Improved stability of offline documentation/snippet generation by aligning the CLI testing environment with a compatible Click version to prevent help text drift.
* **Chores**
  * Refined tooling configuration used for snippet generation and CI-based offline docs testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->