### PR TITLE
refactor(anta): avoid JSON round trip for Jinja reports

### DIFF
--- a/anta/cli/nrfu/utils.py
+++ b/anta/cli/nrfu/utils.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -145,8 +144,7 @@ def print_jinja(results: ResultManager, template: pathlib.Path, output: pathlib.
     """Print result based on template."""
     console.print()
     reporter = ReportJinja(template_path=template)
-    json_data = json.loads(results.json)
-    report = reporter.render(json_data)
+    report = reporter.render(results.dump)
     console.print(report)
     if output is not None:
         with output.open(mode="w", encoding="utf-8") as file:

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -3,7 +3,6 @@
 # that can be found in the LICENSE file.
 """Benchmark tests for anta.reporter."""
 
-import json
 import logging
 from pathlib import Path
 
@@ -62,7 +61,7 @@ def test_json(results: ResultManager) -> None:
 @pytest.mark.dependency(depends=["anta_benchmark"], scope="package")
 def test_jinja(results: ResultManager) -> None:
     """Benchmark ReportJinja."""
-    assert isinstance(ReportJinja(template_path=DATA_DIR / "template.j2").render(json.loads(results.json)), str)
+    assert isinstance(ReportJinja(template_path=DATA_DIR / "template.j2").render(results.dump), str)
 
 
 @pytest.mark.benchmark

--- a/tests/units/cli/nrfu/test_commands.py
+++ b/tests/units/cli/nrfu/test_commands.py
@@ -9,7 +9,7 @@ import json
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from anta.cli import anta
 from anta.cli.utils import ExitCode
@@ -163,7 +163,8 @@ def test_anta_nrfu_json_output_failure(click_runner: CliRunner, tmp_path: Path) 
 
 def test_anta_nrfu_template(click_runner: CliRunner) -> None:
     """Test anta nrfu, catalog is given via env."""
-    result = click_runner.invoke(anta, ["nrfu", "tpl-report", "--template", str(DATA_DIR / "template.j2")])
+    with patch("anta.result_manager.ResultManager.json", new_callable=PropertyMock, side_effect=AssertionError("JSON serialization should not be used")):
+        result = click_runner.invoke(anta, ["nrfu", "tpl-report", "--template", str(DATA_DIR / "template.j2")])
     assert result.exit_code == ExitCode.OK
     assert "* VerifyEOSVersion is SUCCESS for leaf1" in result.output
 


### PR DESCRIPTION
## Description

testing memory pressure


## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved template-based report generation by rendering results directly, avoiding unnecessary JSON serialization.
  - Maintained report output while reducing redundant processing.

- **Tests**
  - Added coverage to verify template reports do not rely on JSON serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->