### PR TITLE
feat(anta.tests): Add test to verify VVTEP IP addresses

### DIFF
--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -261,3 +261,48 @@ class VerifyVxlan1ConnSettings(AntaTest):
             self.result.is_failure(f"Interface: Vxlan1 - Incorrect Source interface - Expected: {self.inputs.source_interface} Actual: {src_intf}")
         if port != self.inputs.udp_port:
             self.result.is_failure(f"Interface: Vxlan1 - Incorrect UDP port - Expected: {self.inputs.udp_port} Actual: {port}")
+
+
+class VerifyVxlan1VVTEPIPAddress(AntaTest):
+    """Verifies VVTEP IP Address.
+
+    Expected Results
+    ----------------
+    * Success: Passes if the input VVTEP ip address is configured as same in the vxlan interface
+    * Failure: Fails if the input VVTEP ip address is configured not as same in the vxlan interface
+    * Skipped: Skips if the Vxlan1 interface is not configured.
+
+    Examples
+    --------
+    ```yaml
+    anta.tests.vxlan:
+      - VerifyVxlan1VVTEPIPAddress:
+          vvtep_ip_address: 5.5.5.5
+    ```
+    """
+
+    categories: ClassVar[list[str]] = ["vxlan"]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show interfaces", revision=1)]
+
+    class Input(AntaTest.Input):
+        """Input model for the VerifyVxlanVtep test."""
+
+        vvtep_ip_address: IPv4Address
+        """VVTEP ip address."""
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        """Main test function for VerifyVxlan1VVTEPIPAddress."""
+        self.result.is_success()
+        command_output = self.instance_commands[0].json_output
+
+        # Skip the test case if vxlan1 interface is not configured
+        vxlan_output = get_value(command_output, "interfaces.Vxlan1")
+        if not vxlan_output:
+            self.result.is_skipped("Interface: Vxlan1 - Not configured")
+            return
+
+        configured_vvtep_ip_address = vxlan_output.get("vArpVtepAddr")
+
+        if str(self.inputs.vvtep_ip_address) != configured_vvtep_ip_address:
+            self.result.is_failure(f"Interface: Vxlan1 - Incorrect VVTEP IP address {configured_vvtep_ip_address} - Expected: {self.inputs.vvtep_ip_address}")

--- a/anta/tests/vxlan.py
+++ b/anta/tests/vxlan.py
@@ -7,16 +7,23 @@
 # pyright: reportAttributeAccessIssue=false
 from __future__ import annotations
 
-from ipaddress import IPv4Address
+from ipaddress import IPv4Address, IPv6Address
 from typing import TYPE_CHECKING, ClassVar
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from anta.custom_types import VlanId, Vni, VxlanSrcIntf
 from anta.models import AntaCommand, AntaTest
 from anta.tools import get_value
 
 if TYPE_CHECKING:
+    import sys
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
+
     from anta.models import AntaTemplate
 
 
@@ -263,21 +270,24 @@ class VerifyVxlan1ConnSettings(AntaTest):
             self.result.is_failure(f"Interface: Vxlan1 - Incorrect UDP port - Expected: {self.inputs.udp_port} Actual: {port}")
 
 
-class VerifyVxlan1VVTEPIPAddress(AntaTest):
-    """Verifies VVTEP IP Address.
+class VerifyVxlan1VVTEPIPAddresses(AntaTest):
+    """Verifies the VVTEP IP addresses.
+
+    Supports IPv4-only, IPv6-only, or dual-stack. At least one address must be provided.
 
     Expected Results
     ----------------
