### PR TITLE
fix: read console authentication methods from EOS output

### DIFF
--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -202,10 +202,10 @@ class VerifyAuthenMethods(AntaTest):
                 # We do not need to verify this accounting type
                 continue
             if auth_type == "login":
-                if "login" not in v:
+                if "console" not in v:
                     self.result.is_failure("AAA authentication methods are not configured for login console")
                     return
-                if v["login"]["methods"] != self.inputs.methods:
+                if v["console"]["methods"] != self.inputs.methods:
                     self.result.is_failure(f"AAA authentication methods {', '.join(self.inputs.methods)} are not matching for login console")
                     return
             not_matching.extend(auth_type for methods in v.values() if methods["methods"] != self.inputs.methods)

--- a/tests/units/anta_tests/test_aaa.py
+++ b/tests/units/anta_tests/test_aaa.py
@@ -158,7 +158,7 @@ DATA: AntaUnitTestData = {
     (VerifyAuthenMethods, "success-login-enable"): {
         "eos_data": [
             {
-                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "login": {"methods": ["group tacacs+", "local"]}},
+                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group tacacs+", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
             }
@@ -169,7 +169,7 @@ DATA: AntaUnitTestData = {
     (VerifyAuthenMethods, "success-dot1x"): {
         "eos_data": [
             {
-                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "login": {"methods": ["group tacacs+", "local"]}},
+                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group tacacs+", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
             }
@@ -191,7 +191,7 @@ DATA: AntaUnitTestData = {
     (VerifyAuthenMethods, "failure-login-console"): {
         "eos_data": [
             {
-                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "login": {"methods": ["group radius", "local"]}},
+                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group radius", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
             }
@@ -202,7 +202,7 @@ DATA: AntaUnitTestData = {
     (VerifyAuthenMethods, "failure-login-default"): {
         "eos_data": [
             {
-                "loginAuthenMethods": {"default": {"methods": ["group radius", "local"]}, "login": {"methods": ["group tacacs+", "local"]}},
+                "loginAuthenMethods": {"default": {"methods": ["group radius", "local"]}, "console": {"methods": ["group tacacs+", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
             }


### PR DESCRIPTION
## Description

`VerifyAuthenMethods` looked for a nonexistent `login` entry inside EOS `loginAuthenMethods` output, causing valid login checks to fail before comparing methods. Read the actual `console` entry and align the AAA fixtures with current EOS output.

Fixes #1586

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation of console authentication methods for login authentication checks.
  * Updated authentication test scenarios to accurately reflect console-based method configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->