### PR TITLE
fix: format IPv6 hosts in device URLs

### DIFF
--- a/asynceapi/device.py
+++ b/asynceapi/device.py
@@ -42,6 +42,13 @@ LOGGER = getLogger(__name__)
 __all__ = ["Device"]
 
 
+def _format_url_host(host: str | None) -> str | None:
+    """Wrap IPv6 literals for use in a URL authority."""
+    if host is not None and ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
 # -----------------------------------------------------------------------------
 #
 #                                 CODE BEGINS
@@ -113,7 +120,8 @@ class Device(httpx.AsyncClient):
         self.host = host
         self._use_session_auth = use_session_auth
         self._session_auth: EapiSessionAuth | None = None
-        kwargs.setdefault("base_url", httpx.URL(f"{proto}://{self.host}:{self.port}"))
+        url_host = _format_url_host(self.host)
+        kwargs.setdefault("base_url", httpx.URL(f"{proto}://{url_host}:{self.port}"))
         kwargs.setdefault("verify", False)
         if self._use_session_auth:
             if not (username and password):
@@ -122,7 +130,7 @@ class Device(httpx.AsyncClient):
             if not self.host:
                 msg = "host is required for session authentication"
                 raise ValueError(msg)
-            login_url = f"{proto}://{self.host}:{self.port}{self.EAPI_LOGIN_URL}"
+            login_url = f"{proto}://{url_host}:{self.port}{self.EAPI_LOGIN_URL}"
             self._session_auth = EapiSessionAuth(host=self.host, username=username, password=password, login_url=login_url)
             kwargs.setdefault("auth", self._session_auth)
             LOGGER.debug("Device %s: eAPI session-based authentication enabled", self.host)

--- a/asynceapi/device.py
+++ b/asynceapi/device.py
@@ -128,7 +128,11 @@ class Device(httpx.AsyncClient):
         self._use_session_auth = use_session_auth
         self._session_auth: EapiSessionAuth | None = None
         url_host = _format_url_host(self.host)
-        kwargs.setdefault("base_url", httpx.URL(f"{proto}://{url_host}:{self.port}"))
+        if "base_url" not in kwargs:
+            if self.host is None:
+                msg = "host is required when base_url is not provided"
+                raise ValueError(msg)
+            kwargs["base_url"] = httpx.URL(f"{proto}://{url_host}:{self.port}")
         kwargs.setdefault("verify", False)
         if self._use_session_auth:
             if not (username and password):

--- a/asynceapi/device.py
+++ b/asynceapi/device.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+from ipaddress import IPv6Address, ip_address
 from logging import getLogger
 from socket import getservbyname
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -44,7 +45,13 @@ __all__ = ["Device"]
 
 def _format_url_host(host: str | None) -> str | None:
     """Wrap IPv6 literals for use in a URL authority."""
-    if host is not None and ":" in host and not host.startswith("["):
+    if host is None or host.startswith("["):
+        return host
+    try:
+        address = ip_address(host)
+    except ValueError:
+        return host
+    if isinstance(address, IPv6Address):
         return f"[{host}]"
     return host
 

--- a/tests/units/asynceapi/test_device.py
+++ b/tests/units/asynceapi/test_device.py
@@ -231,6 +231,15 @@ def test_device_init_session_raises_without_host() -> None:
         Device(host=None, username="admin", password=_PASSWORD, use_session_auth=True)
 
 
+def test_device_init_formats_ipv6_host_in_urls() -> None:
+    """Test that an IPv6 host is bracketed in eAPI URLs."""
+    device = Device(host="fd00:c1ab:8::4", username="admin", password=_PASSWORD, use_session_auth=True)
+
+    assert str(device.base_url) == "https://[fd00:c1ab:8::4]"
+    assert device._session_auth is not None
+    assert device._session_auth._login_url == "https://[fd00:c1ab:8::4]:443/login"
+
+
 async def test_logout_noop_when_session_auth_is_none() -> None:
     """Test that logout() is a no-op when the device is not using session auth."""
     device = Device(host=_HOST, username="admin", password=_PASSWORD, use_session_auth=False)

