### PR TITLE
refactor(anta.tests): Update VerifyAuthenMethods for compatibility with EOS Versions

### DIFF
--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -207,10 +207,16 @@ class VerifyAuthenMethods(AntaTest):
                 # We do not need to verify this accounting type
                 continue
             # Starting with EOS 4.36, the login method list for console authentication is named console.
-            if auth_type == "login" and "login" not in v and "console" not in v:
-                self.result.is_failure("AAA authentication methods are not configured for login console")
-                return
-            not_matching.extend(auth_type for methods in v.values() if methods["methods"] != self.inputs.methods)
+            if auth_type == "login":
+                auth_details = v.get("console", v.get("login"))
+                if auth_details is None:
+                    self.result.is_failure("AAA authentication methods are not configured for login console")
+                    return
+                if auth_details["methods"] != self.inputs.methods:
+                    self.result.is_failure(f"AAA authentication methods {', '.join(self.inputs.methods)} are not matching for login console")
+                    return
+            if any(methods["methods"] != self.inputs.methods for methods in v.values()):
+                not_matching.append(auth_type)
 
         if not not_matching:
             self.result.is_success()

--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -157,11 +157,16 @@ class VerifyTacacsServerGroups(AntaTest):
 
 
 class VerifyAuthenMethods(AntaTest):
-    """Verifies the AAA authentication method lists for different authentication types (login/console, enable, dot1x).
+    """Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).
 
     !!! note
-        Starting with EOS 4.36, the `login` key for console authentication methods has been renamed to `console`.
-        This test supports both keys for compatibility with older and newer EOS versions.
+        Starting with EOS 4.36, the `login` method list for console authentication has been renamed to `console`.
+        This test supports both method-list names for compatibility with older and newer EOS versions.
+
+    !!! warning
+        This test expects all method lists for a selected authentication type to use the same configured methods.
+        For example, when `login` is selected, every method list under `loginAuthenMethods` must match the expected methods.
+        This means the test cannot validate different expected methods per method-list name.
 
     Expected Results
     ----------------
@@ -192,8 +197,8 @@ class VerifyAuthenMethods(AntaTest):
 
         methods: list[AAAAuthMethod]
         """List of AAA authentication methods. Methods should be in the right order."""
-        types: set[Literal["login", "console", "enable", "dot1x"]]
-        """List of authentication types to verify. Both `login` and `console` select console authentication methods."""
+        types: set[Literal["login", "enable", "dot1x"]]
+        """List of authentication types to verify."""
 
     @AntaTest.anta_test
     def test(self) -> None:
@@ -202,18 +207,12 @@ class VerifyAuthenMethods(AntaTest):
         not_matching: list[str] = []
         for k, v in command_output.items():
             auth_type = k.replace("AuthenMethods", "")
-            # If auth_type == 'login', ensures the section is processed when input type has 'console'
-            if auth_type not in self.inputs.types and not (auth_type == "login" and "console" in self.inputs.types):
+            if auth_type not in self.inputs.types:
                 # We do not need to verify this accounting type
                 continue
-            if auth_type == "login":
-                auth_details = v.get("console", v.get("login"))
-                if auth_details is None:
-                    self.result.is_failure("AAA authentication methods are not configured for login console")
-                    return
-                if auth_details["methods"] != self.inputs.methods:
-                    self.result.is_failure(f"AAA authentication methods {', '.join(self.inputs.methods)} are not matching for login console")
-                    return
+            if auth_type == "login" and "login" not in v and "console" not in v:
+                self.result.is_failure("AAA authentication methods are not configured for login console")
+                return
             not_matching.extend(auth_type for methods in v.values() if methods["methods"] != self.inputs.methods)
 
         if not not_matching:

--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -157,7 +157,7 @@ class VerifyTacacsServerGroups(AntaTest):
 
 
 class VerifyAuthenMethods(AntaTest):
-    """Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).
+    """Verifies the AAA authentication method lists for different authentication types (login/console, enable, dot1x).
 
     !!! note
         Starting with EOS 4.36, the `login` key for console authentication methods has been renamed to `console`.
@@ -192,8 +192,8 @@ class VerifyAuthenMethods(AntaTest):
 
         methods: list[AAAAuthMethod]
         """List of AAA authentication methods. Methods should be in the right order."""
