### PR TITLE
test: Remove warnings from pytest

### DIFF
--- a/tests/units/anta_tests/conftest.py
+++ b/tests/units/anta_tests/conftest.py
@@ -25,8 +25,9 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
         # This is a unit test for an AntaTest subclass
         # Extract the test class, the unit test name and test data from the nested structure AntaUnitTestData
+        test_data = tuple((x[0][0], x[1]) for x in metafunc.module.DATA.items())
         metafunc.parametrize(
             "anta_test,unit_test_data",
-            ((x[0][0], x[1]) for x in metafunc.module.DATA.items()),
+            test_data,
             ids=[f"{anta_test.__module__}.{anta_test.__name__}-{unit_test_name}" for (anta_test, unit_test_name) in metafunc.module.DATA],
         )

--- a/tests/units/reporter/test_md_reporter.py
+++ b/tests/units/reporter/test_md_reporter.py
@@ -13,7 +13,8 @@ from unittest.mock import patch
 
 import pytest
 
-from anta.reporter.md_reporter import MDReportBase, MDReportGenerator, TestResults
+# Alias the report section to prevent pytest from collecting it as a test class.
+from anta.reporter.md_reporter import MDReportBase, MDReportGenerator, TestResults as MDTestResults
 from anta.result_manager import ResultManager
 from anta.result_manager.models import AntaTestStatus
 from anta.tools import convert_categories
@@ -213,7 +214,7 @@ def test_md_report_generator_generate_sections_expand_results(tmp_path: Path, re
     statuses = [AntaTestStatus.SUCCESS, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED]
     result_manager = result_manager_factory(size=5, atomic_results_status=statuses, distinct_tests=True, distinct_devices=True)
 
-    sections: list[tuple[type[MDReportBase], ResultManager]] = [(TestResults, result_manager.sort(sort_by=["name", "categories", "test"]))]
+    sections: list[tuple[type[MDReportBase], ResultManager]] = [(MDTestResults, result_manager.sort(sort_by=["name", "categories", "test"]))]
 
     # Generate the Markdown report with the "Test Results" section only with expand_results (this will generate atomic results)
     MDReportGenerator.generate_sections(sections, md_filename, extra_data={"_report_options": {"expand_results": True}})
@@ -236,7 +237,7 @@ def test_md_report_generator_generate_sections_no_custom_field(tmp_path: Path, r
 
     result_manager = result_manager_factory(size=5, distinct_tests=True, distinct_devices=True)
 
-    sections: list[tuple[type[MDReportBase], ResultManager]] = [(TestResults, result_manager.sort(sort_by=["name", "categories", "test"]))]
+    sections: list[tuple[type[MDReportBase], ResultManager]] = [(MDTestResults, result_manager.sort(sort_by=["name", "categories", "test"]))]
 
     # Generate the Markdown report with the "Test Results" section only with no custom field
     MDReportGenerator.generate_sections(sections, md_filename, extra_data={"_report_options": {"render_custom_field": False}})
@@ -262,7 +263,7 @@ def test_md_report_generator_generate_sections_expand_results_custom_columns(tmp
 
     custom_columns = ["DUT", "CAT", "TEST", "DESC", "RES", "MSGS"]
     with patch("anta.reporter.md_reporter.TestResults._TABLE_COLUMNS", custom_columns):
-        sections: list[tuple[type[MDReportBase], ResultManager]] = [(TestResults, result_manager.sort(sort_by=["name", "categories", "test"]))]
+        sections: list[tuple[type[MDReportBase], ResultManager]] = [(MDTestResults, result_manager.sort(sort_by=["name", "categories", "test"]))]
 
         # Generate the Markdown report with the "Test Results" section only with expand_results (this will generate atomic results) and custom columns
         MDReportGenerator.generate_sections(sections, md_filename, extra_data={"_report_options": {"expand_results": True, "render_custom_field": False}})

--- a/tests/units/reporter/test_md_reporter.py
+++ b/tests/units/reporter/test_md_reporter.py
@@ -14,7 +14,8 @@ from unittest.mock import patch
 import pytest
 
 # Alias the report section to prevent pytest from collecting it as a test class.
-from anta.reporter.md_reporter import MDReportBase, MDReportGenerator, TestResults as MDTestResults
+from anta.reporter.md_reporter import MDReportBase, MDReportGenerator
+from anta.reporter.md_reporter import TestResults as MDTestResults
 from anta.result_manager import ResultManager
 from anta.result_manager.models import AntaTestStatus
 from anta.tools import convert_categories


### PR DESCRIPTION
## Description

Pytest version 10 will prevent using iterators in `metafunc.parametrize` and starts emitting warnings in Pytest 9. So addressing these

Fixes # (issue id)

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test generation reliability by precomputing parametrization inputs before applying them, ensuring consistent data evaluation during runs.
  * Updated markdown reporter unit tests to prevent unintended test class collection, while keeping report section scenario coverage consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->