--- a/tests/units/asynceapi/test_device.py
+++ b/tests/units/asynceapi/test_device.py
@@ -232,6 +232,19 @@ def test_device_init_session_raises_without_host() -> None:
         Device(host=None, username="admin", password=_PASSWORD, use_session_auth=True)
 
 
+def test_device_init_raises_without_host_or_base_url() -> None:
+    """Test that Device raises ValueError when it cannot build a default base_url."""
+    with pytest.raises(ValueError, match="host is required when base_url is not provided"):
+        Device(host=None, username="admin", password=_PASSWORD)
+
+
+def test_device_init_allows_base_url_without_host() -> None:
+    """Test that Device accepts a complete base_url when host is not provided."""
+    device = Device(host=None, username="admin", password=_PASSWORD, base_url="https://example.invalid")
+
+    assert str(device.base_url) == "https://example.invalid"
+
+
 @pytest.mark.parametrize(
     ("host", "expected_base_url", "expected_login_url"),
     [

--- a/tests/units/asynceapi/test_device.py
+++ b/tests/units/asynceapi/test_device.py
@@ -15,6 +15,7 @@ from httpx import ConnectError, HTTPStatusError, Response
 
 from asynceapi import Device, EapiCommandError
 from asynceapi._constants import EapiCommandFormat
+from asynceapi.device import _format_url_host
 from asynceapi.errors import EapiAuthenticationError
 
 from .test_data import ERROR_EAPI_RESPONSE, JSONRPC_REQUEST_TEMPLATE, SUCCESS_EAPI_RESPONSE
@@ -231,13 +232,28 @@ def test_device_init_session_raises_without_host() -> None:
         Device(host=None, username="admin", password=_PASSWORD, use_session_auth=True)
 
 
-def test_device_init_formats_ipv6_host_in_urls() -> None:
-    """Test that an IPv6 host is bracketed in eAPI URLs."""
-    device = Device(host="fd00:c1ab:8::4", username="admin", password=_PASSWORD, use_session_auth=True)
+@pytest.mark.parametrize(
+    ("host", "expected_base_url", "expected_login_url"),
+    [
+        ("fd00:c1ab:8::4", "https://[fd00:c1ab:8::4]", "https://[fd00:c1ab:8::4]:443/login"),
+        ("[fd00:c1ab:8::4]", "https://[fd00:c1ab:8::4]", "https://[fd00:c1ab:8::4]:443/login"),
+        (_HOST, _BASE_URL, f"{_BASE_URL}:443/login"),
+        ("switch1.example.com", "https://switch1.example.com", "https://switch1.example.com:443/login"),
+    ],
+    ids=["ipv6", "bracketed_ipv6", "ipv4", "hostname"],
+)
+def test_device_init_formats_host_in_urls(host: str, expected_base_url: str, expected_login_url: str) -> None:
+    """Test that only IPv6 hosts are bracketed in eAPI URLs."""
+    device = Device(host=host, username="admin", password=_PASSWORD, use_session_auth=True)
 
-    assert str(device.base_url) == "https://[fd00:c1ab:8::4]"
+    assert str(device.base_url) == expected_base_url
     assert device._session_auth is not None
-    assert device._session_auth._login_url == "https://[fd00:c1ab:8::4]:443/login"
+    assert device._session_auth._login_url == expected_login_url
+
+
+def test_format_url_host_keeps_invalid_colon_host_unmodified() -> None:
+    """Test that colon-containing non-IPv6 hosts are not bracketed."""
+    assert _format_url_host("not:ipv6") == "not:ipv6"
 
 
 async def test_logout_noop_when_session_auth_is_none() -> None:


### PR DESCRIPTION
## Description

IPv6 literals were interpolated into eAPI URLs without brackets, causing `httpx.InvalidURL` before a connection could start. This formats IPv6 hosts for both the base URL and session-login URL while leaving IPv4 addresses and hostnames unchanged.

Fixes #1581

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed device URL generation when the configured host is an IPv6 address.
  - Session-based authentication now uses properly bracketed IPv6 hosts when constructing login URLs.

- **Tests**
  - Added unit tests covering `base_url` and session login URL formatting for IPv6, including normalization behavior and edge cases (IPv4/hostnames and non-IPv6 colon-containing values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->