### PR TITLE
fix: Invalid AntaTest top-level input types are not rejected explicitly in direct Python/API usage

### DIFF
--- a/anta/models.py
+++ b/anta/models.py
@@ -477,22 +477,25 @@ class AntaTest(ABC):
 
         Any input validation error will set this test result status as 'error'.
         """
-
-        def _raise_invalid_input_type() -> None:
-            msg = f"Input should be a dict, Input instance or None, not {type(inputs).__name__}"
-            raise TypeError(msg)
-
-        try:
-            if inputs is None:
+        if inputs is None:
+            try:
                 self.inputs = self.Input()
-            elif isinstance(inputs, AntaTest.Input):
-                self.inputs = inputs
-            elif isinstance(inputs, dict):
+            except ValidationError as e:
+                message = f"{self.module}.{self.name}: Inputs are not valid\n{e}"
+                self.logger.error(message)
+                self.result.is_error(message=message)
+        elif isinstance(inputs, AntaTest.Input):
+            self.inputs = inputs
+        elif isinstance(inputs, dict):
+            try:
                 self.inputs = self.Input(**inputs)
-            else:
-                _raise_invalid_input_type()
-        except (ValidationError, TypeError) as e:
-            message = f"{self.module}.{self.name}: Inputs are not valid\n{e}"
+            except ValidationError as e:
+                message = f"{self.module}.{self.name}: Inputs are not valid\n{e}"
+                self.logger.error(message)
+                self.result.is_error(message=message)
+        else:
+            msg = f"Input should be a dict, Input instance or None, not {type(inputs).__name__}"
+            message = f"{self.module}.{self.name}: Inputs are not valid\n{msg}"
             self.logger.error(message)
             self.result.is_error(message=message)
 

--- a/anta/models.py
+++ b/anta/models.py
@@ -477,6 +477,11 @@ class AntaTest(ABC):
 
         Any input validation error will set this test result status as 'error'.
         """
+
+        def _raise_invalid_input_type() -> None:
+            msg = f"Input should be a dict, Input instance or None, not {type(inputs).__name__}"
+            raise TypeError(msg)
+
         try:
             if inputs is None:
                 self.inputs = self.Input()
@@ -484,7 +489,9 @@ class AntaTest(ABC):
                 self.inputs = inputs
             elif isinstance(inputs, dict):
                 self.inputs = self.Input(**inputs)
-        except ValidationError as e:
+            else:
+                _raise_invalid_input_type()
+        except (ValidationError, TypeError) as e:
             message = f"{self.module}.{self.name}: Inputs are not valid\n{e}"
             self.logger.error(message)
             self.result.is_error(message=message)

--- a/tests/units/test_models.py
+++ b/tests/units/test_models.py
@@ -297,8 +297,29 @@ class FakeTestWithMissingTest(AntaTest):
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = []
 
 
+class FakeTestWithInputNoDefault(AntaTest):
+    """ANTA test with inputs that require fields."""
+
+    categories: ClassVar[list[str]] = []
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = []
+
+    class Input(AntaTest.Input):
+        """Inputs for FakeTestWithInputNoDefault test."""
+
+        value: str
+
+    @AntaTest.anta_test
+    def test(self) -> None:
+        """Test function."""
+        self.result.is_success()
+
+
 ANTATEST_DATA: dict[tuple[type[AntaTest], str], Any] = {
     (FakeTest, "no input"): {"inputs": None, "expected": {"__init__": {"result": "unset"}, "test": {"result": "success"}}},
+    (FakeTest, "Input instance with no fields"): {
+        "inputs": FakeTest.Input(),
+        "expected": {"__init__": {"result": "unset"}, "test": {"result": "success"}},
+    },
     (FakeTest, "extra input"): {
         "inputs": {"string": "culpa! veniam quas quas veniam molestias, esse"},
         "expected": {"__init__": {"result": "error", "messages": ["Extra inputs are not permitted"]}, "test": {"result": "error"}},
@@ -389,6 +410,22 @@ ANTATEST_DATA: dict[tuple[type[AntaTest], str], Any] = {
     (FakeTestWithKnownEOSError, "known EOS error command"): {
         "inputs": None,
         "expected": {"__init__": {"result": "unset"}, "test": {"result": "failure", "messages": ["BGP inactive"]}},
+    },
+    (FakeTest, "string inputs"): {
+        "inputs": "invalid string input",
+        "expected": {"__init__": {"result": "error", "messages": ["Input should be a dict, Input instance or None, not str"]}, "test": {"result": "error"}},
+    },
+    (FakeTest, "list inputs"): {
+        "inputs": ["invalid", "list", "input"],
+        "expected": {"__init__": {"result": "error", "messages": ["Input should be a dict, Input instance or None, not list"]}, "test": {"result": "error"}},
+    },
+    (FakeTest, "int inputs"): {
+        "inputs": 42,
+        "expected": {"__init__": {"result": "error", "messages": ["Input should be a dict, Input instance or None, not int"]}, "test": {"result": "error"}},
+    },
+    (FakeTestWithInputNoDefault, "tuple inputs"): {
+        "inputs": ("invalid", "tuple"),
+        "expected": {"__init__": {"result": "error", "messages": ["Input should be a dict, Input instance or None, not tuple"]}, "test": {"result": "error"}},
     },
 }
 


### PR DESCRIPTION

## Description
AntaTest._init_inputs() only handles None, dict, and AntaTest.Input. If a caller passes any other top-level type, such as str or list, the framework does not reject it explicitly. Instead, the test object can remain partially initialized and fail later with misleading runtime errors such as AttributeError.

### Fix
Add an explicit else branch in _init_inputs() to reject unsupported top-level input types and mark the result as error with a clear message. 



Fixes #1580

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for provided test inputs.
  * Unsupported input types are now handled explicitly, producing type-specific error messages.
  * Such cases consistently fail the test result and correctly surface validation issues.
* **Tests**
  * Added coverage for inputs with required fields and for additional invalid input-type scenarios (including string, list, integer, and tuple).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->