-        types: set[Literal["login", "enable", "dot1x"]]
-        """List of authentication types to verify."""
+        types: set[Literal["login", "console", "enable", "dot1x"]]
+        """List of authentication types to verify. Both `login` and `console` select console authentication methods."""
 
     @AntaTest.anta_test
     def test(self) -> None:
@@ -202,7 +202,8 @@ class VerifyAuthenMethods(AntaTest):
         not_matching: list[str] = []
         for k, v in command_output.items():
             auth_type = k.replace("AuthenMethods", "")
-            if auth_type not in self.inputs.types:
+            # If auth_type == 'login', ensures the section is processed when input type has 'console'
+            if auth_type not in self.inputs.types and not (auth_type == "login" and "console" in self.inputs.types):
                 # We do not need to verify this accounting type
                 continue
             if auth_type == "login":

--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -159,6 +159,10 @@ class VerifyTacacsServerGroups(AntaTest):
 class VerifyAuthenMethods(AntaTest):
     """Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).
 
+    !!! note
+        Starting with EOS 4.36, the `login` key for console authentication methods has been renamed to `console`.
+        This test supports both keys for compatibility with older and newer EOS versions.
+
     Expected Results
     ----------------
     * Success: The test will pass if the provided AAA authentication method list is matching in the configured authentication types.
@@ -202,10 +206,11 @@ class VerifyAuthenMethods(AntaTest):
                 # We do not need to verify this accounting type
                 continue
             if auth_type == "login":
-                if "login" not in v:
+                auth_details = v.get("console", v.get("login"))
+                if auth_details is None:
                     self.result.is_failure("AAA authentication methods are not configured for login console")
                     return
-                if v["login"]["methods"] != self.inputs.methods:
+                if auth_details["methods"] != self.inputs.methods:
                     self.result.is_failure(f"AAA authentication methods {', '.join(self.inputs.methods)} are not matching for login console")
                     return
             not_matching.extend(auth_type for methods in v.values() if methods["methods"] != self.inputs.methods)

--- a/anta/tests/aaa.py
+++ b/anta/tests/aaa.py
@@ -159,10 +159,6 @@ class VerifyTacacsServerGroups(AntaTest):
 class VerifyAuthenMethods(AntaTest):
     """Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).
 
-    !!! note
-        Starting with EOS 4.36, the `login` method list for console authentication has been renamed to `console`.
-        This test supports both method-list names for compatibility with older and newer EOS versions.
-
     !!! warning
         This test expects all method lists for a selected authentication type to use the same configured methods.
         For example, when `login` is selected, every method list under `loginAuthenMethods` must match the expected methods.
@@ -210,6 +206,7 @@ class VerifyAuthenMethods(AntaTest):
             if auth_type not in self.inputs.types:
                 # We do not need to verify this accounting type
                 continue
+            # Starting with EOS 4.36, the login method list for console authentication is named console.
             if auth_type == "login" and "login" not in v and "console" not in v:
                 self.result.is_failure("AAA authentication methods are not configured for login console")
                 return

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -23,7 +23,7 @@ anta.tests.aaa:
         - commands
         - dot1x
   - VerifyAuthenMethods:
-      # Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).
+      # Verifies the AAA authentication method lists for different authentication types (login/console, enable, dot1x).
       methods:
         - local
         - none

--- a/examples/tests.yaml
+++ b/examples/tests.yaml
@@ -23,7 +23,7 @@ anta.tests.aaa:
         - commands
         - dot1x
   - VerifyAuthenMethods:
-      # Verifies the AAA authentication method lists for different authentication types (login/console, enable, dot1x).
+      # Verifies the AAA authentication method lists for different authentication types (login, enable, dot1x).
       methods:
         - local
         - none

