### PR TITLE
ci: force bash for test pypi install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
       - name: Install `anta` from test Pypi
         env:
           TARGET_VERSION: ${{ needs.target_version.outputs.target_version }}
+        shell: bash
         run: |-
           pip install -i https://test.pypi.org/simple/ "anta[cli]==$TARGET_VERSION" --group test --extra-index-url https://pypi.org/simple
       - name: Run tests


### PR DESCRIPTION
zizmor my friend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release validation by ensuring the Test PyPI installation step runs consistently in a Bash shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->