### PR TITLE
fix(anta): Handle asyncssh errors gracefully

### DIFF
--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -13,7 +13,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from asyncssh import DisconnectError, HostKeyNotVerifiable, SFTPError
+from asyncssh import Error as AsyncSSHError
+from asyncssh import HostKeyNotVerifiable
 from click.exceptions import UsageError
 from httpx import ConnectError, HTTPError
 
@@ -141,14 +142,14 @@ async def _collect_device_show_tech(device: AntaDevice, root_dir: Path, *, confi
         await device.copy(sources=filenames, destination=outdir, direction="from")
         logger.info("Collected %s scheduled tech-support from %s", len(filenames), device.name)
 
-    except (DisconnectError, SFTPError, OSError, EapiCommandError, HTTPError, ConnectError) as e:
-        # asyncssh.scp() reuses SFTP error types for SCP transfer failures
-        msg = (
-            "The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine."
-            if isinstance(e, HostKeyNotVerifiable)
-            else exc_to_str(e)
+    except HostKeyNotVerifiable:
+        logger.error(
+            "Unable to collect tech-support on %s: The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine.",
+            device.name,
         )
-        logger.error("Unable to collect tech-support on %s: %s", device.name, msg)
+    except (AsyncSSHError, OSError, EapiCommandError, HTTPError, ConnectError) as e:
+        # asyncssh.scp() can raise different asyncssh error types for SSH/SCP transfer failures.
+        logger.error("Unable to collect tech-support on %s: %s", device.name, exc_to_str(e))
 
 
 async def _configure_aaa_exec_authorization(device: AntaDevice) -> None:

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -13,7 +13,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from asyncssh import DisconnectError, HostKeyNotVerifiable
+from asyncssh import DisconnectError, HostKeyNotVerifiable, SFTPError
 from click.exceptions import UsageError
 from httpx import ConnectError, HTTPError
 
@@ -101,7 +101,7 @@ async def collect_commands(
             logger.error("Error when collecting commands: %s", str(r))
 
 
-async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bool, tags: set[str] | None = None, latest: int | None = None) -> None:  # noqa: C901
+async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bool, tags: set[str] | None = None, latest: int | None = None) -> None:
     """Collect scheduled show-tech on devices."""
 
     async def collect(device: AntaDevice) -> None:
@@ -167,15 +167,14 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
             await device.copy(sources=filenames, destination=outdir, direction="from")
             logger.info("Collected %s scheduled tech-support from %s", len(filenames), device.name)
 
-        except DisconnectError as e:
+        except (DisconnectError, SFTPError, OSError, EapiCommandError, HTTPError, ConnectError) as e:
+            # asyncssh.scp() reuses SFTP error types for SCP transfer failures
             msg = (
                 "The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine."
                 if isinstance(e, HostKeyNotVerifiable)
                 else exc_to_str(e)
             )
             logger.error("Unable to collect tech-support on %s: %s", device.name, msg)
-        except (EapiCommandError, HTTPError, ConnectError) as e:
-            logger.error("Unable to collect tech-support on %s: %s", device.name, str(e))
 
     logger.info("Connecting to devices...")
     await inv.connect_inventory()

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -147,7 +147,7 @@ async def _collect_device_show_tech(device: AntaDevice, root_dir: Path, *, confi
             "Unable to collect tech-support on %s: The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine.",
             device.name,
         )
-    # NOSONAR: Sonar suggests logger.exception(), but these are expected per-device CLI failures where concise one-line errors are preferred over tracebacks.
+    # Sonar suggests logger.exception(), but these are expected per-device CLI failures where concise one-line errors are preferred over tracebacks.
     except UsageError as e:
         logger.error("Unable to collect tech-support on %s: %s", device.name, e)  # NOSONAR
     except (AsyncSSHError, OSError, EapiCommandError, HTTPError, ConnectError) as e:

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -162,13 +162,10 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
             await device.collect(command=command)
 
             if command.collected and not command.text_output:
-                logger.debug("'aaa authorization exec default local' is not configured on device %s", device.name)
                 if not configure:
                     logger.error("Unable to collect tech-support on %s: configuration 'aaa authorization exec default local' is not present", device.name)
                     return
                 await _configure_aaa_exec_authorization(device)
-
-            logger.debug("'aaa authorization exec default local' is already configured on device %s", device.name)
 
             await device.copy(sources=filenames, destination=outdir, direction="from")
             logger.info("Collected %s scheduled tech-support from %s", len(filenames), device.name)

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -13,8 +13,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from asyncssh import DisconnectError
-from asyncssh.misc import HostKeyNotVerifiable
+from asyncssh import DisconnectError, HostKeyNotVerifiable
 from click.exceptions import UsageError
 from httpx import ConnectError, HTTPError
 

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -147,11 +147,12 @@ async def _collect_device_show_tech(device: AntaDevice, root_dir: Path, *, confi
             "Unable to collect tech-support on %s: The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine.",
             device.name,
         )
+    # NOSONAR: Sonar suggests logger.exception(), but these are expected per-device CLI failures where concise one-line errors are preferred over tracebacks.
     except UsageError as e:
-        logger.error("Unable to collect tech-support on %s: %s", device.name, e)
+        logger.error("Unable to collect tech-support on %s: %s", device.name, e)  # NOSONAR
     except (AsyncSSHError, OSError, EapiCommandError, HTTPError, ConnectError) as e:
         # asyncssh.scp() can raise different asyncssh error types for SSH/SCP transfer failures.
-        logger.error("Unable to collect tech-support on %s: %s", device.name, exc_to_str(e))
+        logger.error("Unable to collect tech-support on %s: %s", device.name, exc_to_str(e))  # NOSONAR
 
 
 async def _configure_aaa_exec_authorization(device: AntaDevice) -> None:

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -13,11 +13,13 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
+from asyncssh import DisconnectError
 from asyncssh.misc import HostKeyNotVerifiable
 from click.exceptions import UsageError
 from httpx import ConnectError, HTTPError
 
 from anta.device import AntaDevice, AsyncEOSDevice
+from anta.logger import exc_to_str
 from anta.models import AntaCommand
 from anta.tools import safe_command
 from asynceapi import EapiCommandError
@@ -166,11 +168,13 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
             await device.copy(sources=filenames, destination=outdir, direction="from")
             logger.info("Collected %s scheduled tech-support from %s", len(filenames), device.name)
 
-        except HostKeyNotVerifiable:
-            logger.error(
-                "Unable to collect tech-support on %s. The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine.",
-                device.name,
+        except DisconnectError as e:
+            msg = (
+                "The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine."
+                if isinstance(e, HostKeyNotVerifiable)
+                else exc_to_str(e)
             )
+            logger.error("Unable to collect tech-support on %s: %s", device.name, msg)
         except (EapiCommandError, HTTPError, ConnectError) as e:
             logger.error("Unable to collect tech-support on %s: %s", device.name, str(e))
 

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -101,6 +101,40 @@ async def collect_commands(
             logger.error("Error when collecting commands: %s", str(r))
 
 
+async def _configure_aaa_exec_authorization(device: AntaDevice) -> None:
+    """Configure 'aaa authorization exec default local' on the device.
+
+    Deprecated: will be removed in ANTA 2.0.0.
+    """
+    # TODO: @mtache - add `config` field to `AntaCommand` object to handle this use case.
+    # TODO: Should enable be also included in AntaDevice?
+    if not isinstance(device, AsyncEOSDevice):
+        msg = "anta exec collect-tech-support is only supported with AsyncEOSDevice for now."
+        raise UsageError(msg)
+
+    # TODO: ANTA 2.0.0
+    msg = (
+        "[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0. "
+        "Please add the required configuration on your devices before running this command from ANTA."
+    )
+    logger.warning(msg)
+
+    commands: list[EapiSimpleCommand | EapiComplexCommand] = []
+    if device.enable and device._enable_password is not None:
+        commands.append({"cmd": "enable", "input": device._enable_password})
+    elif device.enable:
+        commands.append({"cmd": "enable"})
+    commands.extend(
+        [
+            {"cmd": "configure terminal"},
+            {"cmd": "aaa authorization exec default local"},
+        ],
+    )
+    logger.warning("Configuring 'aaa authorization exec default local' on device %s", device.name)
+    await device._session.cli(commands=commands)
+    logger.info("Configured 'aaa authorization exec default local' on device %s", device.name)
+
+
 async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bool, tags: set[str] | None = None, latest: int | None = None) -> None:
     """Collect scheduled show-tech on devices."""
 
@@ -132,35 +166,7 @@ async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bo
                 if not configure:
                     logger.error("Unable to collect tech-support on %s: configuration 'aaa authorization exec default local' is not present", device.name)
                     return
-
-                # TODO: ANTA 2.0.0
-                msg = (
-                    "[DEPRECATED] Using '--configure' for collecting show-techs is deprecated and will be removed in ANTA 2.0.0. "
-                    "Please add the required configuration on your devices before running this command from ANTA."
-                )
-                logger.warning(msg)
-
-                # TODO: @mtache - add `config` field to `AntaCommand` object to handle this use case.
-                # Otherwise mypy complains about enable as it is only implemented for AsyncEOSDevice
-                # TODO: Should enable be also included in AntaDevice?
-                if not isinstance(device, AsyncEOSDevice):
-                    msg = "anta exec collect-tech-support is only supported with AsyncEOSDevice for now."
-                    raise UsageError(msg)
-                commands: list[EapiSimpleCommand | EapiComplexCommand] = []
-                if device.enable and device._enable_password is not None:
-                    commands.append({"cmd": "enable", "input": device._enable_password})
-                elif device.enable:
-                    commands.append({"cmd": "enable"})
-                commands.extend(
-                    [
-                        {"cmd": "configure terminal"},
-                        {"cmd": "aaa authorization exec default local"},
-                    ],
-                )
-                logger.warning("Configuring 'aaa authorization exec default local' on device %s", device.name)
-                command = AntaCommand(command="show running-config | include aaa authorization exec default local", ofmt="text")
-                await device._session.cli(commands=commands)
-                logger.info("Configured 'aaa authorization exec default local' on device %s", device.name)
+                await _configure_aaa_exec_authorization(device)
 
             logger.debug("'aaa authorization exec default local' is already configured on device %s", device.name)
 

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -147,6 +147,8 @@ async def _collect_device_show_tech(device: AntaDevice, root_dir: Path, *, confi
             "Unable to collect tech-support on %s: The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine.",
             device.name,
         )
+    except UsageError as e:
+        logger.error("Unable to collect tech-support on %s: %s", device.name, e)
     except (AsyncSSHError, OSError, EapiCommandError, HTTPError, ConnectError) as e:
         # asyncssh.scp() can raise different asyncssh error types for SSH/SCP transfer failures.
         logger.error("Unable to collect tech-support on %s: %s", device.name, exc_to_str(e))
@@ -159,6 +161,7 @@ async def _configure_aaa_exec_authorization(device: AntaDevice) -> None:
     """
     # TODO: @mtache - add `config` field to `AntaCommand` object to handle this use case.
     # TODO: Should enable be also included in AntaDevice?
+    # TODO: @gmulocher - This should not be a usage error maybe Unsupported device something but as we will remove this.
     if not isinstance(device, AsyncEOSDevice):
         msg = "anta exec collect-tech-support is only supported with AsyncEOSDevice for now."
         raise UsageError(msg)

--- a/anta/cli/exec/utils.py
+++ b/anta/cli/exec/utils.py
@@ -101,6 +101,56 @@ async def collect_commands(
             logger.error("Error when collecting commands: %s", str(r))
 
 
+async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bool, tags: set[str] | None = None, latest: int | None = None) -> None:
+    """Collect scheduled show-tech on devices."""
+    logger.info("Connecting to devices...")
+    await inv.connect_inventory()
+    devices = inv.get_inventory(established_only=True, tags=tags).devices
+    await asyncio.gather(*(_collect_device_show_tech(device, root_dir, configure=configure, latest=latest) for device in devices))
+
+
+async def _collect_device_show_tech(device: AntaDevice, root_dir: Path, *, configure: bool, latest: int | None = None) -> None:
+    """Collect all the tech-support files stored on an Arista switch flash and copy them locally."""
+    try:
+        # Get the tech-support filename to retrieve
+        cmd = f"bash timeout 10 ls -1t {EOS_SCHEDULED_TECH_SUPPORT}"
+        if latest:
+            cmd += f" | head -{latest}"
+        command = AntaCommand(command=cmd, ofmt="text")
+        await device.collect(command=command)
+        if not (command.collected and command.text_output):
+            logger.error("Unable to get tech-support filenames on %s: verify that %s is not empty", device.name, EOS_SCHEDULED_TECH_SUPPORT)
+            return
+
+        filenames = [Path(f"{EOS_SCHEDULED_TECH_SUPPORT}/{f}") for f in command.text_output.splitlines()]
+
+        # Create directories
+        outdir = Path() / root_dir / f"{device.name.lower()}"
+        outdir.mkdir(parents=True, exist_ok=True)
+
+        # Check if 'aaa authorization exec default local' is present in the running-config
+        command = AntaCommand(command="show running-config | include aaa authorization exec default", ofmt="text")
+        await device.collect(command=command)
+
+        if command.collected and not command.text_output:
+            if not configure:
+                logger.error("Unable to collect tech-support on %s: configuration 'aaa authorization exec default local' is not present", device.name)
+                return
+            await _configure_aaa_exec_authorization(device)
+
+        await device.copy(sources=filenames, destination=outdir, direction="from")
+        logger.info("Collected %s scheduled tech-support from %s", len(filenames), device.name)
+
+    except (DisconnectError, SFTPError, OSError, EapiCommandError, HTTPError, ConnectError) as e:
+        # asyncssh.scp() reuses SFTP error types for SCP transfer failures
+        msg = (
+            "The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine."
+            if isinstance(e, HostKeyNotVerifiable)
+            else exc_to_str(e)
+        )
+        logger.error("Unable to collect tech-support on %s: %s", device.name, msg)
+
+
 async def _configure_aaa_exec_authorization(device: AntaDevice) -> None:
     """Configure 'aaa authorization exec default local' on the device.
 
@@ -133,53 +183,3 @@ async def _configure_aaa_exec_authorization(device: AntaDevice) -> None:
     logger.warning("Configuring 'aaa authorization exec default local' on device %s", device.name)
     await device._session.cli(commands=commands)
     logger.info("Configured 'aaa authorization exec default local' on device %s", device.name)
-
-
-async def collect_show_tech(inv: AntaInventory, root_dir: Path, *, configure: bool, tags: set[str] | None = None, latest: int | None = None) -> None:
-    """Collect scheduled show-tech on devices."""
-
-    async def collect(device: AntaDevice) -> None:
-        """Collect all the tech-support files stored on Arista switches flash and copy them locally."""
-        try:
-            # Get the tech-support filename to retrieve
-            cmd = f"bash timeout 10 ls -1t {EOS_SCHEDULED_TECH_SUPPORT}"
-            if latest:
-                cmd += f" | head -{latest}"
-            command = AntaCommand(command=cmd, ofmt="text")
-            await device.collect(command=command)
-            if not (command.collected and command.text_output):
-                logger.error("Unable to get tech-support filenames on %s: verify that %s is not empty", device.name, EOS_SCHEDULED_TECH_SUPPORT)
-                return
-
-            filenames = [Path(f"{EOS_SCHEDULED_TECH_SUPPORT}/{f}") for f in command.text_output.splitlines()]
-
-            # Create directories
-            outdir = Path() / root_dir / f"{device.name.lower()}"
-            outdir.mkdir(parents=True, exist_ok=True)
-
-            # Check if 'aaa authorization exec default local' is present in the running-config
-            command = AntaCommand(command="show running-config | include aaa authorization exec default", ofmt="text")
-            await device.collect(command=command)
-
-            if command.collected and not command.text_output:
-                if not configure:
-                    logger.error("Unable to collect tech-support on %s: configuration 'aaa authorization exec default local' is not present", device.name)
-                    return
-                await _configure_aaa_exec_authorization(device)
-
-            await device.copy(sources=filenames, destination=outdir, direction="from")
-            logger.info("Collected %s scheduled tech-support from %s", len(filenames), device.name)
-
-        except (DisconnectError, SFTPError, OSError, EapiCommandError, HTTPError, ConnectError) as e:
-            # asyncssh.scp() reuses SFTP error types for SCP transfer failures
-            msg = (
-                "The host SSH key could not be verified. Make sure it is part of the `known_hosts` file on your machine."
-                if isinstance(e, HostKeyNotVerifiable)
-                else exc_to_str(e)
-            )
-            logger.error("Unable to collect tech-support on %s: %s", device.name, msg)
-
-    logger.info("Connecting to devices...")
-    await inv.connect_inventory()
-    devices = inv.get_inventory(established_only=True, tags=tags).devices
-    await asyncio.gather(*(collect(device) for device in devices))

--- a/tests/units/cli/exec/test_utils.py
+++ b/tests/units/cli/exec/test_utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from unittest.mock import call, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 import respx
@@ -396,3 +396,173 @@ async def test_collect_show_tech_ssh_errors(
 
     assert expected_message in caplog.text
     assert "Unable to collect tech-support on" in caplog.text
+
+
+async def test_collect_show_tech_usage_error_does_not_abort_batch(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    inventory: AntaInventory,
+    device: AntaDevice,
+) -> None:
+    """Test collect_show_tech handles unsupported device types without aborting other devices."""
+    caplog.set_level(logging.ERROR)
+    device.name = "unsupported-device"
+    inventory.add_device(device)
+    copied_devices: list[str] = []
+
+    async def mock_connect_inventory() -> None:
+        for inventory_device in inventory.values():
+            inventory_device.is_online = True
+            inventory_device.established = True
+            inventory_device.hw_model = "dummy"
+
+    async def mock_collect(self: AntaDevice, command: AntaCommand, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        if "ls -1t" in command.command:
+            command.output = "dummy_tech-support_2023-12-01.1115.log.gz"
+        elif "include aaa authorization" in command.command:
+            command.output = "aaa authorization exec default local"
+
+    async def mock_unsupported_collect(command: AntaCommand, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        if "ls -1t" in command.command:
+            command.output = "unsupported_tech-support_2023-12-01.1115.log.gz"
+        elif "include aaa authorization" in command.command:
+            command.output = ""
+
+    async def mock_copy(self: AntaDevice, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        copied_devices.append(self.name)
+
+    with (
+        patch("anta.device.AsyncEOSDevice.collect", side_effect=mock_collect, autospec=True),
+        patch("anta.device.AsyncEOSDevice.copy", side_effect=mock_copy, autospec=True),
+        patch.object(device, "collect", side_effect=mock_unsupported_collect),
+        patch("anta.inventory.AntaInventory.connect_inventory", side_effect=mock_connect_inventory),
+    ):
+        await collect_show_tech(inventory, root_dir=tmp_path, configure=True)
+
+    assert copied_devices == ["device-0"]
+    assert "Unable to collect tech-support on unsupported-device" in caplog.text
+    assert "anta exec collect-tech-support is only supported with AsyncEOSDevice for now." in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("tech_support_output", "aaa_output", "expected_message"),
+    [
+        pytest.param("", "aaa authorization exec default local", "Unable to get tech-support filenames", id="no-tech-support-files"),
+        pytest.param(
+            "dummy_tech-support_2023-12-01.1115.log.gz",
+            "",
+            "configuration 'aaa authorization exec default local' is not present",
+            id="missing-aaa-without-configure",
+        ),
+    ],
+)
+async def test_collect_show_tech_pre_copy_failures(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    inventory: AntaInventory,
+    tech_support_output: str,
+    aaa_output: str,
+    expected_message: str,
+) -> None:
+    """Test collect_show_tech handles failures before copying files."""
+    caplog.set_level(logging.ERROR)
+
+    async def mock_connect_inventory() -> None:
+        for device in inventory.values():
+            device.is_online = True
+            device.established = True
+            device.hw_model = "dummy"
+
+    async def mock_collect(self: AntaDevice, command: AntaCommand, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        if "ls -1t" in command.command:
+            command.output = tech_support_output
+        elif "include aaa authorization" in command.command:
+            command.output = aaa_output
+
+    with (
+        patch("anta.device.AsyncEOSDevice.collect", side_effect=mock_collect, autospec=True),
+        patch("anta.device.AsyncEOSDevice.copy", new_callable=AsyncMock) as mocked_copy,
+        patch("anta.inventory.AntaInventory.connect_inventory", side_effect=mock_connect_inventory),
+    ):
+        await collect_show_tech(inventory, root_dir=tmp_path, configure=False)
+
+    mocked_copy.assert_not_awaited()
+    assert expected_message in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("enable", "enable_password", "expected_commands"),
+    [
+        pytest.param(
+            True,
+            "enable-password",
+            [
+                {"cmd": "enable", "input": "enable-password"},
+                {"cmd": "configure terminal"},
+                {"cmd": "aaa authorization exec default local"},
+            ],
+            id="enable-with-password",
+        ),
+        pytest.param(
+            True,
+            None,
+            [
+                {"cmd": "enable"},
+                {"cmd": "configure terminal"},
+                {"cmd": "aaa authorization exec default local"},
+            ],
+            id="enable-without-password",
+        ),
+        pytest.param(
+            False,
+            None,
+            [
+                {"cmd": "configure terminal"},
+                {"cmd": "aaa authorization exec default local"},
+            ],
+            id="without-enable",
+        ),
+    ],
+)
+async def test_collect_show_tech_configures_aaa_and_honors_latest(
+    tmp_path: Path,
+    inventory: AntaInventory,
+    *,
+    enable: bool,
+    enable_password: str | None,
+    expected_commands: list[dict[str, str]],
+) -> None:
+    """Test collect_show_tech configures AAA authorization and limits collected show-tech files."""
+    collected_commands: list[str] = []
+    copied_devices: list[str] = []
+    device = next(iter(inventory.values()))
+    device.enable = enable  # type: ignore[attr-defined]
+    device._enable_password = enable_password  # type: ignore[attr-defined]
+
+    async def mock_connect_inventory() -> None:
+        for inventory_device in inventory.values():
+            inventory_device.is_online = True
+            inventory_device.established = True
+            inventory_device.hw_model = "dummy"
+
+    async def mock_collect(self: AntaDevice, command: AntaCommand, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        collected_commands.append(command.command)
+        if "ls -1t" in command.command:
+            command.output = "dummy_tech-support_2023-12-01.1115.log.gz"
+        elif "include aaa authorization" in command.command:
+            command.output = ""
+
+    async def mock_copy(self: AntaDevice, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        copied_devices.append(self.name)
+
+    with (
+        patch("anta.device.AsyncEOSDevice.collect", side_effect=mock_collect, autospec=True),
+        patch("anta.device.AsyncEOSDevice.copy", side_effect=mock_copy, autospec=True),
+        patch("anta.inventory.AntaInventory.connect_inventory", side_effect=mock_connect_inventory),
+        patch.object(device._session, "cli", new_callable=AsyncMock) as mocked_cli,  # type: ignore[attr-defined]
+    ):
+        await collect_show_tech(inventory, root_dir=tmp_path, configure=True, latest=1)
+
+    assert collected_commands[0].endswith("| head -1")
+    mocked_cli.assert_awaited_once_with(commands=expected_commands)
+    assert copied_devices == ["device-0"]

--- a/tests/units/cli/exec/test_utils.py
+++ b/tests/units/cli/exec/test_utils.py
@@ -12,7 +12,7 @@ from unittest.mock import call, patch
 
 import pytest
 import respx
-from asyncssh.misc import ConnectionLost, HostKeyNotVerifiable, KeyExchangeFailed
+from asyncssh import ConnectionLost, HostKeyNotVerifiable, KeyExchangeFailed, SFTPFailure
 
 from anta.cli.exec.utils import clear_counters, collect_commands, collect_show_tech
 from anta.models import AntaCommand
@@ -340,6 +340,16 @@ async def test_collect_commands(
             HostKeyNotVerifiable("Host key not verifiable"),
             "The host SSH key could not be verified",
             id="host-key-not-verifiable",
+        ),
+        pytest.param(
+            SFTPFailure("Permission denied"),
+            "SFTPFailure: Permission denied",
+            id="sftp-failure",
+        ),
+        pytest.param(
+            OSError("Network is unreachable"),
+            "OSError: Network is unreachable",
+            id="os-error",
         ),
     ],
 )

--- a/tests/units/cli/exec/test_utils.py
+++ b/tests/units/cli/exec/test_utils.py
@@ -12,7 +12,8 @@ from unittest.mock import call, patch
 
 import pytest
 import respx
-from asyncssh import ConnectionLost, HostKeyNotVerifiable, KeyExchangeFailed, SFTPFailure
+from asyncssh import ChannelOpenError, ConnectionLost, HostKeyNotVerifiable, KeyExchangeFailed, SFTPFailure
+from asyncssh.constants import OPEN_CONNECT_FAILED
 
 from anta.cli.exec.utils import clear_counters, collect_commands, collect_show_tech
 from anta.models import AntaCommand
@@ -347,6 +348,11 @@ async def test_collect_commands(
             id="sftp-failure",
         ),
         pytest.param(
+            ChannelOpenError(OPEN_CONNECT_FAILED, "channel failed"),
+            "ChannelOpenError: channel failed",
+            id="channel-open-error",
+        ),
+        pytest.param(
             OSError("Network is unreachable"),
             "OSError: Network is unreachable",
             id="os-error",
@@ -360,7 +366,7 @@ async def test_collect_show_tech_ssh_errors(
     ssh_error: Exception,
     expected_message: str,
 ) -> None:
-    """Test collect_show_tech handles asyncssh DisconnectError subclasses gracefully."""
+    """Test collect_show_tech handles asyncssh errors gracefully."""
     caplog.set_level(logging.ERROR)
 
     async def mock_connect_inventory() -> None:

--- a/tests/units/cli/exec/test_utils.py
+++ b/tests/units/cli/exec/test_utils.py
@@ -12,12 +12,11 @@ from unittest.mock import call, patch
 
 import pytest
 import respx
+from asyncssh.misc import ConnectionLost, HostKeyNotVerifiable, KeyExchangeFailed
 
-from anta.cli.exec.utils import clear_counters, collect_commands
+from anta.cli.exec.utils import clear_counters, collect_commands, collect_show_tech
 from anta.models import AntaCommand
 from anta.tools import safe_command
-
-# collect_scheduled_show_tech
 
 if TYPE_CHECKING:
     from anta.device import AntaDevice
@@ -317,3 +316,67 @@ async def test_collect_commands(
             for command in commands["text_format"]:
                 assert Path.is_file(text_path / f"{safe_command(command)}.log")
                 assert f"Collected command '{command}' from device {device.name}" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("ssh_error", "expected_message"),
+    [
+        pytest.param(
+            ConnectionLost("Connection lost"),
+            "ConnectionLost: Connection lost",
+            id="connection-lost",
+        ),
+        pytest.param(
+            KeyExchangeFailed("Key exchange failed"),
+            "KeyExchangeFailed: Key exchange failed",
+            id="key-exchange-failed",
+        ),
+        pytest.param(
+            ConnectionLost(""),
+            "ConnectionLost",
+            id="connection-lost-empty-reason",
+        ),
+        pytest.param(
+            HostKeyNotVerifiable("Host key not verifiable"),
+            "The host SSH key could not be verified",
+            id="host-key-not-verifiable",
+        ),
+    ],
+)
+async def test_collect_show_tech_ssh_errors(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    inventory: AntaInventory,
+    ssh_error: Exception,
+    expected_message: str,
+) -> None:
+    """Test collect_show_tech handles asyncssh DisconnectError subclasses gracefully."""
+    caplog.set_level(logging.ERROR)
+
+    async def mock_connect_inventory() -> None:
+        """Mock connect_inventory coroutine."""
+        for device in inventory.values():
+            device.is_online = True
+            device.established = True
+            device.hw_model = "dummy"
+
+    async def mock_collect(self: AntaDevice, command: AntaCommand, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        """Mock collect coroutine — simulate successful command collection."""
+        if "ls -1t" in command.command:
+            command.output = "dummy_tech-support_2023-12-01.1115.log.gz"
+        elif "include aaa authorization" in command.command:
+            command.output = "aaa authorization exec default local"
+
+    async def mock_copy(self: AntaDevice, *args: Any, **kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        """Mock copy that raises SSH errors."""
+        raise ssh_error
+
+    with (
+        patch("anta.device.AsyncEOSDevice.collect", side_effect=mock_collect, autospec=True),
+        patch("anta.device.AsyncEOSDevice.copy", side_effect=mock_copy, autospec=True),
+        patch("anta.inventory.AntaInventory.connect_inventory", side_effect=mock_connect_inventory),
+    ):
+        await collect_show_tech(inventory, root_dir=tmp_path, configure=False)
+
+    assert expected_message in caplog.text
+    assert "Unable to collect tech-support on" in caplog.text


### PR DESCRIPTION
## Description


This PR improves `anta exec collect-tech-support` error handling when SSH/SCP fails during tech-support collection.

Main changes:

1. Catch `asyncssh` errors gracefully when collecting tech-support, so SSH/SCP failures such as `ConnectionLost`, `ChannelOpenError`, or SFTP errors are logged per device instead of bubbling up as uncaught CLI exceptions.

2. Keep `HostKeyNotVerifiable` as a dedicated error path to preserve the clearer known-hosts guidance.

3. Catch `UsageError` inside the per-device show-tech collection flow so an unsupported device type does not abort the whole batch.

4. Refactor the show-tech collection logic into helpers to make Sonar happy and keep the flow easier to test.
  * Everything else is intended as structural refactor only: same collection logic, same behavior, and same user-facing messages except where noted below.

  * Two intentional small behavior/logging changes:
    * Removed two debug log lines:
      * `"aaa authorization exec default local" is not configured on device ...`
      * `"aaa authorization exec default local" is already configured on device ...`
      This avoids a misleading debug log after a fresh configure.
    * In the configure path, the order changed slightly:
      * The previous code logged the deprecation warning before checking `isinstance(device, AsyncEOSDevice)`.
      * The refactored `_configure_aaa_exec_authorization()` checks the device type first, so a non-`AsyncEOSDevice` raises/logs `UsageError` without also emitting the deprecation warning.

5. Expanded unit coverage for `collect_show_tech`, including:
  - asyncssh disconnect/SFTP/channel-open failures
  - host key verification failures
  - unsupported device type / `UsageError` handling
  - no tech-support files found
  - missing `aaa authorization exec default local` without `--configure`
  - `--latest` command shaping
  - successful `--configure` path with:
    - enable + enable password
    - enable without password
    - no enable mode

Related to issue #1531 but does not fix it.

## Checklist

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and messaging for failures during tech-support (“show-tech”) collection, including clearer SSH host-key verification output.
  * Updated failure logging to include more detailed exception information for transfer/command errors.
  * Expanded unit-test coverage to validate user-visible logging across multiple SSH/SFTP/connection error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->