### PR TITLE
feat(anta.tests): Add a new test to verify transceiver types per-interface

### DIFF
--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -256,7 +256,7 @@ def update_ipv4_route_type(value: str) -> str:
     return route_types[value]
 
 
-def _normalize_interface_prefixes(pattern: str) -> str:
+def normalize_interface_prefixes(pattern: str) -> str:
     """Normalize all interface abbreviations in pattern string using interface_autocomplete.
 
     E.g., 'et1-3,po2' → 'Ethernet1-3,Port-Channel2'
@@ -275,7 +275,7 @@ def _normalize_interface_prefixes(pattern: str) -> str:
     return ",".join(result)
 
 
-def _expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> list[str]:
+def expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> list[str]:
     """Expand normalized (prefix-expanded) pattern into individual interface names.
 
     Assumes all abbreviations have been normalized (e.g., 'et' → 'Ethernet').
@@ -310,6 +310,25 @@ def _expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> l
     return expanded
 
 
+def validate_interface_range(v: str, max_range_size: int = 1000) -> list[str]:
+    """Validate and expand interface range pattern to list of interface names.
+
+    Supports abbreviations (et→Ethernet), ranges (1-3→1,2,3), and multi-level slots (1/1-2→1/1,1/2).
+    For comma-separated patterns, items can omit prefix to reuse the previous one.
+
+    Examples
+    --------
+    >>> validate_interface_range("Ethernet1-3")
+    ['Ethernet1', 'Ethernet2', 'Ethernet3']
+    >>> validate_interface_range("et1,5")
+    ['Ethernet1', 'Ethernet5']
+    >>> validate_interface_range("Ethernet1/1-2")
+    ['Ethernet1/1', 'Ethernet1/2']
+    """
+    normalized = normalize_interface_prefixes(v)
+    return expand_normalized_pattern(normalized, max_range_size)
+
+
 def expand_interface_pattern(name: str, max_range_size: int = 1000) -> list[str]:
     """Expand comma-separated interface pattern to individual interface names.
 
@@ -325,24 +344,7 @@ def expand_interface_pattern(name: str, max_range_size: int = 1000) -> list[str]
     >>> expand_interface_pattern("Ethernet1/1-2")
     ['Ethernet1/1', 'Ethernet1/2']
     """
-    normalized = _normalize_interface_prefixes(name)
-    return _expand_normalized_pattern(normalized, max_range_size)
-
-
-def _validate_interface_range(v: str) -> list[str]:
-    """Expand interface range pattern to list of interface names.
-
-    Pipeline: normalize prefixes → expand ranges → return list of interface names.
-    Uses expand_interface_pattern internally.
-
-    Examples
-    --------
-    >>> _validate_interface_range("Ethernet1-3")
-    ['Ethernet1', 'Ethernet2', 'Ethernet3']
-    >>> _validate_interface_range("et1,5")
-    ['Ethernet1', 'Ethernet5']
-    """
-    return expand_interface_pattern(v)
+    return validate_interface_range(name, max_range_size)
 
 
 # AntaTest.Input types
