### PR TITLE
fix: Test-VerifyStpTopologyChanges None > int raises TypeError

### DIFF
--- a/anta/tests/stp.py
+++ b/anta/tests/stp.py
@@ -318,7 +318,7 @@ class VerifyStpTopologyChanges(AntaTest):
             for interface, details in topology_details.get("interfaces", {}).items():
                 num_of_changes = details.get("numChanges")
                 if num_of_changes is None:
-                    self.result.is_failure(f"Topology: {topology} Interface: {interface} - Number of changes not found")
+                    self.result.is_failure(f"Topology: {topology} Interface: {interface} - Number of changes counter not found")
                 elif num_of_changes > self.inputs.threshold:
                     self.result.is_failure(
                         f"Topology: {topology} Interface: {interface} - Number of changes not within the threshold - Expected: "

--- a/anta/tests/stp.py
+++ b/anta/tests/stp.py
@@ -316,7 +316,10 @@ class VerifyStpTopologyChanges(AntaTest):
         # Verifies the number of changes across all interfaces
         for topology, topology_details in stp_topologies.items():
             for interface, details in topology_details.get("interfaces", {}).items():
-                if (num_of_changes := details.get("numChanges")) > self.inputs.threshold:
+                num_of_changes = details.get("numChanges")
+                if num_of_changes is None:
+                    self.result.is_failure(f"Topology: {topology} Interface: {interface} - Number of changes not found")
+                elif num_of_changes > self.inputs.threshold:
                     self.result.is_failure(
                         f"Topology: {topology} Interface: {interface} - Number of changes not within the threshold - Expected: "
                         f"{self.inputs.threshold} Actual: {num_of_changes}"

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -611,6 +611,22 @@ DATA: AntaUnitTestData = {
         "inputs": {"threshold": 10},
         "expected": {"result": AntaTestStatus.FAILURE, "messages": ["STP is not configured"]},
     },
+    (VerifyStpTopologyChanges, "failure-num-changes-missing"): {
+        "eos_data": [
+            {
+                "unmappedVlans": [],
+                "topologies": {
+                    "Cist": {
+                        "interfaces": {
+                            "Ethernet1": {"state": "forwarding", "lastChange": 1723990624.735365},
+                        }
+                    }
+                },
+            }
+        ],
+        "inputs": {"threshold": 10},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Topology: Cist Interface: Ethernet1 - Number of changes not found"]},
+    },
     (VerifySTPDisabledVlans, "success"): {
         "eos_data": [{"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {"priority": 32768}}}, "6": {}, "4094": {}}}],
         "inputs": {"vlans": ["6", "4094"]},

--- a/tests/units/anta_tests/test_stp.py
+++ b/tests/units/anta_tests/test_stp.py
@@ -625,7 +625,7 @@ DATA: AntaUnitTestData = {
             }
         ],
         "inputs": {"threshold": 10},
-        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Topology: Cist Interface: Ethernet1 - Number of changes not found"]},
+        "expected": {"result": AntaTestStatus.FAILURE, "messages": ["Topology: Cist Interface: Ethernet1 - Number of changes counter not found"]},
     },
     (VerifySTPDisabledVlans, "success"): {
         "eos_data": [{"spanningTreeVlanInstances": {"1": {"spanningTreeVlanInstance": {"protocol": "mstp", "bridge": {"priority": 32768}}}, "6": {}, "4094": {}}}],


### PR DESCRIPTION
## Description
 VerifyStpTopologyChanges.test() — None > int raises TypeError stp.py:319
 

Fixes #1617

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STP topology validation when interface change-count data is missing.
  * Reports a clear failure message instead of producing an unclear comparison error.

* **Tests**
  * Added coverage for interfaces without a reported number of topology changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->