### PR TITLE
ci: Add GHC announcment to the release workflow

### DIFF
--- a/.github/announce_release_to_google_chat.py
+++ b/.github/announce_release_to_google_chat.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Post an ANTA release announcement to Google Chat."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+HIGHLIGHTS_HEADING = "Highlights"
+DEFAULT_DOCS_URL = "https://anta.arista.com/stable"
+DEFAULT_UPGRADE_COMMAND = "pipx upgrade anta"
+MAX_HIGHLIGHTS = 5
+PLACEHOLDER_HIGHLIGHTS = {
+    "...",
+    "fill in",
+    "fill this in",
+    "todo",
+    "tbd",
+}
+
+
+def _normalize_heading(heading: str) -> str:
+    """Return a normalized Markdown heading title."""
+    return heading.strip().strip("#").strip().strip("⭐").strip().casefold()
+
+
+def _sections(markdown: str) -> dict[str, list[str]]:
+    """Split a Markdown document into sections keyed by normalized heading."""
+    sections: dict[str, list[str]] = {}
+    current_heading: str | None = None
+
+    for line in markdown.splitlines():
+        heading_match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
+        if heading_match is not None:
+            current_heading = _normalize_heading(heading_match.group(1))
+            sections.setdefault(current_heading, [])
+            continue
+        if current_heading is not None:
+            sections[current_heading].append(line)
+
+    return sections
+
+
+def _clean_highlight_line(line: str) -> str | None:
+    """Clean a Markdown line for use as a Google Chat highlight."""
+    clean_line = line.strip()
+    if not clean_line or clean_line.startswith("<!--"):
+        return None
+
+    bullet_match = re.match(r"^(?:[-*+]|\d+\.)\s+(.+?)\s*$", clean_line)
+    if bullet_match is not None:
+        clean_line = bullet_match.group(1).strip()
+
+    if not clean_line or clean_line.startswith("#"):
+        return None
+    if clean_line.casefold().startswith("full changelog"):
+        return None
+    if clean_line.casefold() in PLACEHOLDER_HIGHLIGHTS:
+        return None
+
+    return clean_line
+
+
+def _extract_lines_from_section(section_lines: list[str], max_highlights: int) -> list[str]:
+    """Extract announcement-ready highlights from a Markdown section."""
+    highlights: list[str] = []
+    for line in section_lines:
+        highlight = _clean_highlight_line(line)
+        if highlight is None:
+            continue
+        highlights.append(highlight)
+        if len(highlights) == max_highlights:
+            break
+    return highlights
+
+
+def extract_highlights(release_body: str, max_highlights: int = MAX_HIGHLIGHTS) -> list[str]:
+    """Extract curated highlights from the release body."""
+    sections = _sections(release_body)
+    return _extract_lines_from_section(sections.get(_normalize_heading(HIGHLIGHTS_HEADING), []), max_highlights)
+
+
+def require_highlights(release_body: str) -> list[str]:
+    """Return release highlights or raise when the release body is not announcement-ready."""
+    highlights = extract_highlights(release_body)
+    if highlights:
+        return highlights
+
+    msg = (
+        "GitHub release body must contain a non-empty '## Highlights' section before publishing. "
+        "Add 3-5 curated bullets and publish the release again."
+    )
+    raise ValueError(msg)
+
+
+def build_announcement(
+    *,
+    tag_name: str,
+    release_url: str,
+    release_body: str,
+    docs_url: str = DEFAULT_DOCS_URL,
+    upgrade_command: str = DEFAULT_UPGRADE_COMMAND,
+) -> str:
+    """Build the Google Chat release announcement text."""
+    version = tag_name if tag_name.startswith("v") else f"v{tag_name}"
+    highlights = require_highlights(release_body)
+    highlight_lines = "\n".join(highlights)
+
+    return (
+        f"🐜 ANTA {version} is out 🐜\n\n"
+        "📝 Release Notes 📝\n\n"
+        f"{release_url}\n\n"
+        "⭐ Highlights ⭐\n\n"
+        f"{highlight_lines}\n\n"
+        "📖 Documentation 📖\n\n"
+        f"{docs_url}\n\n"
+        "⬆️ Upgrade ⬆️\n\n"
+        f"{upgrade_command}\n\n"
+        "Thanks for the community feedback!\n\n"
+        "Happy testing! 🐜"
+    )
+
+
+def load_release_event(event_path: Path) -> dict[str, str]:
+    """Load release metadata from a GitHub Actions event payload."""
+    with event_path.open(encoding="utf-8") as event_file:
+        event = json.load(event_file)
+
+    release = event.get("release", {})
+    if not isinstance(release, dict):
+        msg = "GitHub event payload does not contain a release object."
+        raise ValueError(msg)
+
+    tag_name = release.get("tag_name")
+    release_url = release.get("html_url")
+    if not isinstance(tag_name, str) or not tag_name:
+        msg = "GitHub release payload does not contain release.tag_name."
+        raise ValueError(msg)
+    if not isinstance(release_url, str) or not release_url:
+        msg = "GitHub release payload does not contain release.html_url."
+        raise ValueError(msg)
+
+    release_body = release.get("body", "")
+    if not isinstance(release_body, str):
+        release_body = ""
+
+    return {"tag_name": tag_name, "release_url": release_url, "release_body": release_body}
+
+
+def post_to_google_chat(webhook_url: str, message: str) -> None:
+    """Post a text message to a Google Chat incoming webhook."""
+    payload = json.dumps({"text": message}).encode()
+    request = urllib.request.Request(webhook_url, data=payload, headers={"Content-Type": "application/json"}, method="POST")
+
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            if response.status < 200 or response.status >= 300:
+                msg = f"Google Chat webhook returned HTTP {response.status}."
+                raise RuntimeError(msg)
+    except urllib.error.HTTPError as error:
+        msg = f"Google Chat webhook returned HTTP {error.code}."
+        raise RuntimeError(msg) from error
+    except urllib.error.URLError as error:
+        msg = f"Failed to reach Google Chat webhook: {error.reason}"
+        raise RuntimeError(msg) from error
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Validate that the release body has curated highlights without posting to Google Chat.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the rendered announcement without posting to Google Chat.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Post the current GitHub release announcement."""
+    args = parse_args(argv or [])
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        print("GITHUB_EVENT_PATH is not set.", file=sys.stderr)
+        return 1
+
+    try:
+        release = load_release_event(Path(event_path))
+        if args.check:
+            require_highlights(release["release_body"])
+            print("Release announcement highlights are ready.")
+            return 0
+        message = build_announcement(**release)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"Failed to build release announcement: {error}", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        print(message)
+        return 0
+
+    webhook_url = os.environ.get("ANTA_FIELD_WEBHOOK_URL")
+    if not webhook_url:
+        print("ANTA_FIELD_WEBHOOK_URL is not set.", file=sys.stderr)
+        return 1
+
+    try:
+        post_to_google_chat(webhook_url, message)
+    except RuntimeError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    print("Posted ANTA release announcement to Google Chat.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/release.md
+++ b/.github/release.md
@@ -59,6 +59,25 @@ The workflow works as follow:
 4. Release to Pypi (it needs to be approved in Github UI).
 5. Build and publish the doc.
 6. Publish docker containers.
+7. Announce the release in the ANTA-Field Google Chat room.
+
+### Google Chat announcement
+
+The release workflow checks for curated highlights before publishing artifacts and posts the ANTA-Field announcement only after PyPI, documentation, and Docker publishing have succeeded.
+
+Set the `ANTA_FIELD_WEBHOOK_URL` GitHub Actions secret to the ANTA-Field incoming webhook URL.
+
+GitHub's generated release-note configuration does not support adding a static placeholder section, so add a `Highlights` section to the GitHub release body before publishing:
+
+```markdown
+## Highlights
+
+- Support for expanded results for a few tests
+- Nicer markdown report
+- Python 3.14 support added
+```
+
+If the `Highlights` section is missing or still contains placeholder text such as `TODO` or `TBD`, the release workflow stops before publishing to PyPI.
 
 ### Tips
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,20 @@ permissions:
   contents: read
 
 jobs:
+  validate-release-announcement:
+    name: 📣 Validate release announcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Check curated release highlights
+        if: github.event_name == 'release'
+        run: python .github/announce_release_to_google_chat.py --check
+      - name: Skip announcement validation for manual TestPyPI runs
+        if: github.event_name != 'release'
+        run: echo "Release announcement validation is only required for published GitHub releases."
+
   target_version:
     name: 🎯 Set target version
     runs-on: ubuntu-latest
@@ -45,7 +59,7 @@ jobs:
 
   build-anta-dist:
     name: 🔨 Build ANTA distribution ${{ needs.target_version.outputs.target_version }}
-    needs: [target_version]
+    needs: [target_version, validate-release-announcement]
     # Building universal wheel as we are not platform dependent
     runs-on: ubuntu-latest
     steps:
@@ -239,3 +253,19 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  announce-anta-field:
+    name: 📣 Announce release to ANTA-Field
+    runs-on: ubuntu-latest
+    needs: [publish-anta-pypi, release-doc, docker]
+    if: github.event_name == 'release'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Post release announcement
+        env:
+          ANTA_FIELD_WEBHOOK_URL: ${{ secrets.ANTA_FIELD_WEBHOOK_URL }}
+        run: python .github/announce_release_to_google_chat.py

--- a/tests/units/test_announce_release_to_google_chat.py
+++ b/tests/units/test_announce_release_to_google_chat.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Tests for the Google Chat release announcement helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+SCRIPT_PATH = Path(__file__).parents[2] / ".github" / "announce_release_to_google_chat.py"
+
+
+def load_announcement_module() -> ModuleType:
+    """Load the GitHub release announcement helper module."""
+    spec = importlib.util.spec_from_file_location("announce_release_to_google_chat", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load {SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ANNOUNCE = load_announcement_module()
+
+
+def test_build_announcement_uses_curated_highlights() -> None:
+    """Curated Highlights from the release body should be preferred."""
+    message = ANNOUNCE.build_announcement(
+        tag_name="v1.7.0",
+        release_url="https://github.com/aristanetworks/anta/releases/tag/v1.7.0",
+        release_body="""## Highlights
+
+- Support for expanded results
+- Nicer markdown report
+
+## Fixed issues
+
+- A less important fallback item
+""",
+    )
+
+    assert "🐜 ANTA v1.7.0 is out 🐜" in message
+    assert "Support for expanded results" in message
+    assert "Nicer markdown report" in message
+    assert "A less important fallback item" not in message
+    assert "https://anta.arista.com/stable" in message
+    assert "pipx upgrade anta" in message
+
+
+def test_extract_highlights_ignores_generated_release_notes() -> None:
+    """Generated release-note sections should not be treated as curated highlights."""
+    assert (
+        ANNOUNCE.extract_highlights(
+            """## Documentation
+
+- Documentation-only change
+
+## New features and enhancements
+
+- Add Python 3.14 support by @anta in #123
+- Add markdown report improvements by @anta in #124
+
+## Fixed issues
+
+- Fix a bug by @anta in #125
+"""
+        )
+        == []
+    )
+
+
+def test_require_highlights_fails_without_curated_highlights() -> None:
+    """Missing highlights should fail before the release is announced."""
+    with pytest.raises(ValueError, match="must contain a non-empty '## Highlights' section"):
+        ANNOUNCE.require_highlights(
+            """## New features and enhancements
+
+- Add Python 3.14 support by @anta in #123
+"""
+        )
+
+
+def test_require_highlights_fails_with_placeholder_highlights() -> None:
+    """Placeholder highlights should not pass validation."""
+    with pytest.raises(ValueError, match="must contain a non-empty '## Highlights' section"):
+        ANNOUNCE.require_highlights(
+            """## Highlights
+
+- TODO
+- TBD
+- Fill this in
+
+## New features and enhancements
+
+- Add Python 3.14 support by @anta in #123
+"""
+        )
+
+
+def test_require_highlights_accepts_curated_highlights() -> None:
+    """Curated highlights should pass validation."""
+    assert ANNOUNCE.require_highlights(
+        """## Documentation
+
+- Documentation-only change
+
+## Highlights
+
+- Add Python 3.14 support
+- Improve markdown report output
+"""
+    ) == ["Add Python 3.14 support", "Improve markdown report output"]
+
+
+def test_build_announcement_fails_for_empty_release_body() -> None:
+    """Empty release notes should not produce a low-quality announcement."""
+    with pytest.raises(ValueError, match="must contain a non-empty '## Highlights' section"):
+        ANNOUNCE.build_announcement(tag_name="v1.7.0", release_url="https://example.com/release", release_body="")
+
+
+def test_build_announcement_adds_v_prefix_when_missing() -> None:
+    """Version formatting should match the manual announcement style."""
+    message = ANNOUNCE.build_announcement(tag_name="1.7.0", release_url="https://example.com/release", release_body="## Highlights\n\n- Useful item")
+
+    assert message.startswith("🐜 ANTA v1.7.0 is out 🐜")
+
+
+def test_load_release_event(tmp_path: Path) -> None:
+    """Release metadata should be read from the GitHub event payload."""
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "release": {
+                    "tag_name": "v1.7.0",
+                    "html_url": "https://github.com/aristanetworks/anta/releases/tag/v1.7.0",
+                    "body": "## Highlights\n\n- Useful item",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert ANNOUNCE.load_release_event(event_path) == {
+        "tag_name": "v1.7.0",
+        "release_url": "https://github.com/aristanetworks/anta/releases/tag/v1.7.0",
+        "release_body": "## Highlights\n\n- Useful item",
+    }
+
+
+def test_main_dry_run_does_not_require_or_print_webhook_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry-run mode should render the message without touching the webhook secret."""
+    event_path = tmp_path / "event.json"
+    webhook_url = "https://chat.googleapis.com/v1/spaces/secret/messages?key=secret&token=secret"
+    event_path.write_text(
+        json.dumps({"release": {"tag_name": "v1.7.0", "html_url": "https://example.com/release", "body": "## Highlights\n\n- Useful item"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("ANTA_FIELD_WEBHOOK_URL", webhook_url)
+
+    assert ANNOUNCE.main(["--dry-run"]) == 0
+
+    captured = capsys.readouterr()
+    assert "🐜 ANTA v1.7.0 is out 🐜" in captured.out
+    assert webhook_url not in captured.out
+    assert webhook_url not in captured.err
+
+
+def test_main_check_validates_highlights(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Check mode should validate highlights without requiring the webhook secret."""
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"release": {"tag_name": "v1.7.0", "html_url": "https://example.com/release", "body": "## Highlights\n\n- Useful item"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.delenv("ANTA_FIELD_WEBHOOK_URL", raising=False)
+
+    assert ANNOUNCE.main(["--check"]) == 0
+
+    captured = capsys.readouterr()
+    assert "Release announcement highlights are ready." in captured.out
+
+
+def test_post_to_google_chat_sends_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The webhook POST should use a JSON text payload."""
+    response = MagicMock()
+    response.__enter__.return_value.status = 200
+    urlopen = MagicMock(return_value=response)
+    monkeypatch.setattr(ANNOUNCE.urllib.request, "urlopen", urlopen)
+
+    ANNOUNCE.post_to_google_chat("https://chat.example.invalid/webhook", "Happy testing! 🐜")
+
+    request = urlopen.call_args.args[0]
+    assert request.full_url == "https://chat.example.invalid/webhook"
+    assert request.get_method() == "POST"
+    assert json.loads(request.data.decode()) == {"text": "Happy testing! 🐜"}
+    assert request.headers["Content-type"] == "application/json"
+
+
+def test_post_to_google_chat_fails_on_non_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-2xx webhook responses should fail the announcement job."""
+    response = MagicMock()
+    response.__enter__.return_value.status = 500
+    monkeypatch.setattr(ANNOUNCE.urllib.request, "urlopen", MagicMock(return_value=response))
+
+    with pytest.raises(RuntimeError, match="Google Chat webhook returned HTTP 500"):
+        ANNOUNCE.post_to_google_chat("https://chat.example.invalid/webhook", "Happy testing! 🐜")


### PR DESCRIPTION
## Description

Automate the ANTA release announcement to the ANTA-Field Google Chat room.

This adds a final release workflow job that posts the announcement only after PyPI, documentation, and Docker publishing have succeeded. The announcement keeps the current manual message style, but reads release metadata from the GitHub release payload and posts through the ANTA_FIELD_WEBHOOK_URL repository secret.

The workflow now validates the release body before publishing artifacts. Published GitHub releases must include a non-empty ## Highlights section, so the Google Chat message keeps curated human-written highlights instead of relying on weak auto-selected release-note bullets. Placeholder-only highlights such as TODO or TBD are rejected.

The release documentation was updated with the required secret and the expected ## Highlights section format.

Fixes #

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (pre-commit run)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (tox -e testenv)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated release announcements to Google Chat, including version details, release links, curated highlights, documentation, and upgrade instructions.
  - Added validation to ensure releases include meaningful highlights before publishing.
  - Added dry-run and check modes for previewing or validating announcements.

- **Documentation**
  - Documented Google Chat announcement setup, required configuration, and release highlight requirements.

- **Tests**
  - Added coverage for announcement formatting, validation, event handling, preview mode, and webhook failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->