-    * Success: Passes if the input VVTEP ip address is configured as same in the vxlan interface
-    * Failure: Fails if the input VVTEP ip address is configured not as same in the vxlan interface
+    * Success: Passes if the provided VVTEP IP addresses match the ones configured on the VXLAN interface.
+    * Failure: Fails if any provided VVTEP IP address does not match the configured value, or is not configured.
     * Skipped: Skips if the Vxlan1 interface is not configured.
 
     Examples
     --------
     ```yaml
     anta.tests.vxlan:
-      - VerifyVxlan1VVTEPIPAddress:
-          vvtep_ip_address: 5.5.5.5
+      - VerifyVxlan1VVTEPIPAddresses:
+          ipv4_address: 5.5.5.5
+          ipv6_address: fd00:dc:1::1
     ```
     """
 
@@ -285,14 +295,24 @@ class VerifyVxlan1VVTEPIPAddress(AntaTest):
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show interfaces", revision=1)]
 
     class Input(AntaTest.Input):
-        """Input model for the VerifyVxlanVtep test."""
+        """Input model for the VerifyVxlan1VVTEPIPAddresses test."""
 
-        vvtep_ip_address: IPv4Address
-        """VVTEP ip address."""
+        ipv4_address: IPv4Address | None = None
+        """VVTEP IPv4 address."""
+        ipv6_address: IPv6Address | None = None
+        """VVTEP IPv6 address."""
+
+        @model_validator(mode="after")
+        def validate_inputs(self) -> Self:
+            """Validate that at least one address is provided."""
+            if not self.ipv4_address and not self.ipv6_address:
+                msg = "'ipv4_address' or 'ipv6_address' must be provided"
+                raise ValueError(msg)
+            return self
 
     @AntaTest.anta_test
     def test(self) -> None:
-        """Main test function for VerifyVxlan1VVTEPIPAddress."""
+        """Main test function for VerifyVxlan1VVTEPIPAddresses."""
         self.result.is_success()
         command_output = self.instance_commands[0].json_output
 
@@ -302,7 +322,15 @@ class VerifyVxlan1VVTEPIPAddress(AntaTest):
             self.result.is_skipped("Interface: Vxlan1 - Not configured")
             return
 
-        configured_vvtep_ip_address = vxlan_output.get("vArpVtepAddr")
+        checks: list[tuple[str, str, str]] = []
+        if self.inputs.ipv4_address is not None:
+            checks.append((str(self.inputs.ipv4_address), "vArpVtepAddr", "IPv4"))
+        if self.inputs.ipv6_address is not None:
+            checks.append((str(self.inputs.ipv6_address), "vArpVtepAddrV6", "IPv6"))
 
-        if str(self.inputs.vvtep_ip_address) != configured_vvtep_ip_address:
-            self.result.is_failure(f"Interface: Vxlan1 - Incorrect VVTEP IP address {configured_vvtep_ip_address} - Expected: {self.inputs.vvtep_ip_address}")
+        for expected, key, ip_version in checks:
+            configured = vxlan_output.get(key)
+            if configured is None:
+                self.result.is_failure(f"Interface: Vxlan1 - VVTEP {ip_version} address is not configured")
+            elif expected != configured:
+                self.result.is_failure(f"Interface: Vxlan1 - Incorrect VVTEP {ip_version} address - Expected: {expected} Actual: {configured}")

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -1613,9 +1613,10 @@ anta.tests.vxlan:
       udp_port: 4789
   - VerifyVxlan1Interface:
       # Verifies the Vxlan1 interface status.
-  - VerifyVxlan1VVTEPIPAddress:
-      # Verifies VVTEP IP Address.
-      vvtep_ip_address: 5.5.5.5
+  - VerifyVxlan1VVTEPIPAddresses:
+      # Verifies the VVTEP IP addresses.
+      ipv4_address: 5.5.5.5
+      ipv6_address: fd00:dc:1::1
   - VerifyVxlanConfigSanity:
       # Verifies there are no VXLAN config-sanity inconsistencies.
   - VerifyVxlanVniBinding:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -1613,6 +1613,9 @@ anta.tests.vxlan:
       udp_port: 4789
   - VerifyVxlan1Interface:
       # Verifies the Vxlan1 interface status.
+  - VerifyVxlan1VVTEPIPAddress:
+      # Verifies VVTEP IP Address.
+      vvtep_ip_address: 5.5.5.5
   - VerifyVxlanConfigSanity:
       # Verifies there are no VXLAN config-sanity inconsistencies.
   - VerifyVxlanVniBinding:

--- a/tests/units/anta_tests/test_vxlan.py
+++ b/tests/units/anta_tests/test_vxlan.py
@@ -9,7 +9,14 @@ from typing import TypeAlias
 
 from anta.models import AntaTest
 from anta.result_manager.models import AntaTestStatus
-from anta.tests.vxlan import VerifyVxlan1ConnSettings, VerifyVxlan1Interface, VerifyVxlanConfigSanity, VerifyVxlanVniBinding, VerifyVxlanVtep
+from anta.tests.vxlan import (
+    VerifyVxlan1ConnSettings,
+    VerifyVxlan1Interface,
+    VerifyVxlan1VVTEPIPAddress,
+    VerifyVxlanConfigSanity,
+    VerifyVxlanVniBinding,
+    VerifyVxlanVtep,
+)
 from tests.units.anta_tests import AntaUnitTest, test
 
 AntaUnitTestData: TypeAlias = dict[tuple[type[AntaTest], str], AntaUnitTest]
@@ -344,5 +351,15 @@ DATA: AntaUnitTestData = {
         "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
         "inputs": {"source_interface": "dps1", "udp_port": 4789},
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Interface: Vxlan1 - Incorrect Source interface - Expected: Dps1 Actual: Loopback10"]},
+    },
+    (VerifyVxlan1VVTEPIPAddress, "success"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789, "vArpVtepAddr": "5.5.5.5"}}}],
+        "inputs": {"vvtep_ip_address": "5.5.5.5"},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
+    (VerifyVxlan1VVTEPIPAddress, "failure"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789, "vArpVtepAddr": "6.6.6.6"}}}],
+        "inputs": {"vvtep_ip_address": "5.5.5.5"},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Interface: Vxlan1 - Incorrect VVTEP IP address 6.6.6.6 - Expected: 5.5.5.5"]},
     },
 }

--- a/tests/units/anta_tests/test_vxlan.py
+++ b/tests/units/anta_tests/test_vxlan.py
@@ -12,7 +12,7 @@ from anta.result_manager.models import AntaTestStatus
 from anta.tests.vxlan import (
     VerifyVxlan1ConnSettings,
     VerifyVxlan1Interface,
-    VerifyVxlan1VVTEPIPAddress,
+    VerifyVxlan1VVTEPIPAddresses,
     VerifyVxlanConfigSanity,
     VerifyVxlanVniBinding,
     VerifyVxlanVtep,
@@ -352,14 +352,58 @@ DATA: AntaUnitTestData = {
         "inputs": {"source_interface": "dps1", "udp_port": 4789},
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Interface: Vxlan1 - Incorrect Source interface - Expected: Dps1 Actual: Loopback10"]},
     },
-    (VerifyVxlan1VVTEPIPAddress, "success"): {
-        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789, "vArpVtepAddr": "5.5.5.5"}}}],
-        "inputs": {"vvtep_ip_address": "5.5.5.5"},
+    (VerifyVxlan1VVTEPIPAddresses, "success-ipv4-only"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"vArpVtepAddr": "5.5.5.5"}}}],
+        "inputs": {"ipv4_address": "5.5.5.5"},
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
-    (VerifyVxlan1VVTEPIPAddress, "failure"): {
-        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789, "vArpVtepAddr": "6.6.6.6"}}}],
-        "inputs": {"vvtep_ip_address": "5.5.5.5"},
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Interface: Vxlan1 - Incorrect VVTEP IP address 6.6.6.6 - Expected: 5.5.5.5"]},
+    (VerifyVxlan1VVTEPIPAddresses, "success-ipv6-only"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"vArpVtepAddrV6": "fd00:dc:1::1"}}}],
+        "inputs": {"ipv6_address": "fd00:dc:1::1"},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
+    (VerifyVxlan1VVTEPIPAddresses, "success-dual-stack"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"vArpVtepAddr": "5.5.5.5", "vArpVtepAddrV6": "fd00:dc:1::1"}}}],
+        "inputs": {"ipv4_address": "5.5.5.5", "ipv6_address": "fd00:dc:1::1"},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
+    (VerifyVxlan1VVTEPIPAddresses, "skipped"): {
+        "eos_data": [{"interfaces": {}}],
+        "inputs": {"ipv4_address": "5.5.5.5"},
+        "expected": {"result": AntaTestStatus.SKIPPED, "messages": ["Interface: Vxlan1 - Not configured"]},
+    },
+    (VerifyVxlan1VVTEPIPAddresses, "failure-incorrect-ipv4"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"vArpVtepAddr": "6.6.6.6"}}}],
+        "inputs": {"ipv4_address": "5.5.5.5"},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Interface: Vxlan1 - Incorrect VVTEP IPv4 address - Expected: 5.5.5.5 Actual: 6.6.6.6"],
+        },
+    },
+    (VerifyVxlan1VVTEPIPAddresses, "failure-incorrect-ipv6"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"vArpVtepAddrV6": "fd00:dc:1::2"}}}],
+        "inputs": {"ipv6_address": "fd00:dc:1::1"},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Interface: Vxlan1 - Incorrect VVTEP IPv6 address - Expected: fd00:dc:1::1 Actual: fd00:dc:1::2"],
+        },
+    },
+    (VerifyVxlan1VVTEPIPAddresses, "failure-not-configured-ipv4"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
+        "inputs": {"ipv4_address": "5.5.5.5"},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Interface: Vxlan1 - VVTEP IPv4 address is not configured"]},
+    },
+    (VerifyVxlan1VVTEPIPAddresses, "failure-not-configured-ipv6"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"srcIpIntf": "Loopback10", "udpPort": 4789}}}],
+        "inputs": {"ipv6_address": "fd00:dc:1::1"},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Interface: Vxlan1 - VVTEP IPv6 address is not configured"]},
+    },
+    (VerifyVxlan1VVTEPIPAddresses, "failure-dual-stack-partial"): {
+        "eos_data": [{"interfaces": {"Vxlan1": {"vArpVtepAddr": "5.5.5.5", "vArpVtepAddrV6": "fd00:dc:1::2"}}}],
+        "inputs": {"ipv4_address": "5.5.5.5", "ipv6_address": "fd00:dc:1::1"},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Interface: Vxlan1 - Incorrect VVTEP IPv6 address - Expected: fd00:dc:1::1 Actual: fd00:dc:1::2"],
+        },
     },
 }


### PR DESCRIPTION
## Description

Added test to compare VVTEP IP address.

Fixes #1538 

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a VXLAN Vxlan1 VVTEP IP address verification that supports IPv4-only, IPv6-only, or dual-stack checks.
  * Updated the sample test configuration to include the new VVTEP IP address verification.

* **Tests**
  * Expanded automated test coverage for successful matches, interface-missing skip behavior, and detailed failure cases for IPv4/IPv6 mismatches and missing expected address families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->