### PR TITLE
ci: use OIDC for CodSpeed benchmarks

### DIFF
--- a/.github/workflows/code-testing.yml
+++ b/.github/workflows/code-testing.yml
@@ -177,6 +177,9 @@ jobs:
     name: Benchmark ANTA for Python 3.12
     needs: [test-python]
     if: needs.file-changes.outputs.code == 'true' && github.repository == 'aristanetworks/anta'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/codspeed.yml
   codecov:
     name: Upload coverage to codecov

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   benchmarks:
@@ -24,6 +25,5 @@ jobs:
       - name: Run benchmarks
         uses: CodSpeedHQ/action@a4a36bb07c0638b0b4ca52bf1f3dad1b4289e52f # v4.18.1
         with:
-          token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation
           run: pytest --codspeed --no-cov --log-cli-level INFO tests/benchmark


### PR DESCRIPTION
## Summary
- grant OIDC token permissions to the CodSpeed reusable workflow
- grant the caller job the same permissions when invoked from code-testing
- remove the static CODSPEED_TOKEN input from CodSpeed action configuration

## Details
CodSpeed recommends GitHub Actions OIDC authentication with id-token: write instead of using a static CODSPEED_TOKEN secret:
https://codspeed.io/docs/integrations/ci/github-actions/configuration#oidc-recommended

## Testing
- uv run --group lint yamllint .github/workflows/codspeed.yml .github/workflows/code-testing.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark-related automation to use the required GitHub Actions permissions.
  * Simplified the benchmark workflow setup by relying on built-in authentication for the benchmark run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->