### PR TITLE
test: add five-device CodSpeed cases

### DIFF
--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -4,6 +4,7 @@
 """Fixtures for benchmarking ANTA."""
 
 import logging
+import os
 from collections import defaultdict
 
 import pytest
@@ -24,6 +25,10 @@ BENCHMARK_PARAMETERS = [
     pytest.param({"count": 1, "disable_cache": True, "reachable": True}, id="1-device"),
     pytest.param({"count": 2, "disable_cache": True, "reachable": True}, id="2-devices"),
 ]
+
+# Keep the expensive 5-device benchmarks out of CodSpeed's simulation pass.
+if os.environ.get("CODSPEED_RUNNER_MODE") == "memory":
+    BENCHMARK_PARAMETERS.append(pytest.param({"count": 5, "disable_cache": True, "reachable": True}, id="5-devices"))
 
 
 @pytest.fixture(name="anta_mock_env", scope="session")  # We want this fixture to have a scope set to session to avoid reparsing all the unit tests data.


### PR DESCRIPTION
## Description

Add a 5 devices benchmark for memory only

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an additional five-device benchmark configuration when running in memory mode.
  * Existing one-device and two-device benchmark configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->