--- a/tests/units/anta_tests/test_aaa.py
+++ b/tests/units/anta_tests/test_aaa.py
@@ -166,7 +166,7 @@ DATA: AntaUnitTestData = {
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
-    (VerifyAuthenMethods, "success-login-enable-latest-revision"): {
+    (VerifyAuthenMethods, "success-login-enable-console-method-list"): {
         "eos_data": [
             {
                 "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group tacacs+", "local"]}},
@@ -175,17 +175,6 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
-        "expected": {"result": AntaTestStatus.SUCCESS},
-    },
-    (VerifyAuthenMethods, "success-console-latest-revision"): {
-        "eos_data": [
-            {
-                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group tacacs+", "local"]}},
-                "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
-                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
-            }
-        ],
-        "inputs": {"methods": ["tacacs+", "local"], "types": ["console"]},
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
     (VerifyAuthenMethods, "success-dot1x"): {
@@ -219,9 +208,9 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login console"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login"]},
     },
-    (VerifyAuthenMethods, "failure-login-console-latest-revision"): {
+    (VerifyAuthenMethods, "failure-login-console-method-list"): {
         "eos_data": [
             {
                 "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group radius", "local"]}},
@@ -230,7 +219,7 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login console"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login"]},
     },
     (VerifyAuthenMethods, "failure-login-default"): {
         "eos_data": [

--- a/tests/units/anta_tests/test_aaa.py
+++ b/tests/units/anta_tests/test_aaa.py
@@ -177,6 +177,17 @@ DATA: AntaUnitTestData = {
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
+    (VerifyAuthenMethods, "success-console-latest-revision"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group tacacs+", "local"]}},
+                "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
+            }
+        ],
+        "inputs": {"methods": ["tacacs+", "local"], "types": ["console"]},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
     (VerifyAuthenMethods, "success-dot1x"): {
         "eos_data": [
             {

--- a/tests/units/anta_tests/test_aaa.py
+++ b/tests/units/anta_tests/test_aaa.py
@@ -208,7 +208,7 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login console"]},
     },
     (VerifyAuthenMethods, "failure-login-console-method-list"): {
         "eos_data": [
@@ -219,7 +219,22 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login console"]},
+    },
+    (VerifyAuthenMethods, "failure-login-command-api-and-default-method-lists"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {
+                    "default": {"methods": ["local", "none"]},
+                    "command-api": {"methods": ["group tacacs+", "none"]},
+                    "login": {"methods": ["none"]},
+                },
+                "enableAuthenMethods": {"default": {"methods": ["local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": []}},
+            }
+        ],
+        "inputs": {"methods": ["none"], "types": ["login"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods none are not matching for login"]},
     },
     (VerifyAuthenMethods, "failure-login-default"): {
         "eos_data": [

--- a/tests/units/anta_tests/test_aaa.py
+++ b/tests/units/anta_tests/test_aaa.py
@@ -166,6 +166,17 @@ DATA: AntaUnitTestData = {
         "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
         "expected": {"result": AntaTestStatus.SUCCESS},
     },
+    (VerifyAuthenMethods, "success-login-enable-latest-revision"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group tacacs+", "local"]}},
+                "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
+            }
+        ],
+        "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
+        "expected": {"result": AntaTestStatus.SUCCESS},
+    },
     (VerifyAuthenMethods, "success-dot1x"): {
         "eos_data": [
             {
@@ -192,6 +203,17 @@ DATA: AntaUnitTestData = {
         "eos_data": [
             {
                 "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "login": {"methods": ["group radius", "local"]}},
+                "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
+                "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
+            }
+        ],
+        "inputs": {"methods": ["tacacs+", "local"], "types": ["login", "enable"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["AAA authentication methods group tacacs+, local are not matching for login console"]},
+    },
+    (VerifyAuthenMethods, "failure-login-console-latest-revision"): {
+        "eos_data": [
+            {
+                "loginAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}, "console": {"methods": ["group radius", "local"]}},
                 "enableAuthenMethods": {"default": {"methods": ["group tacacs+", "local"]}},
                 "dot1xAuthenMethods": {"default": {"methods": ["group radius"]}},
             }


### PR DESCRIPTION
## Description

Update VerifyAuthenMethods for compatibility with EOS Versions

Starting with EOS 4.36, the `login` key for console authentication methods has been renamed to `console`.

Fixes #1586 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication-method verification to handle the EOS 4.36 rename where console entries are provided under the `console` section rather than `login`.
  * Improved method matching rules for the selected authentication type, including stricter comparison against the expected method lists and clearer failure behavior when required configuration is missing.

* **Tests**
  * Expanded coverage for successful console-based configurations and added failure scenarios for mismatched console methods and overall login method mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->