### PR TITLE
fix: avt.py — VerifyAVTSpecificPath 

### DIFF
--- a/anta/input_models/avt.py
+++ b/anta/input_models/avt.py
@@ -26,6 +26,7 @@ class AVTPath(BaseModel):
     """The IPv4 address of the next hop used to reach the AVT peer."""
     path_type: str | None = None
     """Specifies the type of path for the AVT. If not specified, both types 'direct' and 'multihop' are considered."""
+    # TODO: Restrict this to `Literal["direct", "multihop"]` in a breaking release so empty or unsupported values are rejected.
 
     def __str__(self) -> str:
         """Return a human-readable string representation of the AVTPath for reporting.

--- a/anta/tests/avt.py
+++ b/anta/tests/avt.py
@@ -114,25 +114,20 @@ class VerifyAVTSpecificPath(AntaTest):
         """To maintain backward compatibility."""
 
     @staticmethod
-    def _find_matching_path(path_output: dict, destination: str, next_hop: str, path_type: str | None) -> tuple[bool, list[str]]:
-        """Find a matching AVT path in path_output and validate its flags."""
-        path_found = False
-        failures: list[str] = []
+    def _find_matching_path(path_output: dict, destination: str, next_hop: str, path_type: str | None) -> list[tuple[str, dict]]:
+        """Return all path entries matching destination, next-hop, and optional path type."""
+        matches: list[tuple[str, dict]] = []
         for path, path_data in path_output.items():
             if path_data.get("destination") != destination or path_data.get("nexthopAddr") != next_hop:
                 continue
             if path_type:
-                inferred_type = "direct" if get_value(path_data, "flags.directPath") else "multihop"
-                if inferred_type != path_type:
+                actual_type = "direct" if get_value(path_data, "flags.directPath") else "multihop"
+                if actual_type != path_type:
                     continue
-            path_found = True
-            valid = get_value(path_data, "flags.valid")
-            active = get_value(path_data, "flags.active")
-            if not (valid and active):
-                failures.append(f"Incorrect path {path} - Valid: {valid} Active: {active}")
+            matches.append((path, path_data))
             if not path_type:
-                break
-        return path_found, failures
+                break  # stop after first address match when no type filter is set
+        return matches
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
@@ -148,11 +143,16 @@ class VerifyAVTSpecificPath(AntaTest):
                 result.is_failure("No AVT path configured")
                 continue
 
-            path_found, failures = self._find_matching_path(path_output, str(avt_path.destination), str(avt_path.next_hop), avt_path.path_type)
-            if not path_found:
+            matching_paths = self._find_matching_path(path_output, str(avt_path.destination), str(avt_path.next_hop), avt_path.path_type)
+            if not matching_paths:
                 result.is_failure("Path not found")
-            for failure in failures:
-                result.is_failure(failure)
+                continue
+
+            for path, path_data in matching_paths:
+                valid = get_value(path_data, "flags.valid")
+                active = get_value(path_data, "flags.active")
+                if not (valid and active):
+                    result.is_failure(f"Incorrect path {path} - Valid: {valid} Active: {active}")
 
 
 class VerifyAVTRole(AntaTest):

--- a/anta/tests/avt.py
+++ b/anta/tests/avt.py
@@ -125,8 +125,6 @@ class VerifyAVTSpecificPath(AntaTest):
                 if actual_type != path_type:
                     continue
             matches.append((path, path_data))
-            if not path_type:
-                break  # stop after first address match when no type filter is set
         return matches
 
     @skip_on_platforms(["cEOSLab", "vEOS-lab"])

--- a/anta/tests/avt.py
+++ b/anta/tests/avt.py
@@ -113,44 +113,46 @@ class VerifyAVTSpecificPath(AntaTest):
         AVTPaths: ClassVar[type[AVTPath]] = AVTPath
         """To maintain backward compatibility."""
 
+    @staticmethod
+    def _find_matching_path(path_output: dict, destination: str, next_hop: str, path_type: str | None) -> tuple[bool, list[str]]:
+        """Find a matching AVT path in path_output and validate its flags."""
+        path_found = False
+        failures: list[str] = []
+        for path, path_data in path_output.items():
+            if path_data.get("destination") != destination or path_data.get("nexthopAddr") != next_hop:
+                continue
+            if path_type:
+                inferred_type = "direct" if get_value(path_data, "flags.directPath") else "multihop"
+                if inferred_type != path_type:
+                    continue
+            path_found = True
+            valid = get_value(path_data, "flags.valid")
+            active = get_value(path_data, "flags.active")
+            if not (valid and active):
+                failures.append(f"Incorrect path {path} - Valid: {valid} Active: {active}")
+            if not path_type:
+                break
+        return path_found, failures
+
     @skip_on_platforms(["cEOSLab", "vEOS-lab"])
     @AntaTest.anta_test
     def test(self) -> None:
         """Main test function for VerifyAVTSpecificPath."""
-        # Assume the test is successful until a failure is detected
         self.result.is_success()
 
         command_output = self.instance_commands[0].json_output
         for avt_path in self.inputs.avt_paths:
-            # Atomic result
             result = self.result.add(description=str(avt_path), status=AntaTestStatus.SUCCESS)
 
             if (path_output := get_value(command_output, f"vrfs.{avt_path.vrf}.avts.{avt_path.avt_name}.avtPaths")) is None:
                 result.is_failure("No AVT path configured")
                 continue
 
-            path_found = False
-
-            # Check each AVT path
-            for path, path_data in path_output.items():
-                dest = path_data.get("destination")
-                nexthop = path_data.get("nexthopAddr")
-                path_type = "direct" if get_value(path_data, "flags.directPath") else "multihop"
-
-                if not avt_path.path_type:
-                    path_found = all([dest == str(avt_path.destination), nexthop == str(avt_path.next_hop)])
-
-                elif all([dest == str(avt_path.destination), nexthop == str(avt_path.next_hop), path_type == avt_path.path_type]):
-                    path_found = True
-                    # Check the path status and type against the expected values
-                    valid = get_value(path_data, "flags.valid")
-                    active = get_value(path_data, "flags.active")
-                    if not all([valid, active]):
-                        result.is_failure(f"Incorrect path {path} - Valid: {valid} Active: {active}")
-
-            # If no matching path found, mark the test as failed
+            path_found, failures = self._find_matching_path(path_output, str(avt_path.destination), str(avt_path.next_hop), avt_path.path_type)
             if not path_found:
                 result.is_failure("Path not found")
+            for failure in failures:
+                result.is_failure(failure)
 
 
 class VerifyAVTRole(AntaTest):

--- a/anta/tests/avt.py
+++ b/anta/tests/avt.py
@@ -7,7 +7,7 @@
 # pyright: reportAttributeAccessIssue=false
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from anta.decorators import skip_on_platforms
 from anta.input_models.avt import AVTPath
@@ -114,16 +114,19 @@ class VerifyAVTSpecificPath(AntaTest):
         """To maintain backward compatibility."""
 
     @staticmethod
-    def _find_matching_path(path_output: dict, destination: str, next_hop: str, path_type: str | None) -> list[tuple[str, dict]]:
-        """Return all path entries matching destination, next-hop, and optional path type."""
-        matches: list[tuple[str, dict]] = []
+    def _find_matching_paths(path_output: dict[str, Any], path_input: AVTPath) -> list[tuple[str, dict[str, Any]]]:
+        """Return paths matching the expected destination, next hop, and optional type."""
+        matches: list[tuple[str, dict[str, Any]]] = []
         for path, path_data in path_output.items():
-            if path_data.get("destination") != destination or path_data.get("nexthopAddr") != next_hop:
+            if path_data.get("destination") != str(path_input.destination) or path_data.get("nexthopAddr") != str(path_input.next_hop):
                 continue
-            if path_type:
+
+            # TODO: An empty path type silently disables filtering for backward compatibility. Use an explicit None check.
+            if path_input.path_type:
                 actual_type = "direct" if get_value(path_data, "flags.directPath") else "multihop"
-                if actual_type != path_type:
+                if actual_type != path_input.path_type:
                     continue
+
             matches.append((path, path_data))
         return matches
 
@@ -141,8 +144,7 @@ class VerifyAVTSpecificPath(AntaTest):
                 result.is_failure("No AVT path configured")
                 continue
 
-            matching_paths = self._find_matching_path(path_output, str(avt_path.destination), str(avt_path.next_hop), avt_path.path_type)
-            if not matching_paths:
+            if not (matching_paths := self._find_matching_paths(path_output, avt_path)):
                 result.is_failure("Path not found")
                 continue
 

--- a/tests/units/anta_tests/test_avt.py
+++ b/tests/units/anta_tests/test_avt.py
@@ -385,7 +385,6 @@ DATA: AntaUnitTestData = {
         },
     },
     (VerifyAVTSpecificPath, "success-no-path-type-match-not-last-entry"): {
-        # Regression: path_found was overwritten each iteration; matching path first, non-matching path follows.
         "eos_data": [
             {
                 "vrfs": {
@@ -426,7 +425,6 @@ DATA: AntaUnitTestData = {
         },
     },
     (VerifyAVTSpecificPath, "failure-no-path-type-invalid-path"): {
-        # Reproducer: when path_type is None, valid/active flags are not checked — invalid path silently passes.
         "eos_data": [
             {
                 "vrfs": {
@@ -464,6 +462,141 @@ DATA: AntaUnitTestData = {
                     "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1",
                     "result": AntaTestStatus.FAILURE,
                     "messages": ["Incorrect path direct:10 - Valid: False Active: True"],
+                },
+            ],
+        },
+    },
+    (VerifyAVTSpecificPath, "failure-no-path-type-multiple-matches-one-invalid"): {
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "avts": {
+                            "DEFAULT-AVT-POLICY-CONTROL-PLANE": {
+                                "avtPaths": {
+                                    "direct:10": {
+                                        "flags": {"directPath": True, "valid": True, "active": True},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                    "direct:9": {
+                                        "flags": {"directPath": True, "valid": True, "active": True},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                    "multihop:5": {
+                                        "flags": {"directPath": False, "valid": False, "active": True},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "avt_paths": [
+                {
+                    "avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE",
+                    "vrf": "default",
+                    "destination": "10.101.255.2",
+                    "next_hop": "10.101.255.1",
+                    "path_type": "direct",
+                },
+                {"avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE", "vrf": "default", "destination": "10.101.255.2", "next_hop": "10.101.255.1"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                (
+                    "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 - "
+                    "Incorrect path multihop:5 - Valid: False Active: True"
+                ),
+            ],
+            "atomic_results": [
+                {
+                    "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 Path Type: direct",
+                    "result": AntaTestStatus.SUCCESS,
+                },
+                {
+                    "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Incorrect path multihop:5 - Valid: False Active: True"],
+                },
+            ],
+        },
+    },
+    (VerifyAVTSpecificPath, "failure-path-type-and-no-path-type-mixed-validity"): {
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "avts": {
+                            "DEFAULT-AVT-POLICY-CONTROL-PLANE": {
+                                "avtPaths": {
+                                    "direct:10": {
+                                        "flags": {"directPath": True, "valid": True, "active": True},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                    "direct:9": {
+                                        "flags": {"directPath": True, "valid": True, "active": False},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                    "multihop:5": {
+                                        "flags": {"directPath": False, "valid": False, "active": True},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "avt_paths": [
+                {
+                    "avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE",
+                    "vrf": "default",
+                    "destination": "10.101.255.2",
+                    "next_hop": "10.101.255.1",
+                    "path_type": "direct",
+                },
+                {"avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE", "vrf": "default", "destination": "10.101.255.2", "next_hop": "10.101.255.1"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                (
+                    "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 Path Type: direct - "
+                    "Incorrect path direct:9 - Valid: True Active: False"
+                ),
+                (
+                    "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 - "
+                    "Incorrect path direct:9 - Valid: True Active: False"
+                ),
+                (
+                    "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 - "
+                    "Incorrect path multihop:5 - Valid: False Active: True"
+                ),
+            ],
+            "atomic_results": [
+                {
+                    "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 Path Type: direct",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Incorrect path direct:9 - Valid: True Active: False"],
+                },
+                {
+                    "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Incorrect path direct:9 - Valid: True Active: False", "Incorrect path multihop:5 - Valid: False Active: True"],
                 },
             ],
         },

--- a/tests/units/anta_tests/test_avt.py
+++ b/tests/units/anta_tests/test_avt.py
@@ -384,6 +384,90 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
+    (VerifyAVTSpecificPath, "success-no-path-type-match-not-last-entry"): {
+        # Regression: path_found was overwritten each iteration; matching path first, non-matching path follows.
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "avts": {
+                            "DEFAULT-AVT-POLICY-CONTROL-PLANE": {
+                                "avtPaths": {
+                                    "direct:10": {
+                                        "flags": {"directPath": True, "valid": True, "active": True},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                    "direct:9": {
+                                        "flags": {"directPath": True, "valid": True, "active": True},
+                                        "nexthopAddr": "10.101.255.99",
+                                        "destination": "10.101.255.99",
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "avt_paths": [
+                {"avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE", "vrf": "default", "destination": "10.101.255.2", "next_hop": "10.101.255.1"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.SUCCESS,
+            "atomic_results": [
+                {
+                    "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1",
+                    "result": AntaTestStatus.SUCCESS,
+                },
+            ],
+        },
+    },
+    (VerifyAVTSpecificPath, "failure-no-path-type-invalid-path"): {
+        # Reproducer: when path_type is None, valid/active flags are not checked — invalid path silently passes.
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "avts": {
+                            "DEFAULT-AVT-POLICY-CONTROL-PLANE": {
+                                "avtPaths": {
+                                    "direct:10": {
+                                        "flags": {"directPath": True, "valid": False, "active": True},
+                                        "nexthopAddr": "10.101.255.1",
+                                        "destination": "10.101.255.2",
+                                    },
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        ],
+        "inputs": {
+            "avt_paths": [
+                {"avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE", "vrf": "default", "destination": "10.101.255.2", "next_hop": "10.101.255.1"},
+            ]
+        },
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": [
+                (
+                    "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1 - "
+                    "Incorrect path direct:10 - Valid: False Active: True"
+                ),
+            ],
+            "atomic_results": [
+                {
+                    "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.1",
+                    "result": AntaTestStatus.FAILURE,
+                    "messages": ["Incorrect path direct:10 - Valid: False Active: True"],
+                },
+            ],
+        },
+    },
     (VerifyAVTSpecificPath, "failure-no-peer"): {
         "eos_data": [{"vrfs": {}}],
         "inputs": {

--- a/tests/units/anta_tests/test_avt.py
+++ b/tests/units/anta_tests/test_avt.py
@@ -629,7 +629,7 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
-    (VerifyAVTSpecificPath, "failure-path_type_check_true"): {
+    (VerifyAVTSpecificPath, "failure-path-not-found"): {
         "eos_data": [
             {
                 "vrfs": {
@@ -646,24 +646,6 @@ DATA: AntaUnitTestData = {
                                         "flags": {"directPath": True, "valid": True, "active": True},
                                         "nexthopAddr": "10.101.255.1",
                                         "destination": "10.101.255.2",
-                                    },
-                                }
-                            }
-                        }
-                    },
-                    "data": {
-                        "avts": {
-                            "DATA-AVT-POLICY-CONTROL-PLANE": {
-                                "avtPaths": {
-                                    "direct:10": {
-                                        "flags": {"directPath": True, "valid": True, "active": True},
-                                        "nexthopAddr": "10.101.255.1",
-                                        "destination": "10.101.255.3",
-                                    },
-                                    "direct:9": {
-                                        "flags": {"directPath": True, "valid": True, "active": True},
-                                        "nexthopAddr": "10.101.255.1",
-                                        "destination": "10.101.255.3",
                                     },
                                 }
                             }
@@ -681,14 +663,14 @@ DATA: AntaUnitTestData = {
                     "next_hop": "10.101.255.11",
                     "path_type": "multihop",
                 },
-                {"avt_name": "DATA-AVT-POLICY-CONTROL-PLANE", "vrf": "data", "destination": "10.101.255.1", "next_hop": "10.101.255.21", "path_type": "direct"},
+                {"avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE", "vrf": "default", "destination": "10.101.255.2", "next_hop": "10.101.255.11"},
             ]
         },
         "expected": {
             "result": AntaTestStatus.FAILURE,
             "messages": [
                 "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.11 Path Type: multihop - Path not found",
-                "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.21 Path Type: direct - Path not found",
+                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.11 - Path not found",
             ],
             "atomic_results": [
                 {
@@ -697,76 +679,7 @@ DATA: AntaUnitTestData = {
                     "messages": ["Path not found"],
                 },
                 {
-                    "description": "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.21 Path Type: direct",
-                    "result": AntaTestStatus.FAILURE,
-                    "messages": ["Path not found"],
-                },
-            ],
-        },
-    },
-    (VerifyAVTSpecificPath, "failure-path_type_check_false"): {
-        "eos_data": [
-            {
-                "vrfs": {
-                    "default": {
-                        "avts": {
-                            "DEFAULT-AVT-POLICY-CONTROL-PLANE": {
-                                "avtPaths": {
-                                    "direct:10": {
-                                        "flags": {"directPath": True, "valid": True, "active": True},
-                                        "nexthopAddr": "10.101.255.1",
-                                        "destination": "10.101.255.2",
-                                    },
-                                    "direct:9": {
-                                        "flags": {"directPath": True, "valid": True, "active": True},
-                                        "nexthopAddr": "10.101.255.1",
-                                        "destination": "10.101.255.2",
-                                    },
-                                }
-                            }
-                        }
-                    },
-                    "data": {
-                        "avts": {
-                            "DATA-AVT-POLICY-CONTROL-PLANE": {
-                                "avtPaths": {
-                                    "direct:10": {
-                                        "flags": {"directPath": True, "valid": True, "active": True},
-                                        "nexthopAddr": "10.101.255.1",
-                                        "destination": "10.101.255.3",
-                                    },
-                                    "direct:9": {
-                                        "flags": {"directPath": True, "valid": True, "active": True},
-                                        "nexthopAddr": "10.101.255.1",
-                                        "destination": "10.101.255.3",
-                                    },
-                                }
-                            }
-                        }
-                    },
-                }
-            }
-        ],
-        "inputs": {
-            "avt_paths": [
-                {"avt_name": "DEFAULT-AVT-POLICY-CONTROL-PLANE", "vrf": "default", "destination": "10.101.255.2", "next_hop": "10.101.255.11"},
-                {"avt_name": "DATA-AVT-POLICY-CONTROL-PLANE", "vrf": "data", "destination": "10.101.255.1", "next_hop": "10.101.255.21"},
-            ]
-        },
-        "expected": {
-            "result": AntaTestStatus.FAILURE,
-            "messages": [
-                "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.11 - Path not found",
-                "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.21 - Path not found",
-            ],
-            "atomic_results": [
-                {
                     "description": "AVT: DEFAULT-AVT-POLICY-CONTROL-PLANE VRF: default Destination: 10.101.255.2 Next-hop: 10.101.255.11",
-                    "result": AntaTestStatus.FAILURE,
-                    "messages": ["Path not found"],
-                },
-                {
-                    "description": "AVT: DATA-AVT-POLICY-CONTROL-PLANE VRF: data Destination: 10.101.255.1 Next-hop: 10.101.255.21",
                     "result": AntaTestStatus.FAILURE,
                     "messages": ["Path not found"],
                 },


### PR DESCRIPTION
## Description
1. fix Missing valid/active check when path_type is None
2. path_found silently overwritten each loop iteration avt.py

Fixes #1618 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AVT-specific path verification now evaluates all matching paths when no path-type filter is specified.
  * Valid paths are no longer incorrectly rejected because of later non-matching paths.
  * Invalid or inactive paths now produce clearer aggregate and individual failure results.
  * Missing paths are reported when no matching path is found.

* **Tests**
  * Added regression coverage for typed and untyped path requests, including multiple matches and invalid paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->