@@ -585,4 +587,4 @@ ReloadCause = Annotated[
 BgpCommunity = Literal["standard", "extended", "large"]
 DropPrecedence = Literal["DP0", "DP1", "DP2"]
 ModuleStatus = Literal["failed", "disabledUntilSystemUpgrade", "ok", "poweredOff", "active", "disabled", "upgradingFpga", "poweringOn", "unknown", "standby"]
-InterfaceRange = Annotated[list[str], BeforeValidator(_validate_interface_range)]
+InterfaceRange = Annotated[list[str], BeforeValidator(validate_interface_range)]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -278,56 +278,53 @@ def normalize_interface_prefixes(pattern: str) -> str:
     return ",".join(result)
 
 
+_INTERFACE_RANGE_RE = re.compile(
+    r"(?P<prefix>[A-Za-z]+(?:-[A-Za-z]+)*)?"
+    r"(?P<slots>(?:\d+/)*)"
+    r"(?P<port>\d+)"
+    r"(?:\.(?P<sub_start>\d+)(?:-(?P<sub_end>\d+))?"
+    r"|(?!/)(?:-(?P<port_end>\d+))?)?"
+)
+
+
+def _validate_range(start: int, end: int, pattern: str, max_range_size: int) -> None:
+    """Raise ValueError if the range is reversed or exceeds max_range_size."""
+    if end < start:
+        msg = f"Reverse range not supported: {pattern} (start {start} > end {end})"
+        raise ValueError(msg)
+    if (range_size := end - start + 1) > max_range_size:
+        msg = f"Range too large (>{max_range_size}): {pattern} ({range_size} items)"
+        raise ValueError(msg)
+
+
 def expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> list[str]:
     """Expand a normalized pattern into individual interface names.
 
     Handles ranges (1-3), slots (1/1-2), and sub-interfaces (1.10-15). Assumes abbreviations are already resolved.
     """
-    pattern = re.compile(
-        r"(?P<prefix>[A-Za-z]+(?:-[A-Za-z]+)*)?"
-        r"(?P<slots>(?:\d+/)*)"
-        r"(?P<port>\d+)"
-        r"(?:\.(?P<sub_start>\d+)(?:-(?P<sub_end>\d+))?"
-        r"|(?!/)(?:-(?P<port_end>\d+))?)?"
-    )
     prefix = None
     expanded = []
 
     for part in normalized.split(","):
-        match = pattern.fullmatch(part.strip())
+        match = _INTERFACE_RANGE_RE.fullmatch(part.strip())
         if not match:
             msg = f"Invalid interface pattern: {normalized}"
             raise ValueError(msg)
 
-        match_prefix = match.group("prefix")
-        slots = match.group("slots")
-        port = match.group("port")
-        sub_start = match.group("sub_start")
-        sub_end = match.group("sub_end")
-        port_end = match.group("port_end")
-
-        prefix = match_prefix or prefix
+        prefix = match.group("prefix") or prefix
         if not prefix:
             msg = f"Invalid interface pattern: {normalized}"
             raise ValueError(msg)
 
+        slots, port, sub_start = match.group("slots"), match.group("port"), match.group("sub_start")
+
         if sub_start is not None:
-            start, end = int(sub_start), int(sub_end or sub_start)
-            if end < start:
-                msg = f"Reverse range not supported: {normalized} (start {start} > end {end})"
-                raise ValueError(msg)
-            if (range_size := end - start + 1) > max_range_size:
-                msg = f"Range too large (>{max_range_size}): {normalized} ({range_size} items)"
-                raise ValueError(msg)
+            start, end = int(sub_start), int(match.group("sub_end") or sub_start)
+            _validate_range(start, end, normalized, max_range_size)
             expanded.extend(f"{prefix}{slots}{port}.{sub}" for sub in range(start, end + 1))
         else:
-            start, end = int(port), int(port_end or port)
-            if end < start:
-                msg = f"Reverse range not supported: {normalized} (start {start} > end {end})"
-                raise ValueError(msg)
-            if (range_size := end - start + 1) > max_range_size:
-                msg = f"Range too large (>{max_range_size}): {normalized} ({range_size} items)"
-                raise ValueError(msg)
+            start, end = int(port), int(match.group("port_end") or port)
+            _validate_range(start, end, normalized, max_range_size)
             expanded.extend(f"{prefix}{slots}{p}" for p in range(start, end + 1))
 
     return expanded

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -50,6 +50,15 @@ _INTERFACE_ALIAS_MAP: dict[str, str] = {
 }
 """Mapping of interface abbreviations to their full EOS names."""
 
+_INTERFACE_RANGE_RE = re.compile(
+    r"(?P<prefix>[A-Za-z]+(?:-[A-Za-z]+)*)?"
+    r"(?P<slots>(?:\d+/)*)"
+    r"(?P<port>\d+)"
+    r"(?:\.(?P<sub_start>\d+)(?:-(?P<sub_end>\d+))?"
+    r"|(?!/)(?:-(?P<port_end>\d+))?)?"
+)
+"""Regex to parse a single interface segment: optional prefix, optional slots, port, and optional range."""
+
 
 def interface_autocomplete(v: str) -> str:
     """Allow the user to only provide the beginning of an interface name.
@@ -295,15 +304,6 @@ def normalize_interface_prefixes(pattern: str) -> str:
             part = full_prefix + remainder
         result.append(part)
     return ",".join(result)
-
-
-_INTERFACE_RANGE_RE = re.compile(
-    r"(?P<prefix>[A-Za-z]+(?:-[A-Za-z]+)*)?"
-    r"(?P<slots>(?:\d+/)*)"
-    r"(?P<port>\d+)"
-    r"(?:\.(?P<sub_start>\d+)(?:-(?P<sub_end>\d+))?"
-    r"|(?!/)(?:-(?P<port_end>\d+))?)?"
-)
 
 
 def _validate_range(start: int, end: int, pattern: str, max_range_size: int) -> None:
@@ -622,4 +622,4 @@ ReloadCause = Annotated[
 BgpCommunity = Literal["standard", "extended", "large"]
 DropPrecedence = Literal["DP0", "DP1", "DP2"]
 ModuleStatus = Literal["failed", "disabledUntilSystemUpgrade", "ok", "poweredOff", "active", "disabled", "upgradingFpga", "poweringOn", "unknown", "standby"]
-InterfaceRange = Annotated[list[Interface], BeforeValidator(expand_interface_range)]
+InterfaceRange = list[Interface]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -257,7 +257,19 @@ def update_ipv4_route_type(value: str) -> str:
 
 
 def expand_interface_abbreviation(interface_name: str) -> str:
-    """Expand interface abbreviations, supporting ranges (et1-3→Ethernet1-3, po1-2→Port-Channel1-2)."""
+    """Expand interface abbreviations (et→Ethernet, po→Port-Channel, lo→Loopback, vl→Vlan, eth→Ethernet).
+
+    Examples
+    --------
+    >>> expand_interface_abbreviation("et1")
+    'Ethernet1'
+    >>> expand_interface_abbreviation("po1-2")
+    'Port-Channel1-2'
+    >>> expand_interface_abbreviation("lo0")
+    'Loopback0'
+    >>> expand_interface_abbreviation("Ethernet1")
+    'Ethernet1'
+    """
     alias_map = {
         "eth": "Ethernet",
         "po": "Port-Channel",
@@ -271,6 +283,52 @@ def expand_interface_abbreviation(interface_name: str) -> str:
             if remainder and remainder[0].isdigit():
                 return f"{full_name}{remainder}"
     return interface_name
+
+
+def expand_interface_pattern(name: str, max_range_size: int = 1000) -> list[str]:
+    """Expand comma-separated interface pattern to individual interface names.
+
+    Supports abbreviations (et→Ethernet), ranges (1-3→1,2,3), and multi-level slots (1/1-2→1/1,1/2).
+    For comma-separated patterns, items can omit prefix to reuse the previous one.
+
+    Examples
+    --------
+    >>> expand_interface_pattern("Ethernet1-3")
+    ['Ethernet1', 'Ethernet2', 'Ethernet3']
+    >>> expand_interface_pattern("et1,5")
+    ['Ethernet1', 'Ethernet5']
+    >>> expand_interface_pattern("Ethernet1/1-2")
+    ['Ethernet1/1', 'Ethernet1/2']
+    """
+    pattern = re.compile(r"([A-Za-z]+(?:-[A-Za-z]+)*)?((?:\d+/)*)(\d+)(?:-(\d+))?")
+    prefix = None
+    expanded = []
+
+    for part in name.split(","):
+        match = pattern.fullmatch(expand_interface_abbreviation(part.strip()))
+        if match is None:
+            msg = f"Invalid interface pattern: {name}"
+            raise ValueError(msg)
+
+        part_prefix, slot, start_value, end_value = match.groups()
+        prefix = part_prefix or prefix
+        if prefix is None:
+            msg = f"Invalid interface pattern: {name}"
+            raise ValueError(msg)
+
+        start = int(start_value)
+        end = int(end_value) if end_value else start
+        range_size = end - start + 1
+        if range_size <= 0:
+            msg = f"Reverse range not supported: {name} (start {start} > end {end})"
+            raise ValueError(msg)
+        if range_size > max_range_size:
+            msg = f"Range too large (>{max_range_size}): {name} ({range_size} items)"
+            raise ValueError(msg)
+
+        expanded.extend(f"{prefix}{slot}{port}" for port in range(start, end + 1))
+
+    return expanded
 
 
 # AntaTest.Input types

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -622,4 +622,17 @@ ReloadCause = Annotated[
 BgpCommunity = Literal["standard", "extended", "large"]
 DropPrecedence = Literal["DP0", "DP1", "DP2"]
 ModuleStatus = Literal["failed", "disabledUntilSystemUpgrade", "ok", "poweredOff", "active", "disabled", "upgradingFpga", "poweringOn", "unknown", "standby"]
-InterfaceRange = list[Interface]
+
+
+def _expand_for_range(v: object) -> object:
+    """Expand a range string to a list; raise ValueError for single-interface strings to allow union fallback to Interface."""
+    if isinstance(v, str):
+        expanded = expand_interface_range(v)
+        if len(expanded) <= 1:
+            msg = f"Not a range pattern: '{v}'"
+            raise ValueError(msg)
+        return expanded
+    return v
+
+
+InterfaceRange = Annotated[list[Interface], BeforeValidator(_expand_for_range)]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -256,33 +256,58 @@ def update_ipv4_route_type(value: str) -> str:
     return route_types[value]
 
 
-def expand_interface_abbreviation(interface_name: str) -> str:
-    """Expand interface abbreviations (et→Ethernet, po→Port-Channel, lo→Loopback, vl→Vlan, eth→Ethernet).
+def _normalize_interface_prefixes(pattern: str) -> str:
+    """Normalize all interface abbreviations in pattern string using interface_autocomplete.
 
-    Examples
-    --------
-    >>> expand_interface_abbreviation("et1")
-    'Ethernet1'
-    >>> expand_interface_abbreviation("po1-2")
-    'Port-Channel1-2'
-    >>> expand_interface_abbreviation("lo0")
-    'Loopback0'
-    >>> expand_interface_abbreviation("Ethernet1")
-    'Ethernet1'
+    E.g., 'et1-3,po2' → 'Ethernet1-3,Port-Channel2'
     """
-    alias_map = {
-        "eth": "Ethernet",
-        "po": "Port-Channel",
-        "lo": "Loopback",
-        "vl": "Vlan",
-        "et": "Ethernet",
-    }
-    for alias, full_name in alias_map.items():
-        if interface_name.lower().startswith(alias):
-            remainder = interface_name[len(alias) :]
-            if remainder and remainder[0].isdigit():
-                return f"{full_name}{remainder}"
-    return interface_name
+    result = []
+    for part_raw in pattern.split(","):
+        part = part_raw.strip()
+        digit_idx = next((i for i, c in enumerate(part) if c.isdigit()), len(part))
+        if digit_idx > 0:
+            try:
+                normalized = interface_autocomplete(part[:digit_idx] + "1")
+                part = normalized[:-1] + part[digit_idx:]
+            except ValueError:
+                pass
+        result.append(part)
+    return ",".join(result)
+
+
+def _expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> list[str]:
+    """Expand normalized (prefix-expanded) pattern into individual interface names.
+
+    Assumes all abbreviations have been normalized (e.g., 'et' → 'Ethernet').
+    Handles range expansion (1-3 → 1,2,3) and multi-level slots (1/1-2 → 1/1,1/2).
+    """
+    pattern = re.compile(r"([A-Za-z]+(?:-[A-Za-z]+)*)?((?:\d+/)*)(\d+)(?!/)(?:-(\d+))?")
+    prefix = None
+    expanded = []
+
+    for part in normalized.split(","):
+        match = pattern.fullmatch(part.strip())
+        if not match:
+            msg = f"Invalid interface pattern: {normalized}"
+            raise ValueError(msg)
+
+        match_prefix, slot, start_str, end_str = match.groups()
+        prefix = match_prefix or prefix
+        if not prefix:
+            msg = f"Invalid interface pattern: {normalized}"
+            raise ValueError(msg)
+
+        start, end = int(start_str), int(end_str or start_str)
+        if end < start:
+            msg = f"Reverse range not supported: {normalized} (start {start} > end {end})"
+            raise ValueError(msg)
+        if (range_size := end - start + 1) > max_range_size:
+            msg = f"Range too large (>{max_range_size}): {normalized} ({range_size} items)"
+            raise ValueError(msg)
+
+        expanded.extend(f"{prefix}{slot}{port}" for port in range(start, end + 1))
+
+    return expanded
 
 
 def expand_interface_pattern(name: str, max_range_size: int = 1000) -> list[str]:
@@ -300,45 +325,21 @@ def expand_interface_pattern(name: str, max_range_size: int = 1000) -> list[str]
     >>> expand_interface_pattern("Ethernet1/1-2")
     ['Ethernet1/1', 'Ethernet1/2']
     """
-    pattern = re.compile(r"([A-Za-z]+(?:-[A-Za-z]+)*)?((?:\d+/)*)(\d+)(?:-(\d+))?")
-    prefix = None
-    expanded = []
-
-    for part in name.split(","):
-        match = pattern.fullmatch(expand_interface_abbreviation(part.strip()))
-        if match is None:
-            msg = f"Invalid interface pattern: {name}"
-            raise ValueError(msg)
-
-        part_prefix, slot, start_value, end_value = match.groups()
-        prefix = part_prefix or prefix
-        if prefix is None:
-            msg = f"Invalid interface pattern: {name}"
-            raise ValueError(msg)
-
-        start = int(start_value)
-        end = int(end_value) if end_value else start
-        range_size = end - start + 1
-        if range_size <= 0:
-            msg = f"Reverse range not supported: {name} (start {start} > end {end})"
-            raise ValueError(msg)
-        if range_size > max_range_size:
-            msg = f"Range too large (>{max_range_size}): {name} ({range_size} items)"
-            raise ValueError(msg)
-
-        expanded.extend(f"{prefix}{slot}{port}" for port in range(start, end + 1))
-
-    return expanded
+    normalized = _normalize_interface_prefixes(name)
+    return _expand_normalized_pattern(normalized, max_range_size)
 
 
 def _validate_interface_range(v: str) -> list[str]:
     """Expand interface range pattern to list of interface names.
 
+    Pipeline: normalize prefixes → expand ranges → return list of interface names.
+    Uses expand_interface_pattern internally.
+
     Examples
     --------
     >>> _validate_interface_range("Ethernet1-3")
     ['Ethernet1', 'Ethernet2', 'Ethernet3']
-    >>> _validate_interface_range("Ethernet1,5")
+    >>> _validate_interface_range("et1,5")
     ['Ethernet1', 'Ethernet5']
     """
     return expand_interface_pattern(v)

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -256,6 +256,23 @@ def update_ipv4_route_type(value: str) -> str:
     return route_types[value]
 
 
+def expand_interface_abbreviation(interface_name: str) -> str:
+    """Expand interface abbreviations, supporting ranges (et1-3→Ethernet1-3, po1-2→Port-Channel1-2)."""
+    alias_map = {
+        "eth": "Ethernet",
+        "po": "Port-Channel",
+        "lo": "Loopback",
+        "vl": "Vlan",
+        "et": "Ethernet",
+    }
+    for alias, full_name in alias_map.items():
+        if interface_name.lower().startswith(alias):
+            remainder = interface_name[len(alias) :]
+            if remainder and remainder[0].isdigit():
+                return f"{full_name}{remainder}"
+    return interface_name
+
+
 # AntaTest.Input types
 AAAAuthMethod = Annotated[str, AfterValidator(aaa_group_prefix)]
 VlanId = Annotated[int, Field(ge=0, le=4094)]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -41,13 +41,24 @@ def aaa_group_prefix(v: str) -> str:
     return f"group {v}" if v not in built_in_methods and not v.startswith("group ") else v
 
 
+_INTERFACE_ALIAS_MAP: dict[str, str] = {
+    "et": "Ethernet",
+    "eth": "Ethernet",
+    "po": "Port-Channel",
+    "lo": "Loopback",
+    "vl": "Vlan",
+}
+"""Mapping of interface abbreviations to their full EOS names."""
+
+
 def interface_autocomplete(v: str) -> str:
     """Allow the user to only provide the beginning of an interface name.
 
-    Supported alias:
-         - `et`, `eth` will be changed to `Ethernet`
-         - `po` will be changed to `Port-Channel`
+    Supported aliases:
+    - `et`, `eth` will be changed to `Ethernet`
+    - `po` will be changed to `Port-Channel`
     - `lo` will be changed to `Loopback`
+    - `vl` will be changed to `Vlan`
     """
     intf_id_re = re.compile(REGEXP_INTERFACE_ID)
     m = intf_id_re.search(v)
@@ -56,9 +67,7 @@ def interface_autocomplete(v: str) -> str:
         raise ValueError(msg)
     intf_id = m[0]
 
-    alias_map = {"et": "Ethernet", "eth": "Ethernet", "po": "Port-Channel", "lo": "Loopback", "vl": "Vlan"}
-
-    return next((f"{full_name}{intf_id}" for alias, full_name in alias_map.items() if v.lower().startswith(alias)), v)
+    return next((f"{full_name}{intf_id}" for alias, full_name in _INTERFACE_ALIAS_MAP.items() if v.lower().startswith(alias)), v)
 
 
 def interface_case_sensitivity(v: str) -> str:
@@ -257,31 +266,30 @@ def update_ipv4_route_type(value: str) -> str:
 
 
 def normalize_interface_prefixes(pattern: str) -> str:
-    """Normalize all interface abbreviations in pattern string using interface_autocomplete.
-
-    E.g., 'et1-3,po2' → 'Ethernet1-3,Port-Channel2'
-    """
+    """Normalize interface abbreviations in a comma-separated pattern. E.g., 'et1-3,po2' → 'Ethernet1-3,Port-Channel2'."""
     result = []
     for part_raw in pattern.split(","):
         part = part_raw.strip()
         digit_idx = next((i for i, c in enumerate(part) if c.isdigit()), len(part))
         if digit_idx > 0:
-            try:
-                normalized = interface_autocomplete(part[:digit_idx] + "1")
-                part = normalized[:-1] + part[digit_idx:]
-            except ValueError:
-                pass
+            raw_prefix = part[:digit_idx]
+            part = _INTERFACE_ALIAS_MAP.get(raw_prefix.lower(), raw_prefix) + part[digit_idx:]
         result.append(part)
     return ",".join(result)
 
 
 def expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> list[str]:
-    """Expand normalized (prefix-expanded) pattern into individual interface names.
+    """Expand a normalized pattern into individual interface names.
 
-    Assumes all abbreviations have been normalized (e.g., 'et' → 'Ethernet').
-    Handles range expansion (1-3 → 1,2,3) and multi-level slots (1/1-2 → 1/1,1/2).
+    Handles ranges (1-3), slots (1/1-2), and sub-interfaces (1.10-15). Assumes abbreviations are already resolved.
     """
-    pattern = re.compile(r"([A-Za-z]+(?:-[A-Za-z]+)*)?((?:\d+/)*)(\d+)(?!/)(?:-(\d+))?")
+    pattern = re.compile(
+        r"(?P<prefix>[A-Za-z]+(?:-[A-Za-z]+)*)?"
+        r"(?P<slots>(?:\d+/)*)"
+        r"(?P<port>\d+)"
+        r"(?:\.(?P<sub_start>\d+)(?:-(?P<sub_end>\d+))?"
+        r"|(?!/)(?:-(?P<port_end>\d+))?)?"
+    )
     prefix = None
     expanded = []
 
@@ -291,60 +299,55 @@ def expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> li
             msg = f"Invalid interface pattern: {normalized}"
             raise ValueError(msg)
 
-        match_prefix, slot, start_str, end_str = match.groups()
+        match_prefix = match.group("prefix")
+        slots = match.group("slots")
+        port = match.group("port")
+        sub_start = match.group("sub_start")
+        sub_end = match.group("sub_end")
+        port_end = match.group("port_end")
+
         prefix = match_prefix or prefix
         if not prefix:
             msg = f"Invalid interface pattern: {normalized}"
             raise ValueError(msg)
 
-        start, end = int(start_str), int(end_str or start_str)
-        if end < start:
-            msg = f"Reverse range not supported: {normalized} (start {start} > end {end})"
-            raise ValueError(msg)
-        if (range_size := end - start + 1) > max_range_size:
-            msg = f"Range too large (>{max_range_size}): {normalized} ({range_size} items)"
-            raise ValueError(msg)
-
-        expanded.extend(f"{prefix}{slot}{port}" for port in range(start, end + 1))
+        if sub_start is not None:
+            start, end = int(sub_start), int(sub_end or sub_start)
+            if end < start:
+                msg = f"Reverse range not supported: {normalized} (start {start} > end {end})"
+                raise ValueError(msg)
+            if (range_size := end - start + 1) > max_range_size:
+                msg = f"Range too large (>{max_range_size}): {normalized} ({range_size} items)"
+                raise ValueError(msg)
+            expanded.extend(f"{prefix}{slots}{port}.{sub}" for sub in range(start, end + 1))
+        else:
+            start, end = int(port), int(port_end or port)
+            if end < start:
+                msg = f"Reverse range not supported: {normalized} (start {start} > end {end})"
+                raise ValueError(msg)
+            if (range_size := end - start + 1) > max_range_size:
+                msg = f"Range too large (>{max_range_size}): {normalized} ({range_size} items)"
+                raise ValueError(msg)
+            expanded.extend(f"{prefix}{slots}{p}" for p in range(start, end + 1))
 
     return expanded
 
 
-def validate_interface_range(v: str, max_range_size: int = 1000) -> list[str]:
-    """Validate and expand interface range pattern to list of interface names.
+def expand_interface_range(v: str, max_range_size: int = 1000) -> list[str]:
+    """Expand an interface range pattern into individual interface names.
 
-    Supports abbreviations (et→Ethernet), ranges (1-3→1,2,3), and multi-level slots (1/1-2→1/1,1/2).
-    For comma-separated patterns, items can omit prefix to reuse the previous one.
+    Supports abbreviations (et→Ethernet), ranges (Ethernet1-3), slots (Ethernet1/1-2),
+    sub-interface ranges (Ethernet1.10-15), and comma-separated patterns with prefix reuse.
 
     Examples
     --------
-    >>> validate_interface_range("Ethernet1-3")
+    >>> expand_interface_range("Ethernet1-3")
     ['Ethernet1', 'Ethernet2', 'Ethernet3']
-    >>> validate_interface_range("et1,5")
-    ['Ethernet1', 'Ethernet5']
-    >>> validate_interface_range("Ethernet1/1-2")
-    ['Ethernet1/1', 'Ethernet1/2']
+    >>> expand_interface_range("Ethernet1.10-12")
+    ['Ethernet1.10', 'Ethernet1.11', 'Ethernet1.12']
     """
     normalized = normalize_interface_prefixes(v)
     return expand_normalized_pattern(normalized, max_range_size)
-
-
-def expand_interface_pattern(name: str, max_range_size: int = 1000) -> list[str]:
-    """Expand comma-separated interface pattern to individual interface names.
-
-    Supports abbreviations (et→Ethernet), ranges (1-3→1,2,3), and multi-level slots (1/1-2→1/1,1/2).
-    For comma-separated patterns, items can omit prefix to reuse the previous one.
-
-    Examples
-    --------
-    >>> expand_interface_pattern("Ethernet1-3")
-    ['Ethernet1', 'Ethernet2', 'Ethernet3']
-    >>> expand_interface_pattern("et1,5")
-    ['Ethernet1', 'Ethernet5']
-    >>> expand_interface_pattern("Ethernet1/1-2")
-    ['Ethernet1/1', 'Ethernet1/2']
-    """
-    return validate_interface_range(name, max_range_size)
 
 
 # AntaTest.Input types
@@ -587,4 +590,4 @@ ReloadCause = Annotated[
 BgpCommunity = Literal["standard", "extended", "large"]
 DropPrecedence = Literal["DP0", "DP1", "DP2"]
 ModuleStatus = Literal["failed", "disabledUntilSystemUpgrade", "ok", "poweredOff", "active", "disabled", "upgradingFpga", "poweringOn", "unknown", "standby"]
-InterfaceRange = Annotated[list[str], BeforeValidator(validate_interface_range)]
+InterfaceRange = Annotated[list[str], BeforeValidator(expand_interface_range)]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -61,11 +61,15 @@ def interface_autocomplete(v: str) -> str:
     - `vl` will be changed to `Vlan`
     """
     intf_id_re = re.compile(REGEXP_INTERFACE_ID)
-    m = intf_id_re.search(v)
-    if m is None:
+    try:
+        match = intf_id_re.search(v)
+    except TypeError as e:
+        msg = f"Expected str, got {type(v).__name__}"
+        raise ValueError(msg) from e
+    if match is None:
         msg = f"Could not parse interface ID in interface '{v}'"
         raise ValueError(msg)
-    intf_id = m[0]
+    intf_id = match[0]
 
     return next((f"{full_name}{intf_id}" for alias, full_name in _INTERFACE_ALIAS_MAP.items() if v.lower().startswith(alias)), v)
 
@@ -330,11 +334,12 @@ def expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> li
     return expanded
 
 
-def expand_interface_range(v: str, max_range_size: int = 1000) -> list[str]:
+def expand_interface_range(v: str | list[str], max_range_size: int = 1000) -> list[str]:
     """Expand an interface range pattern into individual interface names.
 
     Supports abbreviations (et→Ethernet), ranges (Ethernet1-3), slots (Ethernet1/1-2),
     sub-interface ranges (Ethernet1.10-15), and comma-separated patterns with prefix reuse.
+    An already-expanded list is returned unchanged.
 
     Examples
     --------
@@ -342,7 +347,11 @@ def expand_interface_range(v: str, max_range_size: int = 1000) -> list[str]:
     ['Ethernet1', 'Ethernet2', 'Ethernet3']
     >>> expand_interface_range("Ethernet1.10-12")
     ['Ethernet1.10', 'Ethernet1.11', 'Ethernet1.12']
+    >>> expand_interface_range(["Ethernet1", "Ethernet2"])
+    ['Ethernet1', 'Ethernet2']
     """
+    if isinstance(v, list):
+        return v
     normalized = normalize_interface_prefixes(v)
     return expand_normalized_pattern(normalized, max_range_size)
 
@@ -587,4 +596,4 @@ ReloadCause = Annotated[
 BgpCommunity = Literal["standard", "extended", "large"]
 DropPrecedence = Literal["DP0", "DP1", "DP2"]
 ModuleStatus = Literal["failed", "disabledUntilSystemUpgrade", "ok", "poweredOff", "active", "disabled", "upgradingFpga", "poweringOn", "unknown", "standby"]
-InterfaceRange = Annotated[list[str], BeforeValidator(expand_interface_range)]
+InterfaceRange = Annotated[list[Interface], BeforeValidator(expand_interface_range)]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -331,6 +331,19 @@ def expand_interface_pattern(name: str, max_range_size: int = 1000) -> list[str]
     return expanded
 
 
+def _validate_interface_range(v: str) -> list[str]:
+    """Expand interface range pattern to list of interface names.
+
+    Examples
+    --------
+    >>> _validate_interface_range("Ethernet1-3")
+    ['Ethernet1', 'Ethernet2', 'Ethernet3']
+    >>> _validate_interface_range("Ethernet1,5")
+    ['Ethernet1', 'Ethernet5']
+    """
+    return expand_interface_pattern(v)
+
+
 # AntaTest.Input types
 AAAAuthMethod = Annotated[str, AfterValidator(aaa_group_prefix)]
 VlanId = Annotated[int, Field(ge=0, le=4094)]
@@ -571,3 +584,4 @@ ReloadCause = Annotated[
 BgpCommunity = Literal["standard", "extended", "large"]
 DropPrecedence = Literal["DP0", "DP1", "DP2"]
 ModuleStatus = Literal["failed", "disabledUntilSystemUpgrade", "ok", "poweredOff", "active", "disabled", "upgradingFpga", "poweringOn", "unknown", "standby"]
+InterfaceRange = Annotated[list[str], BeforeValidator(_validate_interface_range)]

--- a/anta/custom_types.py
+++ b/anta/custom_types.py
@@ -61,6 +61,7 @@ def interface_autocomplete(v: str) -> str:
     - `vl` will be changed to `Vlan`
     """
     intf_id_re = re.compile(REGEXP_INTERFACE_ID)
+    # TypeError means v is not a str (e.g., Pydantic passing non-str during union validation)
     try:
         match = intf_id_re.search(v)
     except TypeError as e:
@@ -69,8 +70,10 @@ def interface_autocomplete(v: str) -> str:
     if match is None:
         msg = f"Could not parse interface ID in interface '{v}'"
         raise ValueError(msg)
+    # Extract the numeric ID portion, e.g., '1/1' from 'eth1/1'
     intf_id = match[0]
 
+    # Return full interface name if prefix matches an alias, else return original unchanged
     return next((f"{full_name}{intf_id}" for alias, full_name in _INTERFACE_ALIAS_MAP.items() if v.lower().startswith(alias)), v)
 
 
@@ -274,10 +277,22 @@ def normalize_interface_prefixes(pattern: str) -> str:
     result = []
     for part_raw in pattern.split(","):
         part = part_raw.strip()
+        # Find index where the alpha prefix ends and digits begin
         digit_idx = next((i for i, c in enumerate(part) if c.isdigit()), len(part))
         if digit_idx > 0:
             raw_prefix = part[:digit_idx]
-            part = _INTERFACE_ALIAS_MAP.get(raw_prefix.lower(), raw_prefix) + part[digit_idx:]
+            # Expand alias to full name, or keep as-is if unrecognized
+            full_prefix = _INTERFACE_ALIAS_MAP.get(raw_prefix.lower(), raw_prefix)
+            remainder = part[digit_idx:]
+            # Strip repeated prefix from range end: 'eth1-eth3' → 'Ethernet1-3'
+            if "-" in remainder:
+                dash_idx = remainder.index("-")
+                end_part = remainder[dash_idx + 1 :]
+                end_digit_idx = next((i for i, c in enumerate(end_part) if c.isdigit()), len(end_part))
+                # Only strip if the range end starts with the same raw prefix (e.g., 'eth' in 'eth1-eth3')
+                if end_digit_idx > 0 and end_part[:end_digit_idx].lower() == raw_prefix.lower():
+                    remainder = remainder[: dash_idx + 1] + end_part[end_digit_idx:]
+            part = full_prefix + remainder
         result.append(part)
     return ",".join(result)
 
@@ -306,7 +321,9 @@ def expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> li
 
     Handles ranges (1-3), slots (1/1-2), and sub-interfaces (1.10-15). Assumes abbreviations are already resolved.
     """
+    # Prefix and slots are carried across comma segments: 'Ethernet1/1,2' reuses 'Ethernet' and '1/' for '2'
     prefix = None
+    prev_slots = ""
     expanded = []
 
     for part in normalized.split(","):
@@ -315,18 +332,25 @@ def expand_normalized_pattern(normalized: str, max_range_size: int = 1000) -> li
             msg = f"Invalid interface pattern: {normalized}"
             raise ValueError(msg)
 
+        # Inherit prefix from previous segment if this segment omits it
         prefix = match.group("prefix") or prefix
         if not prefix:
             msg = f"Invalid interface pattern: {normalized}"
             raise ValueError(msg)
 
-        slots, port, sub_start = match.group("slots"), match.group("port"), match.group("sub_start")
+        # Inherit slots from previous segment if this segment omits them (e.g., '5' in 'Ethernet1/1-3,5')
+        slots = match.group("slots") or prev_slots
+        prev_slots = slots
+
+        port, sub_start = match.group("port"), match.group("sub_start")
 
         if sub_start is not None:
+            # Sub-interface range: Ethernet1.10-15 → Ethernet1.10, Ethernet1.11, ...
             start, end = int(sub_start), int(match.group("sub_end") or sub_start)
             _validate_range(start, end, normalized, max_range_size)
             expanded.extend(f"{prefix}{slots}{port}.{sub}" for sub in range(start, end + 1))
         else:
+            # Port range: Ethernet1-3 or Ethernet1/1-2 → individual port names
             start, end = int(port), int(match.group("port_end") or port)
             _validate_range(start, end, normalized, max_range_size)
             expanded.extend(f"{prefix}{slots}{p}" for p in range(start, end + 1))
@@ -350,8 +374,10 @@ def expand_interface_range(v: str | list[str], max_range_size: int = 1000) -> li
     >>> expand_interface_range(["Ethernet1", "Ethernet2"])
     ['Ethernet1', 'Ethernet2']
     """
+    # Pre-expanded list passes through; each element will be validated individually by Interface validators
     if isinstance(v, list):
         return v
+    # Resolve aliases and strip repeated prefixes before expanding
     normalized = normalize_interface_prefixes(v)
     return expand_normalized_pattern(normalized, max_range_size)
 

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -6,12 +6,24 @@
 from __future__ import annotations
 
 from ipaddress import IPv4Interface
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from warnings import warn
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
-from anta.custom_types import Interface, InterfaceRange, PortChannelInterface
+from anta.custom_types import Interface, PortChannelInterface, expand_interface_range
+
+
+def _resolve_interface_name(name: object) -> object:
+    """Return an expanded list for range patterns, or the original value for single interfaces."""
+    if isinstance(name, str):
+        try:
+            expanded = expand_interface_range(name)
+            if len(expanded) > 1:
+                return expanded
+        except ValueError:
+            pass
+    return name
 
 
 class InterfaceState(BaseModel):
@@ -21,10 +33,11 @@ class InterfaceState(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
-    name: Interface | None = None
-    """Interface to validate. Either name or interface_range must be provided."""
-    interface_range: InterfaceRange | None = None
-    """Interface range pattern (e.g., 'Ethernet1-3', 'et1-3'). Expands to list of interface names. Used in `VerifyInterfacesTransceiverType` test."""
+    name: Annotated[list[str] | Interface, BeforeValidator(_resolve_interface_name)]
+    """Interface name or range pattern (e.g., 'Ethernet1', 'Ethernet1-3', 'et1-3').
+
+    A range pattern expands to a list of interface names when used in `VerifyInterfacesTransceiverType`.
+    """
     description: str | None = None
     """Optional metadata describing the interface. Used for reporting."""
     status: Literal["up", "down", "adminDown"] | None = None
@@ -57,16 +70,18 @@ class InterfaceState(BaseModel):
     media_type: str | None = None
     """Expected transceiver media type (e.g., '100GBASE-SR4'). Required for the `VerifyInterfacesTransceiverType` test."""
 
-    @model_validator(mode="after")
-    def validate_inputs(self) -> InterfaceState:
-        """Validate that either name or interface_range is provided, not both."""
-        if self.name is None and self.interface_range is None:
-            msg = "Either 'name' or 'interface_range' must be provided."
-            raise ValueError(msg)
-        if self.name is not None and self.interface_range is not None:
-            msg = "Only one of 'name' or 'interface_range' can be provided, not both."
-            raise ValueError(msg)
-        return self
+    def expand(self) -> list[InterfaceState]:
+        """Return one InterfaceState per interface name, expanding range names into individual entries.
+
+        Examples
+        --------
+        >>> interface = InterfaceState(name="Ethernet1-3", media_type="100GBASE-SR4")
+        >>> [entry.name for entry in interface.expand()]
+        ['Ethernet1', 'Ethernet2', 'Ethernet3']
+        """
+        if isinstance(self.name, list):
+            return [self.model_copy(update={"name": interface_name}) for interface_name in self.name]
+        return [self]
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the InterfaceState for reporting.

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -5,13 +5,14 @@
 
 from __future__ import annotations
 
+import re
 from ipaddress import IPv4Interface
 from typing import Any, Literal
 from warnings import warn
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from anta.custom_types import Interface, PortChannelInterface
+from anta.custom_types import Interface, PortChannelInterface, expand_interface_abbreviation
 
 
 class InterfaceState(BaseModel):
@@ -85,3 +86,75 @@ class InterfaceDetail(InterfaceState):  # pragma: no cover
             stacklevel=2,
         )
         super().__init__(**data)
+
+
+class InterfacesTransceiverType(BaseModel):
+    """Interface pattern with expected transceiver media type; validates and pre-expands at catalog-load."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    """Interface pattern (e.g., 'Ethernet1-3', 'et1-3', 'Ethernet4,6'). Expanded via range expansion and abbreviations."""
+    media_type: str
+    """Expected transceiver media type (e.g., '100GBASE-SR4', '40GBASE-SR4', '25GBASE-LR')."""
+    expanded_names: list[str] = Field(default_factory=list, init=False)
+    """Pre-expanded interface names from pattern; populated after validation."""
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def expand_interface_abbreviation(cls, interface_name: str) -> str:
+        """Expand abbreviations (et→Ethernet, po→Port-Channel, lo→Loopback, vl→Vlan, eth→Ethernet)."""
+        return expand_interface_abbreviation(interface_name)
+
+    @model_validator(mode="after")
+    def validate_and_expand_pattern(self) -> InterfacesTransceiverType:
+        """Validate pattern syntax (no reverse ranges, oversized ranges >1000) and expand ranges to individual interfaces."""
+        range_pattern = re.compile(r"^([\d/]*?)(\d+)-(\d+)$")
+        max_range_size = 1000
+        current_prefix = None
+        expanded = []
+
+        for part in self.name.split(","):
+            part_str = part.strip()
+            if not part_str:
+                continue
+
+            # Extract prefix (Ethernet, Port-Channel, etc)
+            match = re.match(r"^([a-zA-Z]+(?:-[a-zA-Z]+)*)", part_str)
+            if match:
+                current_prefix = match.group(1)
+                remainder = part_str[len(current_prefix) :]
+            else:
+                if current_prefix is None:
+                    msg = f"Invalid interface pattern: {self.name}"
+                    raise ValueError(msg)
+                remainder = part_str
+
+            if not remainder or not remainder[0].isdigit():
+                msg = f"Invalid interface pattern: {self.name}"
+                raise ValueError(msg)
+
+            # Single port or range
+            if "-" not in remainder:
+                expanded.append(f"{current_prefix}{remainder}")
+            else:
+                range_match = range_pattern.match(remainder)
+                if not range_match:
+                    msg = f"Invalid interface range: {self.name}"
+                    raise ValueError(msg)
+
+                prefix_part, start_str, end_str = range_match.groups()
+                start, end = int(start_str), int(end_str)
+
+                if start > end:
+                    msg = f"Reverse range not supported: {self.name} (start {start} > end {end})"
+                    raise ValueError(msg)
+
+                if (end - start + 1) > max_range_size:
+                    msg = f"Range too large (>{max_range_size}): {self.name} ({end - start + 1} items)"
+                    raise ValueError(msg)
+
+                expanded.extend(f"{current_prefix}{prefix_part}{i}" for i in range(start, end + 1))
+
+        self.expanded_names = expanded
+        return self

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -23,6 +23,8 @@ class InterfaceState(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: Interface | None = None
     """Interface to validate. Either name or interface_range must be provided."""
+    interface_range: InterfaceRange | None = None
+    """Interface range pattern (e.g., 'Ethernet1-3', 'et1-3'). Expands to list of interface names. Used in `VerifyInterfacesTransceiverType` test."""
     description: str | None = None
     """Optional metadata describing the interface. Used for reporting."""
     status: Literal["up", "down", "adminDown"] | None = None
@@ -52,8 +54,6 @@ class InterfaceState(BaseModel):
     """The speed of the interface in Gigabits per second. Valid range is 1 to 1000. Required field in the `VerifyInterfacesSpeed` test."""
     lanes: int | None = Field(default=None, ge=1, le=8)
     """The number of lanes in the interface. Valid range is 1 to 8. Can be provided in the `VerifyInterfacesSpeed` test."""
-    interface_range: InterfaceRange | None = None
-    """Interface range pattern (e.g., 'Ethernet1-3', 'et1-3'). Expands to list of interface names. Used in `VerifyInterfacesTransceiverType` test."""
     media_type: str | None = None
     """Expected transceiver media type (e.g., '100GBASE-SR4'). Required for the `VerifyInterfacesTransceiverType` test."""
 

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -11,19 +11,19 @@ from warnings import warn
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
-from anta.custom_types import Interface, PortChannelInterface, expand_interface_range
+from anta.custom_types import Interface, InterfaceRange, PortChannelInterface, expand_interface_range
 
 
-def _resolve_interface_name(name: object) -> object:
+def _resolve_interface_name(v: object) -> object:
     """Return an expanded list for range patterns, or the original value for single interfaces."""
-    if isinstance(name, str):
+    if isinstance(v, str):
         try:
-            expanded = expand_interface_range(name)
+            expanded = expand_interface_range(v)
             if len(expanded) > 1:
                 return expanded
         except ValueError:
             pass
-    return name
+    return v
 
 
 class InterfaceState(BaseModel):
@@ -33,8 +33,8 @@ class InterfaceState(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
-    name: Annotated[list[str] | Interface, BeforeValidator(_resolve_interface_name)]
-    """Interface name or range pattern (e.g., 'Ethernet1', 'Ethernet1-3', 'et1-3').
+    name: Annotated[Interface | InterfaceRange, BeforeValidator(_resolve_interface_name)]
+    """Interface | interface_range pattern (e.g., 'Ethernet1', 'Ethernet1-3', 'et1-3').
 
     A range pattern expands to a list of interface names when used in `VerifyInterfacesTransceiverType`.
     """

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -14,11 +14,11 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 from anta.custom_types import Interface, InterfaceRange, PortChannelInterface, expand_interface_range
 
 
-def _resolve_interface_name(v: object) -> object:
+def _resolve_interface_name(value: object) -> object:
     """Return an expanded list for range patterns, or the original value for single interfaces."""
-    if isinstance(v, str):
+    if isinstance(value, str):
         try:
-            expanded = expand_interface_range(v)
+            expanded = expand_interface_range(value)
             # Only redirect to InterfaceRange branch when the string expands to multiple interfaces
             if len(expanded) > 1:
                 return expanded
@@ -26,7 +26,7 @@ def _resolve_interface_name(v: object) -> object:
             # Non-parseable strings fall through; Interface validator will raise the final error
             pass
     # Non-str values (list, Interface instance) pass through unchanged for Pydantic to validate
-    return v
+    return value
 
 
 class InterfaceState(BaseModel):
@@ -37,9 +37,9 @@ class InterfaceState(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     name: Annotated[Interface | InterfaceRange, BeforeValidator(_resolve_interface_name)]
-    """Interface | interface_range pattern (e.g., 'Ethernet1', 'Ethernet1-3', 'et1-3').
+    """Interface or interface range pattern (e.g., 'Ethernet1', 'Ethernet1-3', 'et1-3').
 
-    A range pattern expands to a list of interface names when used in `VerifyInterfacesTransceiverType`.
+    A range pattern is expanded to a list of interface names by `_resolve_interface_name`.
     """
     description: str | None = None
     """Optional metadata describing the interface. Used for reporting."""
@@ -82,7 +82,6 @@ class InterfaceState(BaseModel):
         >>> [entry.name for entry in interface.expand()]
         ['Ethernet1', 'Ethernet2', 'Ethernet3']
         """
-        # Range inputs arrive as a list after _resolve_interface_name expands them
         if isinstance(self.name, list):
             # Clone this entry for each interface, replacing only the name field
             return [self.model_copy(update={"name": interface_name}) for interface_name in self.name]

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -5,14 +5,13 @@
 
 from __future__ import annotations
 
-import re
 from ipaddress import IPv4Interface
 from typing import Any, Literal
 from warnings import warn
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from anta.custom_types import Interface, PortChannelInterface, expand_interface_abbreviation
+from anta.custom_types import Interface, PortChannelInterface, expand_interface_pattern
 
 
 class InterfaceState(BaseModel):
@@ -97,64 +96,25 @@ class InterfacesTransceiverType(BaseModel):
     """Interface pattern (e.g., 'Ethernet1-3', 'et1-3', 'Ethernet4,6'). Expanded via range expansion and abbreviations."""
     media_type: str
     """Expected transceiver media type (e.g., '100GBASE-SR4', '40GBASE-SR4', '25GBASE-LR')."""
-    expanded_names: list[str] = Field(default_factory=list, init=False)
-    """Pre-expanded interface names from pattern; populated after validation."""
-
-    @field_validator("name", mode="before")
-    @classmethod
-    def expand_interface_abbreviation(cls, interface_name: str) -> str:
-        """Expand abbreviations (et→Ethernet, po→Port-Channel, lo→Loopback, vl→Vlan, eth→Ethernet)."""
-        return expand_interface_abbreviation(interface_name)
 
     @model_validator(mode="after")
-    def validate_and_expand_pattern(self) -> InterfacesTransceiverType:
-        """Validate pattern syntax (no reverse ranges, oversized ranges >1000) and expand ranges to individual interfaces."""
-        range_pattern = re.compile(r"^([\d/]*?)(\d+)-(\d+)$")
-        max_range_size = 1000
-        current_prefix = None
-        expanded = []
+    def validate_pattern(self) -> InterfacesTransceiverType:
+        """Validate the interface pattern syntax.
 
-        for part in self.name.split(","):
-            part_str = part.strip()
-            if not part_str:
-                continue
-
-            # Extract prefix (Ethernet, Port-Channel, etc)
-            match = re.match(r"^([a-zA-Z]+(?:-[a-zA-Z]+)*)", part_str)
-            if match:
-                current_prefix = match.group(1)
-                remainder = part_str[len(current_prefix) :]
-            else:
-                if current_prefix is None:
-                    msg = f"Invalid interface pattern: {self.name}"
-                    raise ValueError(msg)
-                remainder = part_str
-
-            if not remainder or not remainder[0].isdigit():
-                msg = f"Invalid interface pattern: {self.name}"
-                raise ValueError(msg)
-
-            # Single port or range
-            if "-" not in remainder:
-                expanded.append(f"{current_prefix}{remainder}")
-            else:
-                range_match = range_pattern.match(remainder)
-                if not range_match:
-                    msg = f"Invalid interface range: {self.name}"
-                    raise ValueError(msg)
-
-                prefix_part, start_str, end_str = range_match.groups()
-                start, end = int(start_str), int(end_str)
-
-                if start > end:
-                    msg = f"Reverse range not supported: {self.name} (start {start} > end {end})"
-                    raise ValueError(msg)
-
-                if (end - start + 1) > max_range_size:
-                    msg = f"Range too large (>{max_range_size}): {self.name} ({end - start + 1} items)"
-                    raise ValueError(msg)
-
-                expanded.extend(f"{current_prefix}{prefix_part}{i}" for i in range(start, end + 1))
-
-        self.expanded_names = expanded
+        Interface patterns must have a prefix and valid ranges.
+        """
+        # Validate by attempting expansion; any errors are raised
+        expand_interface_pattern(self.name)
         return self
+
+    @property
+    def expanded_names(self) -> list[str]:
+        """Expand interface pattern to individual interface names.
+
+        Examples
+        --------
+        - Ethernet1-3 → ['Ethernet1', 'Ethernet2', 'Ethernet3']
+        - et1,5 → ['Ethernet1', 'Ethernet5']
+        - Ethernet1/1-2 → ['Ethernet1/1', 'Ethernet1/2']
+        """
+        return expand_interface_pattern(self.name)

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -6,27 +6,12 @@
 from __future__ import annotations
 
 from ipaddress import IPv4Interface
-from typing import Annotated, Any, Literal
+from typing import Any, Literal
 from warnings import warn
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field
 
-from anta.custom_types import Interface, InterfaceRange, PortChannelInterface, expand_interface_range
-
-
-def _resolve_interface_name(value: object) -> object:
-    """Return an expanded list for range patterns, or the original value for single interfaces."""
-    if isinstance(value, str):
-        try:
-            expanded = expand_interface_range(value)
-            # Only redirect to InterfaceRange branch when the string expands to multiple interfaces
-            if len(expanded) > 1:
-                return expanded
-        except ValueError:
-            # Non-parseable strings fall through; Interface validator will raise the final error
-            pass
-    # Non-str values (list, Interface instance) pass through unchanged for Pydantic to validate
-    return value
+from anta.custom_types import Interface, InterfaceRange, PortChannelInterface
 
 
 class InterfaceState(BaseModel):
@@ -36,10 +21,10 @@ class InterfaceState(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
-    name: Annotated[Interface | InterfaceRange, BeforeValidator(_resolve_interface_name)]
-    """Interface or interface range pattern (e.g., 'Ethernet1', 'Ethernet1-3', 'et1-3').
+    name: InterfaceRange | Interface
+    """Interface name or range pattern (e.g., 'Ethernet1', 'Ethernet1-3', 'et1-3', 'Ethernet1,et2').
 
-    A range pattern is expanded to a list of interface names by `_resolve_interface_name`.
+    Range patterns are expanded to a list of interface names by the InterfaceRange validator.
     """
     description: str | None = None
     """Optional metadata describing the interface. Used for reporting."""

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -71,17 +71,12 @@ class InterfaceState(BaseModel):
     def __str__(self) -> str:
         """Return a human-readable string representation of the InterfaceState for reporting.
 
-        For interface_range, returns a count since individual interfaces are shown in atomic results.
-        The test loop creates per-interface atomic results with their specific interface names.
-
         Examples
         --------
         - Interface: Ethernet1 Port-Channel: Port-Channel100
         - Interface: Ethernet1
-        - Interface: range(3 items)
         """
-        identifier = self.name if self.name is not None else f"range({len(self.interface_range or [])} items)"
-        base_string = f"Interface: {identifier}"
+        base_string = f"Interface: {self.name}"
         if self.description is not None:
             base_string += f" ({self.description})"
         if self.portchannel is not None:

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -11,7 +11,7 @@ from warnings import warn
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from anta.custom_types import Interface, PortChannelInterface, expand_interface_pattern
+from anta.custom_types import Interface, InterfaceRange, PortChannelInterface
 
 
 class InterfaceState(BaseModel):
@@ -21,8 +21,8 @@ class InterfaceState(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
-    name: Interface
-    """Interface to validate."""
+    name: Interface | None = None
+    """Interface to validate. Either name or interface_range must be provided."""
     description: str | None = None
     """Optional metadata describing the interface. Used for reporting."""
     status: Literal["up", "down", "adminDown"] | None = None
@@ -52,16 +52,36 @@ class InterfaceState(BaseModel):
     """The speed of the interface in Gigabits per second. Valid range is 1 to 1000. Required field in the `VerifyInterfacesSpeed` test."""
     lanes: int | None = Field(default=None, ge=1, le=8)
     """The number of lanes in the interface. Valid range is 1 to 8. Can be provided in the `VerifyInterfacesSpeed` test."""
+    interface_range: InterfaceRange | None = None
+    """Interface range pattern (e.g., 'Ethernet1-3', 'et1-3'). Expands to list of interface names. Used in `VerifyInterfacesTransceiverType` test."""
+    media_type: str | None = None
+    """Expected transceiver media type (e.g., '100GBASE-SR4'). Required for the `VerifyInterfacesTransceiverType` test."""
+
+    @model_validator(mode="after")
+    def validate_inputs(self) -> InterfaceState:
+        """Validate that either name or interface_range is provided, not both."""
+        if self.name is None and self.interface_range is None:
+            msg = "Either 'name' or 'interface_range' must be provided."
+            raise ValueError(msg)
+        if self.name is not None and self.interface_range is not None:
+            msg = "Only one of 'name' or 'interface_range' can be provided, not both."
+            raise ValueError(msg)
+        return self
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the InterfaceState for reporting.
+
+        For interface_range, returns a count since individual interfaces are shown in atomic results.
+        The test loop creates per-interface atomic results with their specific interface names.
 
         Examples
         --------
         - Interface: Ethernet1 Port-Channel: Port-Channel100
         - Interface: Ethernet1
+        - Interface: range(3 items)
         """
-        base_string = f"Interface: {self.name}"
+        identifier = self.name if self.name is not None else f"range({len(self.interface_range or [])} items)"
+        base_string = f"Interface: {identifier}"
         if self.description is not None:
             base_string += f" ({self.description})"
         if self.portchannel is not None:
@@ -85,36 +105,3 @@ class InterfaceDetail(InterfaceState):  # pragma: no cover
             stacklevel=2,
         )
         super().__init__(**data)
-
-
-class InterfacesTransceiverType(BaseModel):
-    """Interface pattern with expected transceiver media type; validates and pre-expands at catalog-load."""
-
-    model_config = ConfigDict(extra="forbid")
-
-    name: str
-    """Interface pattern (e.g., 'Ethernet1-3', 'et1-3', 'Ethernet4,6'). Expanded via range expansion and abbreviations."""
-    media_type: str
-    """Expected transceiver media type (e.g., '100GBASE-SR4', '40GBASE-SR4', '25GBASE-LR')."""
-
-    @model_validator(mode="after")
-    def validate_pattern(self) -> InterfacesTransceiverType:
-        """Validate the interface pattern syntax.
-
-        Interface patterns must have a prefix and valid ranges.
-        """
-        # Validate by attempting expansion; any errors are raised
-        expand_interface_pattern(self.name)
-        return self
-
-    @property
-    def expanded_names(self) -> list[str]:
-        """Expand interface pattern to individual interface names.
-
-        Examples
-        --------
-        - Ethernet1-3 → ['Ethernet1', 'Ethernet2', 'Ethernet3']
-        - et1,5 → ['Ethernet1', 'Ethernet5']
-        - Ethernet1/1-2 → ['Ethernet1/1', 'Ethernet1/2']
-        """
-        return expand_interface_pattern(self.name)

--- a/anta/input_models/interfaces.py
+++ b/anta/input_models/interfaces.py
@@ -19,10 +19,13 @@ def _resolve_interface_name(v: object) -> object:
     if isinstance(v, str):
         try:
             expanded = expand_interface_range(v)
+            # Only redirect to InterfaceRange branch when the string expands to multiple interfaces
             if len(expanded) > 1:
                 return expanded
         except ValueError:
+            # Non-parseable strings fall through; Interface validator will raise the final error
             pass
+    # Non-str values (list, Interface instance) pass through unchanged for Pydantic to validate
     return v
 
 
@@ -79,8 +82,11 @@ class InterfaceState(BaseModel):
         >>> [entry.name for entry in interface.expand()]
         ['Ethernet1', 'Ethernet2', 'Ethernet3']
         """
+        # Range inputs arrive as a list after _resolve_interface_name expands them
         if isinstance(self.name, list):
+            # Clone this entry for each interface, replacing only the name field
             return [self.model_copy(update={"name": interface_name}) for interface_name in self.name]
+        # Single interface: no expansion needed
         return [self]
 
     def __str__(self) -> str:

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -16,7 +16,18 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 from pydantic import Field, TypeAdapter, ValidationError, field_validator, model_validator
 from pydantic_extra_types.mac_address import MacAddress
 
-from anta.custom_types import DropPrecedence, EthernetInterface, Interface, InterfaceType, ManagementInterface, Percent, PortChannelInterface, PositiveInteger
+from anta.custom_types import (
+    DropPrecedence,
+    EthernetInterface,
+    Interface,
+    InterfaceType,
+    ManagementInterface,
+    Percent,
+    PortChannelInterface,
+    PositiveInteger,
+    interface_autocomplete,
+    interface_case_sensitivity,
+)
 from anta.decorators import skip_on_platforms
 from anta.input_models.interfaces import InterfaceDetail, InterfaceState
 from anta.models import AntaCommand, AntaTemplate, AntaTest
@@ -2094,9 +2105,11 @@ class VerifyInterfacesTransceiverType(AntaTest):
         for interface_config in self.inputs.interfaces:
             interfaces_to_check = interface_config.interface_range or [interface_config.name]
             for interface_name in interfaces_to_check:
-                result = self.result.add(description=f"Interface: {interface_name}", status=AntaTestStatus.SUCCESS)
+                # Normalize interface name via the same Interface validators used by InterfaceState.name
+                normalized_name = interface_case_sensitivity(interface_autocomplete(interface_name))
+                result = self.result.add(description=f"Interface: {normalized_name}", status=AntaTestStatus.SUCCESS)
 
-                intf_data = interfaces_data.get(interface_name)
+                intf_data = interfaces_data.get(normalized_name)
                 if intf_data is None:
                     result.is_failure("Not found")
                     continue

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, TypeAdapter, ValidationError, field_validator, model_validator
 from pydantic_extra_types.mac_address import MacAddress
 
 from anta.custom_types import DropPrecedence, EthernetInterface, Interface, InterfaceType, ManagementInterface, Percent, PortChannelInterface, PositiveInteger
 from anta.decorators import skip_on_platforms
-from anta.input_models.interfaces import InterfaceDetail, InterfaceState, InterfacesTransceiverType
+from anta.input_models.interfaces import InterfaceDetail, InterfaceState
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 from anta.result_manager.models import AntaTestStatus
 from anta.tools import custom_division, get_item, get_value, get_value_by_range_key, is_interface_ignored, time_ago
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
 BPS_GBPS_CONVERSIONS = 1000000000
 NO_LIGHT_DBM = -30.0
+ETHERNET_INTERFACES_ADAPTER = TypeAdapter(list[EthernetInterface])
 
 T = TypeVar("T", bound=InterfaceState)
 
@@ -2042,58 +2043,68 @@ class VerifyInterfacesTransceiverType(AntaTest):
     anta.tests.interfaces:
       - VerifyInterfacesTransceiverType:
           interfaces:
-            - name: Ethernet1-3
+            - interface_range: Ethernet1-3
               media_type: 100GBASE-SR4
-            - name: Ethernet4,6
+            - interface_range: Ethernet4,6
               media_type: 40GBASE-SR4
             - name: Ethernet7
               media_type: 25GBASE-SR
-            - name: Ethernet1/1-3
+            - interface_range: Ethernet1/1-3
               media_type: 25GBASE-LR
-            - name: et1-3
+            - interface_range: et1-3
               media_type: 100GBASE-SR4
-            - name: po1-2
-              media_type: 40GBASE-SR4
     ```
     """
 
     categories: ClassVar[list[str]] = ["interfaces"]
-    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
-        AntaCommand(command="show interfaces transceiver detail", revision=1),
-    ]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show interfaces transceiver detail", revision=1)]
     _atomic_support: ClassVar[bool] = True
 
     class Input(AntaTest.Input):
         """Input model for the VerifyInterfacesTransceiverType test."""
 
-        interfaces: list[InterfacesTransceiverType]
-        """List of interfaces and their expected transceiver media types."""
+        interfaces: list[InterfaceState]
+        """List of Ethernet interfaces and their expected transceiver media types."""
+
+        @model_validator(mode="after")
+        def validate_inputs(self) -> Self:
+            """Validate that every entry has a media type and references only Ethernet interfaces."""
+            interface_names: list[Interface | None] = []
+            for interface_config in self.interfaces:
+                if interface_config.media_type is None:
+                    msg = "'media_type' must be provided for all interfaces in VerifyInterfacesTransceiverType."
+                    raise ValueError(msg)
+                interface_names.extend(interface_config.interface_range or [interface_config.name])
+
+            try:
+                ETHERNET_INTERFACES_ADAPTER.validate_python(interface_names)
+            except ValidationError as error:
+                invalid_interface = error.errors()[0]["input"]
+                msg = f"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: {invalid_interface}"
+                raise ValueError(msg) from None
+            return self
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyInterfacesTransceiverType."""
         self.result.is_success()
-        transceiver_output = self.instance_commands[0].json_output
+        interfaces_data = self.instance_commands[0].json_output["interfaces"]
 
         for interface_config in self.inputs.interfaces:
-            expected_media_type = interface_config.media_type
-            for interface_name in interface_config.expanded_names:
-                # Atomic result per interface
+            interfaces_to_check = interface_config.interface_range or [interface_config.name]
+            for interface_name in interfaces_to_check:
                 result = self.result.add(description=f"Interface: {interface_name}", status=AntaTestStatus.SUCCESS)
 
-                # Get transceiver details for the interface
-                intf_data = get_value(transceiver_output, f"interfaces..{interface_name}", separator="..")
+                intf_data = interfaces_data.get(interface_name)
                 if intf_data is None:
                     result.is_failure("Not found")
                     continue
 
-                # Extract media type from transceiver data
                 actual_media_type = intf_data.get("mediaType")
                 if actual_media_type is None:
                     result.is_failure("Transceiver media type not found")
                     continue
 
-                # Compare expected vs actual media type
-                if actual_media_type != expected_media_type:
-                    result.is_failure(f"Transceiver media type mismatch - Expected: {expected_media_type} Actual: {actual_media_type}")
+                if actual_media_type != interface_config.media_type:
+                    result.is_failure(f"Transceiver media type mismatch - Expected: {interface_config.media_type} Actual: {actual_media_type}")

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -36,6 +36,10 @@ NO_LIGHT_DBM = -30.0
 
 T = TypeVar("T", bound=InterfaceState)
 
+# Pre-compiled regex patterns for interface expansion (computed once at module load)
+_INTERFACE_PREFIX_PATTERN = re.compile(r"^([a-zA-Z][a-zA-Z\-]*)")
+_INTERFACE_RANGE_PATTERN = re.compile(r"^([\d/]*?)(\d+)-(\d+)$")
+
 
 class VerifyInterfaceUtilization(AntaTest):
     """Verifies that the utilization of interfaces is below a certain threshold.
@@ -2024,3 +2028,169 @@ class VerifyInterfacesECNCounters(AntaTest):
                     self.result.is_failure(
                         f"Interface: {interface} Queue: {queue} - Counters above threshold - Expected: <= {self.inputs.counters_threshold} Actual: {counter_value}"
                     )
+
+
+class VerifyInterfacesTransceiverType(AntaTest):
+    """Verifies that the installed transceivers on specified interfaces match the expected media type.
+
+    Supports interface range expansion using standard Arista CLI syntax (e.g., `Ethernet1-24`, `Ethernet1/1-3`, `Ethernet51/1/1-4`).
+
+    Expected Results
+    ----------------
+    * Success: The test will pass if all specified interfaces have transceivers with the expected media type.
+    * Failure: The test will fail if any interface is not found, or if the transceiver media type does not match the expected value.
+
+    Examples
+    --------
+    ```yaml
+    anta.tests.interfaces:
+      - VerifyInterfacesTransceiverType:
+          interfaces:
+            - name: Ethernet1-3
+              media_type: 100GBASE-SR4
+            - name: Ethernet4,6
+              media_type: 40GBASE-SR4
+            - name: Ethernet7
+              media_type: 25GBASE-SR
+            - name: Ethernet1/1-3
+              media_type: 25GBASE-LR
+            - name: et1-3
+              media_type: 100GBASE-SR4
+            - name: po1-2
+              media_type: 40GBASE-SR4
+    ```
+    """
+
+    # Maximum number of interfaces allowed in a single range (DoS protection)
+    _MAX_RANGE_SIZE: ClassVar[int] = 1000
+
+    categories: ClassVar[list[str]] = ["interfaces"]
+    commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
+        AntaCommand(command="show interfaces transceiver detail", revision=1),
+    ]
+    _atomic_support: ClassVar[bool] = True
+
+    class Input(AntaTest.Input):
+        """Input model for the VerifyInterfacesTransceiverType test."""
+
+        class InterfaceMediaType(AntaTest.Input):
+            """Model for interface name and expected transceiver media type."""
+
+            # Aliases ordered by length: "eth" before "et" for correct matching
+            _INTERFACE_SHORTHAND_MAP: ClassVar[dict[str, str]] = {
+                "eth": "Ethernet",
+                "po": "Port-Channel",
+                "lo": "Loopback",
+                "vl": "Vlan",
+                "et": "Ethernet",
+            }
+
+            name: str
+            """Interface name or pattern (supports ranges like '1-3', '1/1-3' and shorthand like 'et1', 'po1')."""
+            media_type: str
+            """Expected transceiver media type (e.g., '100GBASE-SR4', '40GBASE-SR4')."""
+
+            @field_validator("name", mode="before")
+            @classmethod
+            def expand_interface_shorthand(cls, v: str) -> str:
+                """Expand shorthand aliases (et→Ethernet, po→Port-Channel, lo→Loopback, vl→Vlan)."""
+                for alias, full_name in cls._INTERFACE_SHORTHAND_MAP.items():
+                    if v.lower().startswith(alias):
+                        remainder = v[len(alias) :]
+                        if remainder and remainder[0].isdigit():
+                            return f"{full_name}{remainder}"
+                return v
+
+        interfaces: list[InterfaceMediaType]
+        """List of interfaces and their expected transceiver media types."""
+
+    def _expand_interface_range(self, interface_pattern: str) -> list[str]:
+        """Expand interface range patterns into individual interface names.
+
+        Supports arbitrary nesting levels with digits and slashes.
+
+        Examples
+        --------
+        'Ethernet1-3' → ['Ethernet1', 'Ethernet2', 'Ethernet3']
+        'Ethernet1,3-5' → ['Ethernet1', 'Ethernet3', 'Ethernet4', 'Ethernet5']
+        'Ethernet1/1-3' → ['Ethernet1/1', 'Ethernet1/2', 'Ethernet1/3']
+        'Ethernet1/1/1-3' → ['Ethernet1/1/1', 'Ethernet1/1/2', 'Ethernet1/1/3']
+        'Ethernet48-50' → ['Ethernet48', 'Ethernet49', 'Ethernet50']
+        'Ethernet1/48-50,2/1' → ['Ethernet1/48', 'Ethernet1/49', 'Ethernet1/50', 'Ethernet2/1']
+        """
+        match = _INTERFACE_PREFIX_PATTERN.match(interface_pattern)
+        if not match:
+            return []
+
+        prefix = match.group(1)
+        remainder = interface_pattern[len(prefix) :]
+        expanded = []
+
+        for item in remainder.split(","):
+            stripped_item = item.strip()
+            if not stripped_item:
+                continue
+            expanded.extend(self._expand_single_part(prefix, stripped_item))
+
+        return expanded
+
+    def _expand_single_part(self, prefix: str, item: str) -> list[str]:
+        """Expand a single part (range or single port)."""
+        # Single port: no range dash detected
+        if "-" not in item:
+            return [f"{prefix}{item}"]
+
+        # Parse range syntax using regex
+        range_match = _INTERFACE_RANGE_PATTERN.match(item)
+        if not range_match:
+            return []
+
+        # Extract slot prefix, start port, and end port from regex groups
+        prefix_part, start_str, end_str = range_match.groups()
+        # Convert endpoints to integers
+        try:
+            start = int(start_str)
+            end = int(end_str)
+        except ValueError:
+            return []
+
+        # Reject reverse ranges and enforce DoS protection limit
+        if start > end or (end - start + 1) > self._MAX_RANGE_SIZE:
+            return []
+
+        # Generate interface names for each port in the range
+        return [f"{prefix}{prefix_part}{i}" for i in range(start, end + 1)]
+
+    @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
+    @AntaTest.anta_test
+    def test(self) -> None:
+        """Main test function for VerifyInterfacesTransceiverType."""
+        self.result.is_success()
+        transceiver_output = self.instance_commands[0].json_output
+
+        for interface_config in self.inputs.interfaces:
+            expected_media_type = interface_config.media_type
+            expanded_interfaces = self._expand_interface_range(interface_config.name)
+            # Skip invalid range patterns (e.g., reverse ranges or oversized ranges)
+            if not expanded_interfaces:
+                continue
+
+            for interface_name in expanded_interfaces:
+                # Atomic result per interface
+                result = self.result.add(description=f"Interface: {interface_name}", status=AntaTestStatus.SUCCESS)
+
+                # Get transceiver details for the interface
+                intf_data = get_value(transceiver_output, f"interfaces..{interface_name}", separator="..")
+                if intf_data is None:
+                    result.is_failure("Not found")
+                    continue
+
+                # Extract media type from transceiver data
+                actual_media_type = intf_data.get("mediaType")
+                if actual_media_type is None:
+                    result.is_failure("Transceiver media type not found")
+                    continue
+
+                # Compare expected vs actual media type
+                if actual_media_type != expected_media_type:
+                    result.is_failure(f"Transceiver media type mismatch - Expected: {expected_media_type} Actual: {actual_media_type}")

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -2084,7 +2084,6 @@ class VerifyInterfacesTransceiverType(AntaTest):
         """List of Ethernet interfaces and their expected transceiver media types."""
 
         @field_validator("interfaces")
-        @classmethod
         def validate_interfaces(cls, interfaces: list[InterfaceState]) -> list[InterfaceState]:
             """Validate that 'media_type' field is provided in each interface."""
             for interface in interfaces:

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -2084,6 +2084,7 @@ class VerifyInterfacesTransceiverType(AntaTest):
         """List of Ethernet interfaces and their expected transceiver media types."""
 
         @field_validator("interfaces")
+        @classmethod
         def validate_interfaces(cls, interfaces: list[InterfaceState]) -> list[InterfaceState]:
             """Validate that 'media_type' field is provided in each interface."""
             for interface in interfaces:

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -2052,15 +2052,15 @@ class VerifyInterfacesTransceiverType(AntaTest):
     anta.tests.interfaces:
       - VerifyInterfacesTransceiverType:
           interfaces:
-            - interface_range: Ethernet1-3
+            - name: Ethernet1-3
               media_type: 100GBASE-SR4
-            - interface_range: Ethernet4,6
+            - name: Ethernet4,6
               media_type: 40GBASE-SR4
             - name: Ethernet7
               media_type: 25GBASE-SR
-            - interface_range: Ethernet1/1-3
+            - name: Ethernet1/1-3
               media_type: 25GBASE-LR
-            - interface_range: et1-3
+            - name: et1-3
               media_type: 100GBASE-SR4
     ```
     """
@@ -2075,27 +2075,29 @@ class VerifyInterfacesTransceiverType(AntaTest):
         interfaces: list[InterfaceState]
         """List of Ethernet interfaces and their expected transceiver media types."""
 
+        @field_validator("interfaces")
+        @classmethod
+        def validate_interfaces(cls, interfaces: list[InterfaceState]) -> list[InterfaceState]:
+            """Validate that 'media_type' field is provided in each interface."""
+            for interface in interfaces:
+                if interface.media_type is None:
+                    msg = f"{interface} 'media_type' field missing in the input"
+                    raise ValueError(msg)
+            return interfaces
+
         @model_validator(mode="after")
         def validate_inputs(self) -> Self:
-            """Validate the inputs and expand interface ranges into individual interface entries."""
-            expanded_interfaces: list[InterfaceState] = []
-            for interface in self.interfaces:
-                if interface.media_type is None:
-                    msg = "'media_type' must be provided for all interfaces in VerifyInterfacesTransceiverType."
-                    raise ValueError(msg)
-                if interface.interface_range is None:
-                    expanded_interfaces.append(interface)
-                    continue
-                expanded_interfaces.extend(
-                    interface.model_copy(update={"name": interface_name, "interface_range": None}) for interface_name in interface.interface_range
-                )
+            """Expand range names and enforce the Ethernet-only constraint."""
+            expanded = [entry for iface in self.interfaces for entry in iface.expand()]
+
             try:
-                ETHERNET_INTERFACES_ADAPTER.validate_python([interface.name for interface in expanded_interfaces])
+                ETHERNET_INTERFACES_ADAPTER.validate_python([e.name for e in expanded])
             except ValidationError as error:
-                invalid_interfaces = ", ".join(str(validation_error["input"]) for validation_error in error.errors())
-                msg = f"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: {invalid_interfaces}"
+                invalid = ", ".join(str(e["input"]) for e in error.errors())
+                msg = f"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: {invalid}"
                 raise ValueError(msg) from None
-            self.interfaces = expanded_interfaces
+
+            self.interfaces = expanded
             return self
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
@@ -2106,7 +2108,7 @@ class VerifyInterfacesTransceiverType(AntaTest):
         interfaces_data = self.instance_commands[0].json_output["interfaces"]
 
         for interface in self.inputs.interfaces:
-            # Interfaces are pre-expanded by validate_inputs; each entry has a name and no interface_range.
+            # Interfaces are pre-expanded by validate_inputs; each entry has a single interface name.
             result = self.result.add(description=f"Interface: {interface.name}", status=AntaTestStatus.SUCCESS)
 
             intf_data = interfaces_data.get(interface.name)

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -25,8 +25,6 @@ from anta.custom_types import (
     Percent,
     PortChannelInterface,
     PositiveInteger,
-    interface_autocomplete,
-    interface_case_sensitivity,
 )
 from anta.decorators import skip_on_platforms
 from anta.input_models.interfaces import InterfaceDetail, InterfaceState
@@ -2079,20 +2077,25 @@ class VerifyInterfacesTransceiverType(AntaTest):
 
         @model_validator(mode="after")
         def validate_inputs(self) -> Self:
-            """Validate that every entry has a media type and references only Ethernet interfaces."""
-            interface_names: list[Interface | None] = []
-            for interface_config in self.interfaces:
-                if interface_config.media_type is None:
+            """Validate the inputs and expand interface ranges into individual interface entries."""
+            expanded_interfaces: list[InterfaceState] = []
+            for interface in self.interfaces:
+                if interface.media_type is None:
                     msg = "'media_type' must be provided for all interfaces in VerifyInterfacesTransceiverType."
                     raise ValueError(msg)
-                interface_names.extend(interface_config.interface_range or [interface_config.name])
-
+                if interface.interface_range is None:
+                    expanded_interfaces.append(interface)
+                    continue
+                expanded_interfaces.extend(
+                    interface.model_copy(update={"name": interface_name, "interface_range": None}) for interface_name in interface.interface_range
+                )
             try:
-                ETHERNET_INTERFACES_ADAPTER.validate_python(interface_names)
+                ETHERNET_INTERFACES_ADAPTER.validate_python([interface.name for interface in expanded_interfaces])
             except ValidationError as error:
-                invalid_interface = error.errors()[0]["input"]
-                msg = f"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: {invalid_interface}"
+                invalid_interfaces = ", ".join(str(validation_error["input"]) for validation_error in error.errors())
+                msg = f"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: {invalid_interfaces}"
                 raise ValueError(msg) from None
+            self.interfaces = expanded_interfaces
             return self
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
@@ -2102,22 +2105,19 @@ class VerifyInterfacesTransceiverType(AntaTest):
         self.result.is_success()
         interfaces_data = self.instance_commands[0].json_output["interfaces"]
 
-        for interface_config in self.inputs.interfaces:
-            interfaces_to_check = interface_config.interface_range or [interface_config.name]
-            for interface_name in interfaces_to_check:
-                # Normalize interface name via the same Interface validators used by InterfaceState.name
-                normalized_name = interface_case_sensitivity(interface_autocomplete(interface_name))
-                result = self.result.add(description=f"Interface: {normalized_name}", status=AntaTestStatus.SUCCESS)
+        for interface in self.inputs.interfaces:
+            # Interfaces are pre-expanded by validate_inputs; each entry has a name and no interface_range.
+            result = self.result.add(description=f"Interface: {interface.name}", status=AntaTestStatus.SUCCESS)
 
-                intf_data = interfaces_data.get(normalized_name)
-                if intf_data is None:
-                    result.is_failure("Not found")
-                    continue
+            intf_data = interfaces_data.get(interface.name)
+            if intf_data is None:
+                result.is_failure("Not found")
+                continue
 
-                actual_media_type = intf_data.get("mediaType")
-                if actual_media_type is None:
-                    result.is_failure("Transceiver media type not found")
-                    continue
+            actual_media_type = intf_data.get("mediaType")
+            if actual_media_type is None:
+                result.is_failure("Transceiver media type not found")
+                continue
 
-                if actual_media_type != interface_config.media_type:
-                    result.is_failure(f"Transceiver media type mismatch - Expected: {interface_config.media_type} Actual: {actual_media_type}")
+            if actual_media_type != interface.media_type:
+                result.is_failure(f"Transceiver media type mismatch - Expected: {interface.media_type} Actual: {actual_media_type}")

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -18,7 +18,7 @@ from pydantic_extra_types.mac_address import MacAddress
 
 from anta.custom_types import DropPrecedence, EthernetInterface, Interface, InterfaceType, ManagementInterface, Percent, PortChannelInterface, PositiveInteger
 from anta.decorators import skip_on_platforms
-from anta.input_models.interfaces import InterfaceDetail, InterfaceState
+from anta.input_models.interfaces import InterfaceDetail, InterfaceState, InterfacesTransceiverType
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 from anta.result_manager.models import AntaTestStatus
 from anta.tools import custom_division, get_item, get_value, get_value_by_range_key, is_interface_ignored, time_ago
@@ -35,10 +35,6 @@ BPS_GBPS_CONVERSIONS = 1000000000
 NO_LIGHT_DBM = -30.0
 
 T = TypeVar("T", bound=InterfaceState)
-
-# Pre-compiled regex patterns for interface expansion (computed once at module load)
-_INTERFACE_PREFIX_PATTERN = re.compile(r"^([a-zA-Z][a-zA-Z\-]*)")
-_INTERFACE_RANGE_PATTERN = re.compile(r"^([\d/]*?)(\d+)-(\d+)$")
 
 
 class VerifyInterfaceUtilization(AntaTest):
@@ -2058,11 +2054,10 @@ class VerifyInterfacesTransceiverType(AntaTest):
               media_type: 100GBASE-SR4
             - name: po1-2
               media_type: 40GBASE-SR4
+            - name: lo0
+              media_type: N/A
     ```
     """
-
-    # Maximum number of interfaces allowed in a single range (DoS protection)
-    _MAX_RANGE_SIZE: ClassVar[int] = 1000
 
     categories: ClassVar[list[str]] = ["interfaces"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
@@ -2073,93 +2068,8 @@ class VerifyInterfacesTransceiverType(AntaTest):
     class Input(AntaTest.Input):
         """Input model for the VerifyInterfacesTransceiverType test."""
 
-        class InterfaceMediaType(AntaTest.Input):
-            """Model for interface name and expected transceiver media type."""
-
-            # Aliases ordered by length: "eth" before "et" for correct matching
-            _INTERFACE_SHORTHAND_MAP: ClassVar[dict[str, str]] = {
-                "eth": "Ethernet",
-                "po": "Port-Channel",
-                "lo": "Loopback",
-                "vl": "Vlan",
-                "et": "Ethernet",
-            }
-
-            name: str
-            """Interface name or pattern (supports ranges like '1-3', '1/1-3' and shorthand like 'et1', 'po1')."""
-            media_type: str
-            """Expected transceiver media type (e.g., '100GBASE-SR4', '40GBASE-SR4')."""
-
-            @field_validator("name", mode="before")
-            @classmethod
-            def expand_interface_shorthand(cls, v: str) -> str:
-                """Expand shorthand aliases (et→Ethernet, po→Port-Channel, lo→Loopback, vl→Vlan)."""
-                for alias, full_name in cls._INTERFACE_SHORTHAND_MAP.items():
-                    if v.lower().startswith(alias):
-                        remainder = v[len(alias) :]
-                        if remainder and remainder[0].isdigit():
-                            return f"{full_name}{remainder}"
-                return v
-
-        interfaces: list[InterfaceMediaType]
+        interfaces: list[InterfacesTransceiverType]
         """List of interfaces and their expected transceiver media types."""
-
-    def _expand_interface_range(self, interface_pattern: str) -> list[str]:
-        """Expand interface range patterns into individual interface names.
-
-        Supports arbitrary nesting levels with digits and slashes.
-
-        Examples
-        --------
-        'Ethernet1-3' → ['Ethernet1', 'Ethernet2', 'Ethernet3']
-        'Ethernet1,3-5' → ['Ethernet1', 'Ethernet3', 'Ethernet4', 'Ethernet5']
-        'Ethernet1/1-3' → ['Ethernet1/1', 'Ethernet1/2', 'Ethernet1/3']
-        'Ethernet1/1/1-3' → ['Ethernet1/1/1', 'Ethernet1/1/2', 'Ethernet1/1/3']
-        'Ethernet48-50' → ['Ethernet48', 'Ethernet49', 'Ethernet50']
-        'Ethernet1/48-50,2/1' → ['Ethernet1/48', 'Ethernet1/49', 'Ethernet1/50', 'Ethernet2/1']
-        """
-        match = _INTERFACE_PREFIX_PATTERN.match(interface_pattern)
-        if not match:
-            return []
-
-        prefix = match.group(1)
-        remainder = interface_pattern[len(prefix) :]
-        expanded = []
-
-        for item in remainder.split(","):
-            stripped_item = item.strip()
-            if not stripped_item:
-                continue
-            expanded.extend(self._expand_single_part(prefix, stripped_item))
-
-        return expanded
-
-    def _expand_single_part(self, prefix: str, item: str) -> list[str]:
-        """Expand a single part (range or single port)."""
-        # Single port: no range dash detected
-        if "-" not in item:
-            return [f"{prefix}{item}"]
-
-        # Parse range syntax using regex
-        range_match = _INTERFACE_RANGE_PATTERN.match(item)
-        if not range_match:
-            return []
-
-        # Extract slot prefix, start port, and end port from regex groups
-        prefix_part, start_str, end_str = range_match.groups()
-        # Convert endpoints to integers
-        try:
-            start = int(start_str)
-            end = int(end_str)
-        except ValueError:
-            return []
-
-        # Reject reverse ranges and enforce DoS protection limit
-        if start > end or (end - start + 1) > self._MAX_RANGE_SIZE:
-            return []
-
-        # Generate interface names for each port in the range
-        return [f"{prefix}{prefix_part}{i}" for i in range(start, end + 1)]
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab", "cEOSCloudLab", "vEOS"])
     @AntaTest.anta_test
@@ -2170,12 +2080,7 @@ class VerifyInterfacesTransceiverType(AntaTest):
 
         for interface_config in self.inputs.interfaces:
             expected_media_type = interface_config.media_type
-            expanded_interfaces = self._expand_interface_range(interface_config.name)
-            # Skip invalid range patterns (e.g., reverse ranges or oversized ranges)
-            if not expanded_interfaces:
-                continue
-
-            for interface_name in expanded_interfaces:
+            for interface_name in interface_config.expanded_names:
                 # Atomic result per interface
                 result = self.result.add(description=f"Interface: {interface_name}", status=AntaTestStatus.SUCCESS)
 

--- a/anta/tests/interfaces.py
+++ b/anta/tests/interfaces.py
@@ -2054,8 +2054,6 @@ class VerifyInterfacesTransceiverType(AntaTest):
               media_type: 100GBASE-SR4
             - name: po1-2
               media_type: 40GBASE-SR4
-            - name: lo0
-              media_type: N/A
     ```
     """
 

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -599,18 +599,16 @@ anta.tests.interfaces:
   - VerifyInterfacesTransceiverType:
       # Verifies that the installed transceivers on specified interfaces match the expected media type.
       interfaces:
-        - name: Ethernet1-3
+        - interface_range: Ethernet1-3
           media_type: 100GBASE-SR4
-        - name: Ethernet4,6
+        - interface_range: Ethernet4,6
           media_type: 40GBASE-SR4
         - name: Ethernet7
           media_type: 25GBASE-SR
-        - name: Ethernet1/1-3
+        - interface_range: Ethernet1/1-3
           media_type: 25GBASE-LR
-        - name: et1-3
+        - interface_range: et1-3
           media_type: 100GBASE-SR4
-        - name: po1-2
-          media_type: 40GBASE-SR4
   - VerifyInterfacesTridentCounters:
       # Verifies the Trident debug counters of all interfaces.
       ignored_counters:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -596,6 +596,21 @@ anta.tests.interfaces:
         - name: Ethernet49/1
           status: adminDown
           line_protocol_status: notPresent
+  - VerifyInterfacesTransceiverType:
+      # Verifies that the installed transceivers on specified interfaces match the expected media type.
+      interfaces:
+        - name: Ethernet1-3
+          media_type: 100GBASE-SR4
+        - name: Ethernet4,6
+          media_type: 40GBASE-SR4
+        - name: Ethernet7
+          media_type: 25GBASE-SR
+        - name: Ethernet1/1-3
+          media_type: 25GBASE-LR
+        - name: et1-3
+          media_type: 100GBASE-SR4
+        - name: po1-2
+          media_type: 40GBASE-SR4
   - VerifyInterfacesTridentCounters:
       # Verifies the Trident debug counters of all interfaces.
       ignored_counters:

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -599,15 +599,15 @@ anta.tests.interfaces:
   - VerifyInterfacesTransceiverType:
       # Verifies that the installed transceivers on specified interfaces match the expected media type.
       interfaces:
-        - interface_range: Ethernet1-3
+        - name: Ethernet1-3
           media_type: 100GBASE-SR4
-        - interface_range: Ethernet4,6
+        - name: Ethernet4,6
           media_type: 40GBASE-SR4
         - name: Ethernet7
           media_type: 25GBASE-SR
-        - interface_range: Ethernet1/1-3
+        - name: Ethernet1/1-3
           media_type: 25GBASE-LR
-        - interface_range: et1-3
+        - name: et1-3
           media_type: 100GBASE-SR4
   - VerifyInterfacesTridentCounters:
       # Verifies the Trident debug counters of all interfaces.

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6910,6 +6910,31 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
+    (VerifyInterfacesTransceiverType, "success-with-direct-name"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet3": {"mediaType": "100GBASE-SR4"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet2-3", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
+            ],
+        },
+    },
     (VerifyInterfacesTransceiverType, "success-multiple-abbreviations-comma-separated"): {
         "eos_data": [
             {

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6698,7 +6698,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "failure_media_type_mismatch"): {
+    (VerifyInterfacesTransceiverType, "failure-media-type-mismatch"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6734,7 +6734,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "failure_interface_not_found"): {
+    (VerifyInterfacesTransceiverType, "failure-interface-not-found"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6760,7 +6760,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "failure_transceiver_not_found"): {
+    (VerifyInterfacesTransceiverType, "failure-transceiver-not-found"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6785,7 +6785,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success_with_abbreviation"): {
+    (VerifyInterfacesTransceiverType, "success-with-abbreviation"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6814,7 +6814,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "failure_empty_transceiver"): {
+    (VerifyInterfacesTransceiverType, "failure-empty-transceiver"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6842,7 +6842,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success_with_large_range"): {
+    (VerifyInterfacesTransceiverType, "success-with-large-range"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6860,7 +6860,7 @@ DATA: AntaUnitTestData = {
             "atomic_results": [{"description": f"Interface: Ethernet{i}", "result": AntaTestStatus.SUCCESS} for i in range(1, 13)],
         },
     },
-    (VerifyInterfacesTransceiverType, "success_with_three_level_slots"): {
+    (VerifyInterfacesTransceiverType, "success-with-three-level-slots"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6884,7 +6884,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "failure_multiple_ranges_mismatch"): {
+    (VerifyInterfacesTransceiverType, "failure-multiple-ranges-mismatch"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6906,10 +6906,10 @@ DATA: AntaUnitTestData = {
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": [
-                ("Interface: Ethernet5 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"),
-                ("Interface: Ethernet6 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"),
-                ("Interface: Ethernet7 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"),
-                ("Interface: Ethernet10 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 25GBASE-SR"),
+                "Interface: Ethernet5 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4",
+                "Interface: Ethernet6 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4",
+                "Interface: Ethernet7 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4",
+                "Interface: Ethernet10 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 25GBASE-SR",
             ],
             "atomic_results": [
                 {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
@@ -6938,7 +6938,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success_mixed_abbreviation_in_pattern"): {
+    (VerifyInterfacesTransceiverType, "success-mixed-abbreviation-in-pattern"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6960,7 +6960,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success_multiple_abbreviations_comma_separated"): {
+    (VerifyInterfacesTransceiverType, "success-multiple-abbreviations-comma-separated"): {
         "eos_data": [
             {
                 "interfaces": {

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6773,7 +6773,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success_with_shorthand"): {
+    (VerifyInterfacesTransceiverType, "success_with_abbreviation"): {
         "eos_data": [
             {
                 "interfaces": {
@@ -6872,7 +6872,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success_with_multiple_ranges"): {
+    (VerifyInterfacesTransceiverType, "failure_multiple_ranges_mismatch"): {
         "eos_data": [
             {
                 "interfaces": {

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6860,52 +6860,6 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "failure-empty-transceiver"): {
-        "eos_data": [
-            {
-                "interfaces": {
-                    "Ethernet1": {},
-                    "Ethernet2": {"mediaType": "100GBASE-SR4", "temperature": 31.6},
-                    "Ethernet3": {},
-                }
-            }
-        ],
-        "inputs": {
-            "interfaces": [
-                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
-            ]
-        },
-        "expected": {
-            "result": AntaTestStatus.FAILURE,
-            "messages": [
-                "Interface: Ethernet1 - Transceiver media type not found",
-                "Interface: Ethernet3 - Transceiver media type not found",
-            ],
-            "atomic_results": [
-                {"description": "Interface: Ethernet1", "result": AntaTestStatus.FAILURE, "messages": ["Transceiver media type not found"]},
-                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet3", "result": AntaTestStatus.FAILURE, "messages": ["Transceiver media type not found"]},
-            ],
-        },
-    },
-    (VerifyInterfacesTransceiverType, "success-with-large-range"): {
-        "eos_data": [
-            {
-                "interfaces": {
-                    **{f"Ethernet{i}": {"mediaType": "100GBASE-SR4"} for i in range(1, 13)},
-                }
-            }
-        ],
-        "inputs": {
-            "interfaces": [
-                {"name": "Ethernet1-12", "media_type": "100GBASE-SR4"},
-            ]
-        },
-        "expected": {
-            "result": AntaTestStatus.SUCCESS,
-            "atomic_results": [{"description": f"Interface: Ethernet{i}", "result": AntaTestStatus.SUCCESS} for i in range(1, 13)],
-        },
-    },
     (VerifyInterfacesTransceiverType, "failure-multiple-ranges-mismatch"): {
         "eos_data": [
             {
@@ -6957,31 +6911,6 @@ DATA: AntaUnitTestData = {
                     "result": AntaTestStatus.FAILURE,
                     "messages": ["Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 25GBASE-SR"],
                 },
-            ],
-        },
-    },
-    (VerifyInterfacesTransceiverType, "success-with-direct-name"): {
-        "eos_data": [
-            {
-                "interfaces": {
-                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet3": {"mediaType": "100GBASE-SR4"},
-                }
-            }
-        ],
-        "inputs": {
-            "interfaces": [
-                {"name": "Ethernet1", "media_type": "100GBASE-SR4"},
-                {"name": "Ethernet2-3", "media_type": "100GBASE-SR4"},
-            ]
-        },
-        "expected": {
-            "result": AntaTestStatus.SUCCESS,
-            "atomic_results": [
-                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
             ],
         },
     },

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6666,21 +6666,21 @@ DATA: AntaUnitTestData = {
                     "Ethernet1": {"mediaType": "100GBASE-SR4"},
                     "Ethernet2": {"mediaType": "100GBASE-SR4"},
                     "Ethernet3": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet4": {"mediaType": "40GBASE-SR4"},
-                    "Ethernet6": {"mediaType": "40GBASE-SR4"},
-                    "Ethernet7": {"mediaType": "25GBASE-SR"},
-                    "Ethernet1/1": {"mediaType": "25GBASE-LR"},
-                    "Ethernet1/2": {"mediaType": "25GBASE-LR"},
-                    "Ethernet1/3": {"mediaType": "25GBASE-LR"},
+                    "Ethernet50": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet51": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet1/1/1": {"mediaType": "25GBASE-LR"},
+                    "Ethernet1/1/2": {"mediaType": "25GBASE-LR"},
+                    "Ethernet10": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet11": {"mediaType": "100GBASE-SR4"},
                 }
             }
         ],
         "inputs": {
             "interfaces": [
                 {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
-                {"interface_range": "Ethernet4,6", "media_type": "40GBASE-SR4"},
-                {"name": "Ethernet7", "media_type": "25GBASE-SR"},
-                {"interface_range": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
+                {"interface_range": "et50-51", "media_type": "40GBASE-SR4"},
+                {"interface_range": "Ethernet1/1/1-2", "media_type": "25GBASE-LR"},
+                {"interface_range": "Ethernet10,et11", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6689,12 +6689,12 @@ DATA: AntaUnitTestData = {
                 {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet4", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet6", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet7", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet1/1", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet1/2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet1/3", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet50", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet51", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/1/1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/1/2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet10", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet11", "result": AntaTestStatus.SUCCESS},
             ],
         },
     },
@@ -6785,35 +6785,6 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success-with-abbreviation"): {
-        "eos_data": [
-            {
-                "interfaces": {
-                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet3": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet50": {"mediaType": "40GBASE-SR4"},
-                    "Ethernet51": {"mediaType": "40GBASE-SR4"},
-                }
-            }
-        ],
-        "inputs": {
-            "interfaces": [
-                {"interface_range": "et1-3", "media_type": "100GBASE-SR4"},
-                {"interface_range": "Ethernet50-51", "media_type": "40GBASE-SR4"},
-            ]
-        },
-        "expected": {
-            "result": AntaTestStatus.SUCCESS,
-            "atomic_results": [
-                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet50", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet51", "result": AntaTestStatus.SUCCESS},
-            ],
-        },
-    },
     (VerifyInterfacesTransceiverType, "failure-empty-transceiver"): {
         "eos_data": [
             {
@@ -6858,30 +6829,6 @@ DATA: AntaUnitTestData = {
         "expected": {
             "result": AntaTestStatus.SUCCESS,
             "atomic_results": [{"description": f"Interface: Ethernet{i}", "result": AntaTestStatus.SUCCESS} for i in range(1, 13)],
-        },
-    },
-    (VerifyInterfacesTransceiverType, "success-with-three-level-slots"): {
-        "eos_data": [
-            {
-                "interfaces": {
-                    "Ethernet1/1/1": {"mediaType": "25GBASE-LR"},
-                    "Ethernet1/1/2": {"mediaType": "25GBASE-LR"},
-                    "Ethernet1/1/3": {"mediaType": "25GBASE-LR"},
-                }
-            }
-        ],
-        "inputs": {
-            "interfaces": [
-                {"interface_range": "Ethernet1/1/1-3", "media_type": "25GBASE-LR"},
-            ]
-        },
-        "expected": {
-            "result": AntaTestStatus.SUCCESS,
-            "atomic_results": [
-                {"description": "Interface: Ethernet1/1/1", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet1/1/2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet1/1/3", "result": AntaTestStatus.SUCCESS},
-            ],
         },
     },
     (VerifyInterfacesTransceiverType, "failure-multiple-ranges-mismatch"): {
@@ -6944,12 +6891,14 @@ DATA: AntaUnitTestData = {
                 "interfaces": {
                     "Ethernet1": {"mediaType": "100GBASE-SR4"},
                     "Ethernet2": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet1/1/1": {"mediaType": "25GBASE-LR"},
                 }
             }
         ],
         "inputs": {
             "interfaces": [
                 {"interface_range": "Ethernet1,et2", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1/1/1", "media_type": "25GBASE-LR"},
             ]
         },
         "expected": {
@@ -6957,6 +6906,7 @@ DATA: AntaUnitTestData = {
             "atomic_results": [
                 {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/1/1", "result": AntaTestStatus.SUCCESS},
             ],
         },
     },
@@ -6966,14 +6916,16 @@ DATA: AntaUnitTestData = {
                 "interfaces": {
                     "Ethernet1": {"mediaType": "40GBASE-SR4"},
                     "Ethernet2": {"mediaType": "40GBASE-SR4"},
-                    "Ethernet50": {"mediaType": "40GBASE-SR4"},
-                    "Ethernet51": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet10": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet11": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet1/1/1": {"mediaType": "25GBASE-LR"},
                 }
             }
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "et1-2,Ethernet50-51", "media_type": "40GBASE-SR4"},
+                {"interface_range": "et1-2,Ethernet10-11", "media_type": "40GBASE-SR4"},
+                {"interface_range": "Ethernet1/1/1", "media_type": "25GBASE-LR"},
             ]
         },
         "expected": {
@@ -6981,8 +6933,9 @@ DATA: AntaUnitTestData = {
             "atomic_results": [
                 {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet50", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet51", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet10", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet11", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/1/1", "result": AntaTestStatus.SUCCESS},
             ],
         },
     },

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6677,10 +6677,10 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
-                {"interface_range": "et50-51", "media_type": "40GBASE-SR4"},
-                {"interface_range": "Ethernet1/1/1-2", "media_type": "25GBASE-LR"},
-                {"interface_range": "Ethernet10,et11", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"name": "et50-51", "media_type": "40GBASE-SR4"},
+                {"name": "Ethernet1/1/1-2", "media_type": "25GBASE-LR"},
+                {"name": "Ethernet10,et11", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6710,7 +6710,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6744,7 +6744,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6771,7 +6771,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "Ethernet1-2", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet1-2", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6797,7 +6797,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6823,7 +6823,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "Ethernet1-12", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet1-12", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6847,7 +6847,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "Ethernet1-3,5-7,10", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet1-3,5-7,10", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6885,31 +6885,6 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyInterfacesTransceiverType, "success-mixed-abbreviation-in-pattern"): {
-        "eos_data": [
-            {
-                "interfaces": {
-                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
-                    "Ethernet1/1/1": {"mediaType": "25GBASE-LR"},
-                }
-            }
-        ],
-        "inputs": {
-            "interfaces": [
-                {"interface_range": "Ethernet1,et2", "media_type": "100GBASE-SR4"},
-                {"interface_range": "Ethernet1/1/1", "media_type": "25GBASE-LR"},
-            ]
-        },
-        "expected": {
-            "result": AntaTestStatus.SUCCESS,
-            "atomic_results": [
-                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Ethernet1/1/1", "result": AntaTestStatus.SUCCESS},
-            ],
-        },
-    },
     (VerifyInterfacesTransceiverType, "success-with-direct-name"): {
         "eos_data": [
             {
@@ -6923,7 +6898,7 @@ DATA: AntaUnitTestData = {
         "inputs": {
             "interfaces": [
                 {"name": "Ethernet1", "media_type": "100GBASE-SR4"},
-                {"interface_range": "Ethernet2-3", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet2-3", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6949,8 +6924,8 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"interface_range": "et1-2,Ethernet10-11", "media_type": "40GBASE-SR4"},
-                {"interface_range": "Ethernet1/1/1", "media_type": "25GBASE-LR"},
+                {"name": "et1-2,Ethernet10-11", "media_type": "40GBASE-SR4"},
+                {"name": "Ethernet1/1/1", "media_type": "25GBASE-LR"},
             ]
         },
         "expected": {

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6677,10 +6677,10 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
-                {"name": "Ethernet4,6", "media_type": "40GBASE-SR4"},
+                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet4,6", "media_type": "40GBASE-SR4"},
                 {"name": "Ethernet7", "media_type": "25GBASE-SR"},
-                {"name": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
+                {"interface_range": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
             ]
         },
         "expected": {
@@ -6710,7 +6710,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6744,7 +6744,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6771,7 +6771,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1-2", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1-2", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6792,15 +6792,15 @@ DATA: AntaUnitTestData = {
                     "Ethernet1": {"mediaType": "100GBASE-SR4"},
                     "Ethernet2": {"mediaType": "100GBASE-SR4"},
                     "Ethernet3": {"mediaType": "100GBASE-SR4"},
-                    "Port-Channel1": {"mediaType": "40GBASE-SR4"},
-                    "Port-Channel2": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet50": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet51": {"mediaType": "40GBASE-SR4"},
                 }
             }
         ],
         "inputs": {
             "interfaces": [
-                {"name": "et1-3", "media_type": "100GBASE-SR4"},
-                {"name": "po1-2", "media_type": "40GBASE-SR4"},
+                {"interface_range": "et1-3", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet50-51", "media_type": "40GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6809,8 +6809,8 @@ DATA: AntaUnitTestData = {
                 {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Port-Channel1", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Port-Channel2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet50", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet51", "result": AntaTestStatus.SUCCESS},
             ],
         },
     },
@@ -6826,7 +6826,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6852,7 +6852,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1-12", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1-12", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6872,7 +6872,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1/1/1-3", "media_type": "25GBASE-LR"},
+                {"interface_range": "Ethernet1/1/1-3", "media_type": "25GBASE-LR"},
             ]
         },
         "expected": {
@@ -6900,7 +6900,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1-3,5-7,10", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1-3,5-7,10", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6949,7 +6949,7 @@ DATA: AntaUnitTestData = {
         ],
         "inputs": {
             "interfaces": [
-                {"name": "Ethernet1,et2", "media_type": "100GBASE-SR4"},
+                {"interface_range": "Ethernet1,et2", "media_type": "100GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6966,14 +6966,14 @@ DATA: AntaUnitTestData = {
                 "interfaces": {
                     "Ethernet1": {"mediaType": "40GBASE-SR4"},
                     "Ethernet2": {"mediaType": "40GBASE-SR4"},
-                    "Port-Channel3": {"mediaType": "40GBASE-SR4"},
-                    "Port-Channel4": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet50": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet51": {"mediaType": "40GBASE-SR4"},
                 }
             }
         ],
         "inputs": {
             "interfaces": [
-                {"name": "et1-2,po3-4", "media_type": "40GBASE-SR4"},
+                {"interface_range": "et1-2,Ethernet50-51", "media_type": "40GBASE-SR4"},
             ]
         },
         "expected": {
@@ -6981,8 +6981,8 @@ DATA: AntaUnitTestData = {
             "atomic_results": [
                 {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Port-Channel3", "result": AntaTestStatus.SUCCESS},
-                {"description": "Interface: Port-Channel4", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet50", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet51", "result": AntaTestStatus.SUCCESS},
             ],
         },
     },

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -27,6 +27,7 @@ from anta.tests.interfaces import (
     VerifyInterfacesPFCCounters,
     VerifyInterfacesSpeed,
     VerifyInterfacesStatus,
+    VerifyInterfacesTransceiverType,
     VerifyInterfacesTridentCounters,
     VerifyInterfacesVoqAndEgressQueueDrops,
     VerifyInterfaceUtilization,
@@ -6643,6 +6644,285 @@ DATA: AntaUnitTestData = {
             "messages": [
                 "Interface: Ethernet3/1/1 - Not found",
                 "Interface: Ethernet3/2/1 - Counters above threshold - Expected: <= 0 Actual RX PFC: 1 Actual TX PFC: 2",
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "success"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet3": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet4": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet6": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet7": {"mediaType": "25GBASE-SR"},
+                    "Ethernet1/1": {"mediaType": "25GBASE-LR"},
+                    "Ethernet1/2": {"mediaType": "25GBASE-LR"},
+                    "Ethernet1/3": {"mediaType": "25GBASE-LR"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"name": "Ethernet4,6", "media_type": "40GBASE-SR4"},
+                {"name": "Ethernet7", "media_type": "25GBASE-SR"},
+                {"name": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet4", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet6", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet7", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/3", "result": AntaTestStatus.SUCCESS},
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "failure_media_type_mismatch"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet2": {"mediaType": "100GBASE-LR4"},
+                    "Ethernet3": {"mediaType": "40GBASE-SR4"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                "Interface: Ethernet2 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 100GBASE-LR4",
+                "Interface: Ethernet3 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4",
+            ],
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {
+                    "description": "Interface: Ethernet2",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 100GBASE-LR4"],
+                },
+                {
+                    "description": "Interface: Ethernet3",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"],
+                },
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "failure_interface_not_found"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                "Interface: Ethernet2 - Not found",
+                "Interface: Ethernet3 - Not found",
+            ],
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.FAILURE, "messages": ["Not found"]},
+                {"description": "Interface: Ethernet3", "result": AntaTestStatus.FAILURE, "messages": ["Not found"]},
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "failure_transceiver_not_found"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {},
+                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1-2", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                "Interface: Ethernet1 - Transceiver media type not found",
+            ],
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.FAILURE, "messages": ["Transceiver media type not found"]},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "success_with_shorthand"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet3": {"mediaType": "100GBASE-SR4"},
+                    "Port-Channel1": {"mediaType": "40GBASE-SR4"},
+                    "Port-Channel2": {"mediaType": "40GBASE-SR4"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "et1-3", "media_type": "100GBASE-SR4"},
+                {"name": "po1-2", "media_type": "40GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Port-Channel1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Port-Channel2", "result": AntaTestStatus.SUCCESS},
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "failure_empty_transceiver"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {},
+                    "Ethernet2": {"mediaType": "100GBASE-SR4", "temperature": 31.6},
+                    "Ethernet3": {},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                "Interface: Ethernet1 - Transceiver media type not found",
+                "Interface: Ethernet3 - Transceiver media type not found",
+            ],
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.FAILURE, "messages": ["Transceiver media type not found"]},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet3", "result": AntaTestStatus.FAILURE, "messages": ["Transceiver media type not found"]},
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "success_with_large_range"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    **{f"Ethernet{i}": {"mediaType": "100GBASE-SR4"} for i in range(1, 13)},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1-12", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [{"description": f"Interface: Ethernet{i}", "result": AntaTestStatus.SUCCESS} for i in range(1, 13)],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "success_with_three_level_slots"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1/1/1": {"mediaType": "25GBASE-LR"},
+                    "Ethernet1/1/2": {"mediaType": "25GBASE-LR"},
+                    "Ethernet1/1/3": {"mediaType": "25GBASE-LR"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1/1/1-3", "media_type": "25GBASE-LR"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [
+                {"description": "Interface: Ethernet1/1/1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/1/2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet1/1/3", "result": AntaTestStatus.SUCCESS},
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "success_with_multiple_ranges"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet3": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet5": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet6": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet7": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet10": {"mediaType": "25GBASE-SR"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1-3,5-7,10", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                ("Interface: Ethernet5 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"),
+                ("Interface: Ethernet6 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"),
+                ("Interface: Ethernet7 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"),
+                ("Interface: Ethernet10 - Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 25GBASE-SR"),
+            ],
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
+                {
+                    "description": "Interface: Ethernet5",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"],
+                },
+                {
+                    "description": "Interface: Ethernet6",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"],
+                },
+                {
+                    "description": "Interface: Ethernet7",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 40GBASE-SR4"],
+                },
+                {
+                    "description": "Interface: Ethernet10",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Transceiver media type mismatch - Expected: 100GBASE-SR4 Actual: 25GBASE-SR"],
+                },
             ],
         },
     },

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6926,4 +6926,52 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
+    (VerifyInterfacesTransceiverType, "success_mixed_abbreviation_in_pattern"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet2": {"mediaType": "100GBASE-SR4"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "Ethernet1,et2", "media_type": "100GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+            ],
+        },
+    },
+    (VerifyInterfacesTransceiverType, "success_multiple_abbreviations_comma_separated"): {
+        "eos_data": [
+            {
+                "interfaces": {
+                    "Ethernet1": {"mediaType": "40GBASE-SR4"},
+                    "Ethernet2": {"mediaType": "40GBASE-SR4"},
+                    "Port-Channel3": {"mediaType": "40GBASE-SR4"},
+                    "Port-Channel4": {"mediaType": "40GBASE-SR4"},
+                }
+            }
+        ],
+        "inputs": {
+            "interfaces": [
+                {"name": "et1-2,po3-4", "media_type": "40GBASE-SR4"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [
+                {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Port-Channel3", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Port-Channel4", "result": AntaTestStatus.SUCCESS},
+            ],
+        },
+    },
 }

--- a/tests/units/anta_tests/test_interfaces.py
+++ b/tests/units/anta_tests/test_interfaces.py
@@ -6741,6 +6741,9 @@ DATA: AntaUnitTestData = {
                     "Ethernet1": {"mediaType": "100GBASE-SR4"},
                     "Ethernet2": {"mediaType": "100GBASE-SR4"},
                     "Ethernet3": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet4": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet5": {"mediaType": "100GBASE-SR4"},
+                    "Ethernet6": {"mediaType": "100GBASE-SR4"},
                     "Ethernet50": {"mediaType": "40GBASE-SR4"},
                     "Ethernet51": {"mediaType": "40GBASE-SR4"},
                     "Ethernet1/1/1": {"mediaType": "25GBASE-LR"},
@@ -6753,6 +6756,7 @@ DATA: AntaUnitTestData = {
         "inputs": {
             "interfaces": [
                 {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                {"name": ["eth4", "eth5", "eth6"], "media_type": "100GBASE-SR4"},
                 {"name": "et50-51", "media_type": "40GBASE-SR4"},
                 {"name": "Ethernet1/1/1-2", "media_type": "25GBASE-LR"},
                 {"name": "Ethernet10,et11", "media_type": "100GBASE-SR4"},
@@ -6764,6 +6768,9 @@ DATA: AntaUnitTestData = {
                 {"description": "Interface: Ethernet1", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet2", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet3", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet4", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet5", "result": AntaTestStatus.SUCCESS},
+                {"description": "Interface: Ethernet6", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet50", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet51", "result": AntaTestStatus.SUCCESS},
                 {"description": "Interface: Ethernet1/1/1", "result": AntaTestStatus.SUCCESS},

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -346,31 +346,31 @@ class TestVerifyInterfacesTransceiverTypeInput:  # pylint: disable=too-few-publi
                 [
                     {"name": "et1-3", "media_type": "100GBASE-SR4"},
                 ],
-                id="shorthand-et",
+                id="abbreviation-et",
             ),
             pytest.param(
                 [
                     {"name": "po1-3", "media_type": "40GBASE-SR4"},
                 ],
-                id="shorthand-po",
+                id="abbreviation-po",
             ),
             pytest.param(
                 [
                     {"name": "lo0", "media_type": "N/A"},
                 ],
-                id="shorthand-loopback",
+                id="abbreviation-loopback",
             ),
             pytest.param(
                 [
                     {"name": "vl1-3", "media_type": "N/A"},
                 ],
-                id="shorthand-vlan",
+                id="abbreviation-vlan",
             ),
             pytest.param(
                 [
                     {"name": "ET1", "media_type": "100GBASE-SR4"},
                 ],
-                id="uppercase-shorthand",
+                id="uppercase-abbreviation",
             ),
             pytest.param(
                 [

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -21,6 +21,7 @@ from anta.tests.interfaces import (
     VerifyInterfacesOpticsTemperature,
     VerifyInterfacesSpeed,
     VerifyInterfacesStatus,
+    VerifyInterfacesTransceiverType,
     VerifyLACPInterfacesStatus,
 )
 
@@ -309,3 +310,78 @@ class TestVerifyInterfacesOpticsTemperatureInput:
             VerifyInterfacesOpticsTemperature.Input(
                 interfaces=interfaces, ignored_interfaces=ignored_interfaces, max_transceiver_temperature=max_transceiver_temperature
             )
+
+
+class TestVerifyInterfacesTransceiverTypeInput:  # pylint: disable=too-few-public-methods
+    """Test anta.tests.interfaces.VerifyInterfacesTransceiverType.Input."""
+
+    @pytest.mark.parametrize(
+        ("interfaces"),
+        [
+            pytest.param(
+                [
+                    {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                ],
+                id="basic-range",
+            ),
+            pytest.param(
+                [
+                    {"name": "Ethernet4,6", "media_type": "40GBASE-SR4"},
+                ],
+                id="comma-separated",
+            ),
+            pytest.param(
+                [
+                    {"name": "Ethernet7", "media_type": "25GBASE-SR"},
+                ],
+                id="single-interface",
+            ),
+            pytest.param(
+                [
+                    {"name": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
+                ],
+                id="multi-level-slots",
+            ),
+            pytest.param(
+                [
+                    {"name": "et1-3", "media_type": "100GBASE-SR4"},
+                ],
+                id="shorthand-et",
+            ),
+            pytest.param(
+                [
+                    {"name": "po1-3", "media_type": "40GBASE-SR4"},
+                ],
+                id="shorthand-po",
+            ),
+            pytest.param(
+                [
+                    {"name": "lo0", "media_type": "N/A"},
+                ],
+                id="shorthand-loopback",
+            ),
+            pytest.param(
+                [
+                    {"name": "vl1-3", "media_type": "N/A"},
+                ],
+                id="shorthand-vlan",
+            ),
+            pytest.param(
+                [
+                    {"name": "ET1", "media_type": "100GBASE-SR4"},
+                ],
+                id="uppercase-shorthand",
+            ),
+            pytest.param(
+                [
+                    {"name": "eth1-3", "media_type": "100GBASE-SR4"},
+                    {"name": "po1-2", "media_type": "40GBASE-SR4"},
+                    {"name": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
+                ],
+                id="mixed-formats",
+            ),
+        ],
+    )
+    def test_valid(self, interfaces: list) -> None:
+        """Test VerifyInterfacesTransceiverType.Input valid inputs."""
+        VerifyInterfacesTransceiverType.Input(interfaces=interfaces)

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -380,6 +380,18 @@ class TestVerifyInterfacesTransceiverTypeInput:  # pylint: disable=too-few-publi
                 ],
                 id="mixed-formats",
             ),
+            pytest.param(
+                [
+                    {"name": "Ethernet1,et2", "media_type": "100GBASE-SR4"},
+                ],
+                id="mixed-abbreviation-in-pattern",
+            ),
+            pytest.param(
+                [
+                    {"name": "et1,po2", "media_type": "40GBASE-SR4"},
+                ],
+                id="multiple-abbreviations-comma-separated",
+            ),
         ],
     )
     def test_valid(self, interfaces: list) -> None:

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -55,10 +55,11 @@ class TestInterfaceState:
             pytest.param({"name": "Ethernet1-3", "media_type": "100GBASE-SR4"}, id="range"),
             pytest.param({"name": "et1-3", "media_type": "100GBASE-SR4"}, id="abbreviated-range"),
             pytest.param({"name": "et1,po2", "media_type": "40GBASE-SR4"}, id="comma-separated-abbreviations"),
+            pytest.param({"name": ["Ethernet1", "Ethernet2"]}, id="pre-expanded-list"),
         ],
     )
     def test_valid(self, model_params: dict) -> None:
-        """Test InterfaceState valid inputs — single names, abbreviations, and range patterns."""
+        """Test InterfaceState valid inputs — single names, abbreviations, range patterns, and pre-expanded lists."""
         InterfaceState.model_validate(model_params)
 
     @pytest.mark.parametrize(
@@ -74,10 +75,20 @@ class TestInterfaceState:
                 r"Extra inputs are not permitted",
                 id="extra-interface-range-field",
             ),
+            pytest.param(
+                {"name": "GigabitEthernet1-3", "media_type": "100GBASE-SR4"},
+                r"String should match pattern",
+                id="range-with-unsupported-interface-type",
+            ),
+            pytest.param(
+                {"name": "abc"},
+                r"Could not parse interface ID in interface",
+                id="non-parseable-string",
+            ),
         ],
     )
     def test_invalid(self, model_params: dict, error_match: str) -> None:
-        """Test InterfaceState rejects missing required fields and unknown extra fields."""
+        """Test InterfaceState rejects missing required fields, unknown extra fields, and invalid EOS interface types."""
         with pytest.raises(ValidationError, match=error_match):
             InterfaceState.model_validate(model_params)
 

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -345,10 +345,12 @@ class TestVerifyInterfacesTransceiverTypeInput:
             pytest.param([{"name": "Ethernet1-3", "media_type": "100GBASE-SR4"}], id="range"),
             pytest.param([{"name": "et1-3", "media_type": "100GBASE-SR4"}], id="abbreviated-range"),
             pytest.param([{"name": "Ethernet1,et2", "media_type": "100GBASE-SR4"}], id="comma-separated"),
+            pytest.param([{"name": ["eth1", "eth2", "eth3"], "media_type": "100GBASE-SR4"}], id="pre-expanded-abbreviated-list"),
+            pytest.param([{"name": "ether1-ether3", "media_type": "100GBASE-SR4"}], id="repeated-prefix-range-unrecognized-alias"),
         ],
     )
     def test_valid(self, interfaces: list[InterfaceState]) -> None:
-        """Test VerifyInterfacesTransceiverType.Input accepts single names, ranges, and comma-separated patterns."""
+        """Test VerifyInterfacesTransceiverType.Input accepts single names, ranges, comma-separated patterns, and pre-expanded lists."""
         VerifyInterfacesTransceiverType.Input(interfaces=interfaces)
 
     @pytest.mark.parametrize(

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -21,7 +21,6 @@ from anta.tests.interfaces import (
     VerifyInterfacesOpticsTemperature,
     VerifyInterfacesSpeed,
     VerifyInterfacesStatus,
-    VerifyInterfacesTransceiverType,
     VerifyLACPInterfacesStatus,
 )
 
@@ -82,35 +81,6 @@ class TestInterfaceState:
         """Test InterfaceState invalid inputs with proper error messages."""
         with pytest.raises(ValidationError, match=error_match):
             InterfaceState.model_validate(model_params)
-
-    @pytest.mark.parametrize(
-        ("interface_range", "media_type"),
-        [
-            pytest.param("Ethernet1", "100GBASE-SR4", id="single-interface-range"),
-            pytest.param("Ethernet1-5", "100GBASE-SR4", id="range-5-items"),
-            pytest.param("Ethernet1/1-3", "25GBASE-LR", id="multi-level-range"),
-            pytest.param("po1-2", "40GBASE-SR4", id="portchannel-range"),
-        ],
-    )
-    def test_valid_complex(self, interface_range: str, media_type: str) -> None:
-        """Test various valid interface_range scenarios."""
-        interface_state = InterfaceState.model_validate({"interface_range": interface_range, "media_type": media_type})
-        assert interface_state.interface_range is not None
-        assert len(interface_state.interface_range) > 0
-
-    @pytest.mark.parametrize(
-        ("interface_range", "media_type", "error_match"),
-        [
-            pytest.param("1-3", "100GBASE-SR4", r"Invalid interface pattern", id="no-prefix"),
-            pytest.param("Ethernet3-1", "100GBASE-SR4", r"Reverse range not supported", id="reverse-range"),
-            pytest.param("Ethernet1-1001", "100GBASE-SR4", r"Range too large", id="oversized-range"),
-            pytest.param("@#$%^", "100GBASE-SR4", r"Invalid interface pattern", id="unparseable-name"),
-        ],
-    )
-    def test_invalid_complex(self, interface_range: str, media_type: str, error_match: str) -> None:
-        """Test invalid interface_range patterns."""
-        with pytest.raises(ValidationError, match=error_match):
-            InterfaceState.model_validate({"interface_range": interface_range, "media_type": media_type})
 
 
 class TestVerifyInterfacesStatusInput:
@@ -377,56 +347,3 @@ class TestVerifyInterfacesOpticsTemperatureInput:
             VerifyInterfacesOpticsTemperature.Input(
                 interfaces=interfaces, ignored_interfaces=ignored_interfaces, max_transceiver_temperature=max_transceiver_temperature
             )
-
-
-class TestVerifyInterfacesTransceiverTypeInput:  # pylint: disable=too-few-public-methods
-    """Test anta.tests.interfaces.VerifyInterfacesTransceiverType.Input."""
-
-    @pytest.mark.parametrize(
-        "interfaces",
-        [
-            pytest.param(
-                [{"name": "Ethernet7", "media_type": "25GBASE-SR"}],
-                id="single-interface",
-            ),
-            pytest.param(
-                [{"interface_range": "et1-3", "media_type": "100GBASE-SR4"}],
-                id="interface-range",
-            ),
-            pytest.param(
-                [
-                    {"interface_range": "Ethernet1-2", "media_type": "100GBASE-SR4"},
-                    {"name": "Ethernet3", "media_type": "40GBASE-SR4"},
-                ],
-                id="range-and-single-interface",
-            ),
-        ],
-    )
-    def test_valid(self, interfaces: list[dict[str, str]]) -> None:
-        """Test VerifyInterfacesTransceiverType.Input valid inputs."""
-        VerifyInterfacesTransceiverType.Input.model_validate({"interfaces": interfaces})
-
-    @pytest.mark.parametrize(
-        ("interfaces", "error_match"),
-        [
-            pytest.param(
-                [{"name": "Ethernet1", "media_type": "100GBASE-SR4"}, {"name": "Ethernet2"}],
-                r"'media_type' must be provided for all interfaces in VerifyInterfacesTransceiverType",
-                id="missing-media-type",
-            ),
-            pytest.param(
-                [{"interface_range": "Ethernet1-2,po3", "media_type": "40GBASE-SR4"}],
-                r"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: Port-Channel3",
-                id="non-ethernet-in-range",
-            ),
-            pytest.param(
-                [{"name": "Port-Channel3", "media_type": "40GBASE-SR4"}],
-                r"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: Port-Channel3",
-                id="non-ethernet-interface",
-            ),
-        ],
-    )
-    def test_invalid(self, interfaces: list[dict[str, str]], error_match: str) -> None:
-        """Test VerifyInterfacesTransceiverType.Input invalid inputs."""
-        with pytest.raises(ValidationError, match=error_match):
-            VerifyInterfacesTransceiverType.Input.model_validate({"interfaces": interfaces})

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -103,6 +103,8 @@ class TestInterfaceState:
         [
             pytest.param("1-3", "100GBASE-SR4", r"Invalid interface pattern", id="no-prefix"),
             pytest.param("Ethernet3-1", "100GBASE-SR4", r"Reverse range not supported", id="reverse-range"),
+            pytest.param("Ethernet1-1001", "100GBASE-SR4", r"Range too large", id="oversized-range"),
+            pytest.param("@#$%^", "100GBASE-SR4", r"Invalid interface pattern", id="unparseable-name"),
         ],
     )
     def test_invalid_complex(self, interface_range: str, media_type: str, error_match: str) -> None:

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -21,6 +21,7 @@ from anta.tests.interfaces import (
     VerifyInterfacesOpticsTemperature,
     VerifyInterfacesSpeed,
     VerifyInterfacesStatus,
+    VerifyInterfacesTransceiverType,
     VerifyLACPInterfacesStatus,
 )
 
@@ -307,6 +308,41 @@ class TestVerifyInterfacesEgressQueueDropsInput:
         """Test VerifyInterfacesEgressQueueDrops.Input invalid inputs."""
         with pytest.raises(ValidationError):
             VerifyInterfacesEgressQueueDrops.Input(interfaces=interfaces, ignored_interfaces=ignored_interfaces)
+
+
+class TestVerifyInterfacesTransceiverTypeInput:
+    """Test anta.tests.interfaces.VerifyInterfacesTransceiverType.Input."""
+
+    @pytest.mark.parametrize(
+        "interfaces",
+        [
+            pytest.param([{"name": "Ethernet1", "media_type": "100GBASE-SR4"}], id="single-name"),
+            pytest.param([{"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"}], id="interface-range"),
+        ],
+    )
+    def test_valid(self, interfaces: list[InterfaceState]) -> None:
+        """Test VerifyInterfacesTransceiverType.Input valid inputs."""
+        VerifyInterfacesTransceiverType.Input(interfaces=interfaces)
+
+    @pytest.mark.parametrize(
+        ("interfaces", "error_match"),
+        [
+            pytest.param(
+                [{"name": "Ethernet1"}],
+                r"'media_type' must be provided for all interfaces",
+                id="missing-media-type",
+            ),
+            pytest.param(
+                [{"name": "Loopback1", "media_type": "100GBASE-SR4"}],
+                r"VerifyInterfacesTransceiverType only supports Ethernet interfaces\. Got: Loopback1",
+                id="non-ethernet-interface",
+            ),
+        ],
+    )
+    def test_invalid(self, interfaces: list[InterfaceState], error_match: str) -> None:
+        """Test VerifyInterfacesTransceiverType.Input invalid inputs."""
+        with pytest.raises(ValidationError, match=error_match):
+            VerifyInterfacesTransceiverType.Input(interfaces=interfaces)
 
 
 class TestVerifyInterfacesOpticsTemperatureInput:

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -45,6 +45,71 @@ class TestInterfaceState:
         """Test InterfaceState __str__."""
         assert str(InterfaceState(name=name, portchannel=portchannel)) == expected
 
+    @pytest.mark.parametrize(
+        "model_params",
+        [
+            pytest.param({"name": "Ethernet1"}, id="name-only"),
+            pytest.param(
+                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
+                id="interface-range-with-media-type",
+            ),
+            pytest.param(
+                {"interface_range": "et1,po2", "media_type": "40GBASE-SR4"},
+                id="interface-range-abbreviation-with-media-type",
+            ),
+        ],
+    )
+    def test_valid(self, model_params: dict) -> None:
+        """Test InterfaceState valid inputs with name or interface_range."""
+        InterfaceState.model_validate(model_params)
+
+    @pytest.mark.parametrize(
+        ("model_params", "error_match"),
+        [
+            pytest.param(
+                {"name": None, "interface_range": None},
+                r"Either 'name' or 'interface_range' must be provided",
+                id="neither-name-nor-range",
+            ),
+            pytest.param(
+                {"name": "Ethernet1", "interface_range": "Ethernet2-3", "media_type": "100GBASE-SR4"},
+                r"Only one of 'name' or 'interface_range' can be provided, not both",
+                id="both-name-and-range",
+            ),
+        ],
+    )
+    def test_invalid(self, model_params: dict, error_match: str) -> None:
+        """Test InterfaceState invalid inputs with proper error messages."""
+        with pytest.raises(ValidationError, match=error_match):
+            InterfaceState.model_validate(model_params)
+
+    @pytest.mark.parametrize(
+        ("interface_range", "media_type"),
+        [
+            pytest.param("Ethernet1", "100GBASE-SR4", id="single-interface-range"),
+            pytest.param("Ethernet1-5", "100GBASE-SR4", id="range-5-items"),
+            pytest.param("Ethernet1/1-3", "25GBASE-LR", id="multi-level-range"),
+            pytest.param("po1-2", "40GBASE-SR4", id="portchannel-range"),
+        ],
+    )
+    def test_valid_complex(self, interface_range: str, media_type: str) -> None:
+        """Test various valid interface_range scenarios."""
+        interface_state = InterfaceState.model_validate({"interface_range": interface_range, "media_type": media_type})
+        assert interface_state.interface_range is not None
+        assert len(interface_state.interface_range) > 0
+
+    @pytest.mark.parametrize(
+        ("interface_range", "media_type", "error_match"),
+        [
+            pytest.param("1-3", "100GBASE-SR4", r"Invalid interface pattern", id="no-prefix"),
+            pytest.param("Ethernet3-1", "100GBASE-SR4", r"Reverse range not supported", id="reverse-range"),
+        ],
+    )
+    def test_invalid_complex(self, interface_range: str, media_type: str, error_match: str) -> None:
+        """Test invalid interface_range patterns."""
+        with pytest.raises(ValidationError, match=error_match):
+            InterfaceState.model_validate({"interface_range": interface_range, "media_type": media_type})
+
 
 class TestVerifyInterfacesStatusInput:
     """Test anta.tests.interfaces.VerifyInterfacesStatus.Input."""
@@ -169,8 +234,7 @@ class TestVerifyPhysicalInterfacesCounterDetailsInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces", "link_status_changes_threshold"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], 10, id="invalid-interfaces"),
-            pytest.param(["et1"], ["Ethernet1"], 10, id="invalid-interfaces"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], 10, id="invalid-overlap"),
         ],
     )
     def test_invalid(
@@ -202,8 +266,7 @@ class TestVerifytInterfacesBERInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces"),
         [
-            pytest.param(["Ethernet1/1"], ["Ethernet1/1"], id="invalid-interfaces"),
-            pytest.param(["et1"], ["Ethernet1"], id="invalid-interfaces"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-overlap"),
         ],
     )
     def test_invalid(self, interfaces: list[EthernetInterface], ignored_interfaces: list[EthernetInterface]) -> None:
@@ -228,8 +291,7 @@ class TestVerifyInterfacesOpticalReceivePowerInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces"),
         [
-            pytest.param(["Ethernet1/1"], ["Ethernet1/1"], id="invalid-interfaces"),
-            pytest.param(["et1"], ["Ethernet1"], id="invalid-interfaces"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-overlap"),
         ],
     )
     def test_invalid(self, interfaces: list[EthernetInterface], ignored_interfaces: list[EthernetInterface]) -> None:
@@ -258,8 +320,7 @@ class TestVerifyInterfacesEgressQueueDropsInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-interfaces"),
-            pytest.param(["et1"], ["Ethernet1"], id="invalid-interfaces"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-overlap"),
         ],
     )
     def test_invalid(
@@ -295,8 +356,7 @@ class TestVerifyInterfacesOpticsTemperatureInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces", "max_transceiver_temperature"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], 10.00, id="invalid-interfaces"),
-            pytest.param(["et1"], ["Ethernet1"], 10, id="invalid-interfaces"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], 10.00, id="invalid-overlap"),
         ],
     )
     def test_invalid(
@@ -316,84 +376,50 @@ class TestVerifyInterfacesTransceiverTypeInput:  # pylint: disable=too-few-publi
     """Test anta.tests.interfaces.VerifyInterfacesTransceiverType.Input."""
 
     @pytest.mark.parametrize(
-        ("interfaces"),
+        "interfaces",
         [
             pytest.param(
-                [
-                    {"name": "Ethernet1-3", "media_type": "100GBASE-SR4"},
-                ],
-                id="basic-range",
-            ),
-            pytest.param(
-                [
-                    {"name": "Ethernet4,6", "media_type": "40GBASE-SR4"},
-                ],
-                id="comma-separated",
-            ),
-            pytest.param(
-                [
-                    {"name": "Ethernet7", "media_type": "25GBASE-SR"},
-                ],
+                [{"name": "Ethernet7", "media_type": "25GBASE-SR"}],
                 id="single-interface",
             ),
             pytest.param(
-                [
-                    {"name": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
-                ],
-                id="multi-level-slots",
+                [{"interface_range": "et1-3", "media_type": "100GBASE-SR4"}],
+                id="interface-range",
             ),
             pytest.param(
                 [
-                    {"name": "et1-3", "media_type": "100GBASE-SR4"},
+                    {"interface_range": "Ethernet1-2", "media_type": "100GBASE-SR4"},
+                    {"name": "Ethernet3", "media_type": "40GBASE-SR4"},
                 ],
-                id="abbreviation-et",
-            ),
-            pytest.param(
-                [
-                    {"name": "po1-3", "media_type": "40GBASE-SR4"},
-                ],
-                id="abbreviation-po",
-            ),
-            pytest.param(
-                [
-                    {"name": "lo0", "media_type": "N/A"},
-                ],
-                id="abbreviation-loopback",
-            ),
-            pytest.param(
-                [
-                    {"name": "vl1-3", "media_type": "N/A"},
-                ],
-                id="abbreviation-vlan",
-            ),
-            pytest.param(
-                [
-                    {"name": "ET1", "media_type": "100GBASE-SR4"},
-                ],
-                id="uppercase-abbreviation",
-            ),
-            pytest.param(
-                [
-                    {"name": "eth1-3", "media_type": "100GBASE-SR4"},
-                    {"name": "po1-2", "media_type": "40GBASE-SR4"},
-                    {"name": "Ethernet1/1-3", "media_type": "25GBASE-LR"},
-                ],
-                id="mixed-formats",
-            ),
-            pytest.param(
-                [
-                    {"name": "Ethernet1,et2", "media_type": "100GBASE-SR4"},
-                ],
-                id="mixed-abbreviation-in-pattern",
-            ),
-            pytest.param(
-                [
-                    {"name": "et1,po2", "media_type": "40GBASE-SR4"},
-                ],
-                id="multiple-abbreviations-comma-separated",
+                id="range-and-single-interface",
             ),
         ],
     )
-    def test_valid(self, interfaces: list) -> None:
+    def test_valid(self, interfaces: list[dict[str, str]]) -> None:
         """Test VerifyInterfacesTransceiverType.Input valid inputs."""
-        VerifyInterfacesTransceiverType.Input(interfaces=interfaces)
+        VerifyInterfacesTransceiverType.Input.model_validate({"interfaces": interfaces})
+
+    @pytest.mark.parametrize(
+        ("interfaces", "error_match"),
+        [
+            pytest.param(
+                [{"name": "Ethernet1", "media_type": "100GBASE-SR4"}, {"name": "Ethernet2"}],
+                r"'media_type' must be provided for all interfaces in VerifyInterfacesTransceiverType",
+                id="missing-media-type",
+            ),
+            pytest.param(
+                [{"interface_range": "Ethernet1-2,po3", "media_type": "40GBASE-SR4"}],
+                r"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: Port-Channel3",
+                id="non-ethernet-in-range",
+            ),
+            pytest.param(
+                [{"name": "Port-Channel3", "media_type": "40GBASE-SR4"}],
+                r"VerifyInterfacesTransceiverType only supports Ethernet interfaces. Got: Port-Channel3",
+                id="non-ethernet-interface",
+            ),
+        ],
+    )
+    def test_invalid(self, interfaces: list[dict[str, str]], error_match: str) -> None:
+        """Test VerifyInterfacesTransceiverType.Input invalid inputs."""
+        with pytest.raises(ValidationError, match=error_match):
+            VerifyInterfacesTransceiverType.Input.model_validate({"interfaces": interfaces})

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -32,56 +32,70 @@ if TYPE_CHECKING:
 class TestInterfaceState:
     """Test anta.input_models.interfaces.InterfaceState."""
 
-    # pylint: disable=too-few-public-methods
-
     @pytest.mark.parametrize(
-        ("name", "portchannel", "expected"),
+        ("name", "portchannel", "description", "expected"),
         [
-            pytest.param("Ethernet1", "Port-Channel42", "Interface: Ethernet1 Port-Channel: Port-Channel42", id="with port-channel"),
-            pytest.param("Ethernet1", None, "Interface: Ethernet1", id="no port-channel"),
+            pytest.param("Ethernet1", "Port-Channel42", None, "Interface: Ethernet1 Port-Channel: Port-Channel42", id="with-port-channel"),
+            pytest.param("Ethernet1", None, None, "Interface: Ethernet1", id="name-only"),
+            pytest.param("Ethernet1", None, "uplink", "Interface: Ethernet1 (uplink)", id="with-description"),
+            pytest.param(
+                "Ethernet1", "Port-Channel42", "uplink", "Interface: Ethernet1 (uplink) Port-Channel: Port-Channel42", id="with-description-and-port-channel"
+            ),
         ],
     )
-    def test_valid__str__(self, name: Interface, portchannel: PortChannelInterface | None, expected: str) -> None:
-        """Test InterfaceState __str__."""
-        assert str(InterfaceState(name=name, portchannel=portchannel)) == expected
+    def test_valid__str__(self, name: Interface, portchannel: PortChannelInterface | None, description: str | None, expected: str) -> None:
+        """Test InterfaceState __str__ covers all optional field combinations."""
+        assert str(InterfaceState(name=name, portchannel=portchannel, description=description)) == expected
 
     @pytest.mark.parametrize(
         "model_params",
         [
-            pytest.param({"name": "Ethernet1"}, id="name-only"),
-            pytest.param(
-                {"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"},
-                id="interface-range-with-media-type",
-            ),
-            pytest.param(
-                {"interface_range": "et1,po2", "media_type": "40GBASE-SR4"},
-                id="interface-range-abbreviation-with-media-type",
-            ),
+            pytest.param({"name": "Ethernet1"}, id="single-interface"),
+            pytest.param({"name": "et1"}, id="single-abbreviation"),
+            pytest.param({"name": "Ethernet1-3", "media_type": "100GBASE-SR4"}, id="range"),
+            pytest.param({"name": "et1-3", "media_type": "100GBASE-SR4"}, id="abbreviated-range"),
+            pytest.param({"name": "et1,po2", "media_type": "40GBASE-SR4"}, id="comma-separated-abbreviations"),
         ],
     )
     def test_valid(self, model_params: dict) -> None:
-        """Test InterfaceState valid inputs with name or interface_range."""
+        """Test InterfaceState valid inputs — single names, abbreviations, and range patterns."""
         InterfaceState.model_validate(model_params)
 
     @pytest.mark.parametrize(
         ("model_params", "error_match"),
         [
             pytest.param(
-                {"name": None, "interface_range": None},
-                r"Either 'name' or 'interface_range' must be provided",
-                id="neither-name-nor-range",
+                {},
+                r"Field required",
+                id="missing-name",
             ),
             pytest.param(
                 {"name": "Ethernet1", "interface_range": "Ethernet2-3", "media_type": "100GBASE-SR4"},
-                r"Only one of 'name' or 'interface_range' can be provided, not both",
-                id="both-name-and-range",
+                r"Extra inputs are not permitted",
+                id="extra-interface-range-field",
             ),
         ],
     )
     def test_invalid(self, model_params: dict, error_match: str) -> None:
-        """Test InterfaceState invalid inputs with proper error messages."""
+        """Test InterfaceState rejects missing required fields and unknown extra fields."""
         with pytest.raises(ValidationError, match=error_match):
             InterfaceState.model_validate(model_params)
+
+    @pytest.mark.parametrize(
+        ("model_params", "expected_names"),
+        [
+            pytest.param({"name": "Ethernet1"}, ["Ethernet1"], id="single-returns-self"),
+            pytest.param({"name": "Ethernet1-3"}, ["Ethernet1", "Ethernet2", "Ethernet3"], id="range-expands"),
+            pytest.param({"name": "et1-2"}, ["Ethernet1", "Ethernet2"], id="abbreviated-range-expands-and-normalizes"),
+            pytest.param({"name": "Ethernet1,et2"}, ["Ethernet1", "Ethernet2"], id="comma-separated-expands"),
+        ],
+    )
+    def test_expand(self, model_params: dict, expected_names: list[str]) -> None:
+        """Test InterfaceState.expand() yields individual str-named entries for every input shape."""
+        interface = InterfaceState.model_validate(model_params)
+        expanded = interface.expand()
+        assert [e.name for e in expanded] == expected_names
+        assert all(isinstance(e.name, str) for e in expanded), "Every expanded entry must have a str name"
 
 
 class TestVerifyInterfacesStatusInput:
@@ -316,12 +330,14 @@ class TestVerifyInterfacesTransceiverTypeInput:
     @pytest.mark.parametrize(
         "interfaces",
         [
-            pytest.param([{"name": "Ethernet1", "media_type": "100GBASE-SR4"}], id="single-name"),
-            pytest.param([{"interface_range": "Ethernet1-3", "media_type": "100GBASE-SR4"}], id="interface-range"),
+            pytest.param([{"name": "Ethernet1", "media_type": "100GBASE-SR4"}], id="single-interface"),
+            pytest.param([{"name": "Ethernet1-3", "media_type": "100GBASE-SR4"}], id="range"),
+            pytest.param([{"name": "et1-3", "media_type": "100GBASE-SR4"}], id="abbreviated-range"),
+            pytest.param([{"name": "Ethernet1,et2", "media_type": "100GBASE-SR4"}], id="comma-separated"),
         ],
     )
     def test_valid(self, interfaces: list[InterfaceState]) -> None:
-        """Test VerifyInterfacesTransceiverType.Input valid inputs."""
+        """Test VerifyInterfacesTransceiverType.Input accepts single names, ranges, and comma-separated patterns."""
         VerifyInterfacesTransceiverType.Input(interfaces=interfaces)
 
     @pytest.mark.parametrize(
@@ -329,18 +345,23 @@ class TestVerifyInterfacesTransceiverTypeInput:
         [
             pytest.param(
                 [{"name": "Ethernet1"}],
-                r"'media_type' must be provided for all interfaces",
+                r"Interface: Ethernet1 'media_type' field missing in the input",
                 id="missing-media-type",
             ),
             pytest.param(
                 [{"name": "Loopback1", "media_type": "100GBASE-SR4"}],
                 r"VerifyInterfacesTransceiverType only supports Ethernet interfaces\. Got: Loopback1",
-                id="non-ethernet-interface",
+                id="non-ethernet-single",
+            ),
+            pytest.param(
+                [{"name": "Loopback1-3", "media_type": "100GBASE-SR4"}],
+                r"VerifyInterfacesTransceiverType only supports Ethernet interfaces\. Got: Loopback1, Loopback2, Loopback3",
+                id="non-ethernet-range",
             ),
         ],
     )
     def test_invalid(self, interfaces: list[InterfaceState], error_match: str) -> None:
-        """Test VerifyInterfacesTransceiverType.Input invalid inputs."""
+        """Test VerifyInterfacesTransceiverType.Input rejects missing media_type and non-Ethernet interfaces."""
         with pytest.raises(ValidationError, match=error_match):
             VerifyInterfacesTransceiverType.Input(interfaces=interfaces)
 

--- a/tests/units/input_models/test_interfaces.py
+++ b/tests/units/input_models/test_interfaces.py
@@ -236,7 +236,8 @@ class TestVerifyPhysicalInterfacesCounterDetailsInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces", "link_status_changes_threshold"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], 10, id="invalid-overlap"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], 10, id="invalid-interfaces"),
+            pytest.param(["et1"], ["Ethernet1"], 10, id="invalid-interfaces"),
         ],
     )
     def test_invalid(
@@ -268,7 +269,8 @@ class TestVerifytInterfacesBERInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-overlap"),
+            pytest.param(["Ethernet1/1"], ["Ethernet1/1"], id="invalid-interfaces"),
+            pytest.param(["et1"], ["Ethernet1"], id="invalid-interfaces"),
         ],
     )
     def test_invalid(self, interfaces: list[EthernetInterface], ignored_interfaces: list[EthernetInterface]) -> None:
@@ -293,7 +295,8 @@ class TestVerifyInterfacesOpticalReceivePowerInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-overlap"),
+            pytest.param(["Ethernet1/1"], ["Ethernet1/1"], id="invalid-interfaces"),
+            pytest.param(["et1"], ["Ethernet1"], id="invalid-interfaces"),
         ],
     )
     def test_invalid(self, interfaces: list[EthernetInterface], ignored_interfaces: list[EthernetInterface]) -> None:
@@ -322,7 +325,8 @@ class TestVerifyInterfacesEgressQueueDropsInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-overlap"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], id="invalid-interfaces"),
+            pytest.param(["et1"], ["Ethernet1"], id="invalid-interfaces"),
         ],
     )
     def test_invalid(
@@ -358,7 +362,8 @@ class TestVerifyInterfacesOpticsTemperatureInput:
     @pytest.mark.parametrize(
         ("interfaces", "ignored_interfaces", "max_transceiver_temperature"),
         [
-            pytest.param(["Ethernet1"], ["Ethernet1"], 10.00, id="invalid-overlap"),
+            pytest.param(["Ethernet1"], ["Ethernet1"], 10.00, id="invalid-interfaces"),
+            pytest.param(["et1"], ["Ethernet1"], 10, id="invalid-interfaces"),
         ],
     )
     def test_invalid(

--- a/tests/units/test_custom_types.py
+++ b/tests/units/test_custom_types.py
@@ -25,6 +25,7 @@ from anta.custom_types import (
     aaa_group_prefix,
     bgp_multiprotocol_capabilities_abbreviations,
     convert_reload_cause,
+    expand_interface_pattern,
     interface_autocomplete,
     interface_case_sensitivity,
     snmp_v3_prefix,
@@ -323,3 +324,32 @@ def test_invalid_convert_reload_cause(str_input: str) -> None:
     """Test invalid convert_reload_cause."""
     with pytest.raises(ValueError, match=r"Invalid reload cause: 'ztp2' - expected causes are \['ZTP', 'USER', 'FPGA', 'USER_HITLESS'\]"):
         convert_reload_cause(str_input)
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        pytest.param("Ethernet1", ["Ethernet1"], id="single-interface"),
+        pytest.param("Ethernet1-3", ["Ethernet1", "Ethernet2", "Ethernet3"], id="range"),
+        pytest.param("Ethernet1,5", ["Ethernet1", "Ethernet5"], id="comma-separated-reuse-prefix"),
+        pytest.param("et1-3", ["Ethernet1", "Ethernet2", "Ethernet3"], id="abbreviation-range"),
+        pytest.param("Ethernet1/1-2", ["Ethernet1/1", "Ethernet1/2"], id="multi-level-slot"),
+    ],
+)
+def test_expand_interface_pattern_valid(pattern: str, expected: list[str]) -> None:
+    """Test expand_interface_pattern with valid patterns."""
+    assert expand_interface_pattern(pattern) == expected
+
+
+@pytest.mark.parametrize(
+    ("pattern", "error_match"),
+    [
+        pytest.param("1-3", r"Invalid interface pattern: 1-3", id="no-prefix"),
+        pytest.param("Ethernet3-1", r"Reverse range not supported: Ethernet3-1 \(start 3 > end 1\)", id="reverse-range"),
+        pytest.param("Ethernet1-1001", r"Range too large \(>1000\): Ethernet1-1001 \(1001 items\)", id="oversized-range"),
+    ],
+)
+def test_expand_interface_pattern_invalid(pattern: str, error_match: str) -> None:
+    """Test expand_interface_pattern with invalid patterns."""
+    with pytest.raises(ValueError, match=error_match):
+        expand_interface_pattern(pattern)

--- a/tests/units/test_custom_types.py
+++ b/tests/units/test_custom_types.py
@@ -25,7 +25,7 @@ from anta.custom_types import (
     aaa_group_prefix,
     bgp_multiprotocol_capabilities_abbreviations,
     convert_reload_cause,
-    expand_interface_pattern,
+    expand_interface_range,
     interface_autocomplete,
     interface_case_sensitivity,
     snmp_v3_prefix,
@@ -334,11 +334,13 @@ def test_invalid_convert_reload_cause(str_input: str) -> None:
         pytest.param("Ethernet1,5", ["Ethernet1", "Ethernet5"], id="comma-separated-reuse-prefix"),
         pytest.param("et1-3", ["Ethernet1", "Ethernet2", "Ethernet3"], id="abbreviation-range"),
         pytest.param("Ethernet1/1-2", ["Ethernet1/1", "Ethernet1/2"], id="multi-level-slot"),
+        pytest.param("Ethernet1.10", ["Ethernet1.10"], id="single-subinterface"),
+        pytest.param("Ethernet1.10-15", ["Ethernet1.10", "Ethernet1.11", "Ethernet1.12", "Ethernet1.13", "Ethernet1.14", "Ethernet1.15"], id="subinterface-range"),
     ],
 )
-def test_expand_interface_pattern_valid(pattern: str, expected: list[str]) -> None:
-    """Test expand_interface_pattern with valid patterns."""
-    assert expand_interface_pattern(pattern) == expected
+def test_expand_interface_range_valid(pattern: str, expected: list[str]) -> None:
+    """Test expand_interface_range with valid patterns."""
+    assert expand_interface_range(pattern) == expected
 
 
 @pytest.mark.parametrize(
@@ -347,9 +349,10 @@ def test_expand_interface_pattern_valid(pattern: str, expected: list[str]) -> No
         pytest.param("1-3", r"Invalid interface pattern: 1-3", id="no-prefix"),
         pytest.param("Ethernet3-1", r"Reverse range not supported: Ethernet3-1 \(start 3 > end 1\)", id="reverse-range"),
         pytest.param("Ethernet1-1001", r"Range too large \(>1000\): Ethernet1-1001 \(1001 items\)", id="oversized-range"),
+        pytest.param("Ethernet1.15-10", r"Reverse range not supported: Ethernet1.15-10 \(start 15 > end 10\)", id="reverse-subinterface-range"),
     ],
 )
-def test_expand_interface_pattern_invalid(pattern: str, error_match: str) -> None:
-    """Test expand_interface_pattern with invalid patterns."""
+def test_expand_interface_range_invalid(pattern: str, error_match: str) -> None:
+    """Test expand_interface_range with invalid patterns."""
     with pytest.raises(ValueError, match=error_match):
-        expand_interface_pattern(pattern)
+        expand_interface_range(pattern)

--- a/tests/units/test_custom_types.py
+++ b/tests/units/test_custom_types.py
@@ -346,6 +346,7 @@ def test_expand_interface_range_valid(pattern: str, expected: list[str]) -> None
 @pytest.mark.parametrize(
     ("pattern", "error_match"),
     [
+        pytest.param("Ethernet", r"Invalid interface pattern: Ethernet", id="no-port-number"),
         pytest.param("1-3", r"Invalid interface pattern: 1-3", id="no-prefix"),
         pytest.param("Ethernet3-1", r"Reverse range not supported: Ethernet3-1 \(start 3 > end 1\)", id="reverse-range"),
         pytest.param("Ethernet1-1001", r"Range too large \(>1000\): Ethernet1-1001 \(1001 items\)", id="oversized-range"),

--- a/tests/units/test_custom_types.py
+++ b/tests/units/test_custom_types.py
@@ -333,6 +333,7 @@ def test_invalid_convert_reload_cause(str_input: str) -> None:
         pytest.param("Ethernet1-3", ["Ethernet1", "Ethernet2", "Ethernet3"], id="range"),
         pytest.param("Ethernet1,5", ["Ethernet1", "Ethernet5"], id="comma-separated-reuse-prefix"),
         pytest.param("et1-3", ["Ethernet1", "Ethernet2", "Ethernet3"], id="abbreviation-range"),
+        pytest.param("eth1-eth3", ["Ethernet1", "Ethernet2", "Ethernet3"], id="repeated-prefix-range"),
         pytest.param("Ethernet1/1-2", ["Ethernet1/1", "Ethernet1/2"], id="multi-level-slot"),
         pytest.param("Ethernet1.10", ["Ethernet1.10"], id="single-subinterface"),
         pytest.param("Ethernet1.10-15", ["Ethernet1.10", "Ethernet1.11", "Ethernet1.12", "Ethernet1.13", "Ethernet1.14", "Ethernet1.15"], id="subinterface-range"),


### PR DESCRIPTION

## Description
Add a new test to verify transceiver types per-interface

Fixes #1496 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transceiver media type verification for Ethernet interfaces.
  * Supports individual interfaces, abbreviations, comma-separated selections, numeric ranges, and multi-level interface names.
  * Interface checks now expand ranges into individual interface results.
  * Reports clear failures for unavailable transceiver data and media type mismatches.
  * Optics receive-power checks distinguish explicitly requested interfaces from automatically discovered interfaces when threshold data is unavailable.
  * Validates and rejects malformed, reverse, or oversized interface ranges.

* **Tests**
  * Expanded coverage for interface patterns, validation errors, and missing optics threshold data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->