### PR TITLE
test: Allow error in unit tests but not in benchmark

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -182,7 +182,7 @@ And AntaUnitTest have the following keys:
 - `eos_data` (list[dict]): List of data mocking EOS returned data to be passed to the test.
 - `inputs` (dict): Dictionary to instantiate the `test` inputs as defined in the class from `test`.
 - `expected` (dict): Expected test result structure, a dictionary containing a key
-    `result` containing one of the allowed statuses (`Literal[AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.SKIPPED]`) and optionally a key `messages` which is a list(str) and each message is expected to be a substring of one of the actual messages in the TestResult object.
+    `result` containing one of the allowed statuses (`Literal[AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED]`) and optionally a key `messages` which is a list(str) and each message is expected to be a substring of one of the actual messages in the TestResult object.
 
 ``` python
 class AtomicResult(TypedDict):
@@ -198,11 +198,12 @@ class AtomicResult(TypedDict):
 class UnitTestResult(TypedDict):
     """Expected result of a unit test of an AntaTest subclass.
 
-    For our AntaTest unit tests we expect only success, inconclusive, failure or skipped.
-    Never unset nor error.
+    For our AntaTest unit tests we expect a terminal result, never unset.
     """
 
-    result: Literal[AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.SKIPPED]  # The expected status of this unit test.
+    result: Literal[
+        AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED
+    ]  # The expected status of this unit test.
     messages: NotRequired[list[str]]  # The expected messages of the test. The strings can be a substrings of the actual messages.
     atomic_results: NotRequired[list[AtomicResult]]  # The list of expected atomic results.
 

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -16,6 +16,7 @@ import httpx
 
 from anta.catalog import AntaCatalog, AntaTestDefinition
 from anta.models import AntaCommand, AntaTest
+from anta.result_manager.models import AntaTestStatus
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -61,8 +62,10 @@ class AntaMockEnvironment:  # pylint: disable=too-few-public-methods
         - `eos_data` (list[dict]): List of data mocking EOS returned data to be passed to the test.
         - `inputs` (dict): Dictionary to instantiate the `test` inputs as defined in the class from `test`.
         - `expected` (dict): Expected test result structure, a dictionary containing a key `result` containing one of the allowed status
-        (`Literal[AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.SKIPPED]`) and
+        (`Literal[AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED]`) and
         optionally a key `messages` which is a list(str) and each message is expected to be a substring of one of the actual messages in the TestResult object.
+
+    Unit test cases expecting an error result are excluded from the benchmark catalog.
 
     The keys of `eos_data_catalog` is the tuple (AntaTest subclass, A string used as name displayed by pytest). The values are `eos_data`.
     """
@@ -96,6 +99,9 @@ class AntaMockEnvironment:  # pylint: disable=too-few-public-methods
         eos_data_catalog = {}
         for module in import_test_modules():
             for (test, name), test_data in module.DATA.items():
+                if test_data["expected"]["result"] is AntaTestStatus.ERROR:
+                    continue
+
                 # Extract the test class, name and test data from a nested tuple structure:
                 # unit test: Tuple[Tuple[Type[AntaTest], str], AntaUnitTest]
                 result_overwrite = AntaTest.Input.ResultOverwrite(custom_field=name)

--- a/tests/units/anta_tests/__init__.py
+++ b/tests/units/anta_tests/__init__.py
@@ -36,11 +36,10 @@ class AtomicResult(TypedDict):
 class UnitTestResult(TypedDict):
     """Expected result of a unit test of an AntaTest subclass.
 
-    For our AntaTest unit tests we expect only success, inconclusive, failure or skipped.
-    Never unset nor error.
+    For our AntaTest unit tests we expect a terminal result, never unset.
     """
 
-    result: Literal[AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.SKIPPED]
+    result: Literal[AntaTestStatus.SUCCESS, AntaTestStatus.INCONCLUSIVE, AntaTestStatus.FAILURE, AntaTestStatus.ERROR, AntaTestStatus.SKIPPED]
     messages: NotRequired[list[str]]
     atomic_results: NotRequired[list[AtomicResult]]
 

--- a/tests/units/anta_tests/advisories/test_sa_117.py
+++ b/tests/units/anta_tests/advisories/test_sa_117.py
@@ -86,6 +86,53 @@ DATA: AntaUnitTestData = {
             "messages": ["The EOS version '4.33.1FX-wbb' is not affected by this advisory."],
         },
     },
+    (VerifySA117, "error-unknown-configuration"): {
+        "eos_data": [{}, {}, {"version": "4.32.4M"}],
+        "expected": {
+            "result": AntaTestStatus.ERROR,
+            "messages": ["The gNMI transport configuration could not be determined from the available EOS command output."],
+        },
+    },
+    (VerifySA117, "error-malformed-transport"): {
+        "eos_data": [
+            {"transports": {"default": "invalid"}},
+            {"cmds": {}},
+            {"version": "4.32.4M"},
+        ],
+        "expected": {
+            "result": AntaTestStatus.ERROR,
+            "messages": ["The gNMI transport configuration could not be determined from the available EOS command output."],
+        },
+    },
+    (VerifySA117, "error-unknown-transport-state"): {
+        "eos_data": [
+            {"transports": {"default": {}}},
+            {"cmds": {}},
+            {"version": "4.32.4M"},
+        ],
+        "expected": {
+            "result": AntaTestStatus.ERROR,
+            "messages": ["The gNMI transport configuration could not be determined from the available EOS command output."],
+        },
+    },
+    (VerifySA117, "error-unknown-accounting-state"): {
+        "eos_data": [
+            {"transports": {"default": {"enabled": True}}},
+            {"cmds": {}},
+            {"version": "4.32.4M"},
+        ],
+        "expected": {
+            "result": AntaTestStatus.ERROR,
+            "messages": ["The gNMI accounting or OpenConfig trace configuration could not be determined from the available EOS command output."],
+        },
+    },
+    (VerifySA117, "error-invalid-version"): {
+        "eos_data": [{}, {}, {"version": "invalid"}],
+        "expected": {
+            "result": AntaTestStatus.ERROR,
+            "messages": ["The EOS version could not be determined from the 'show version' command output."],
+        },
+    },
 }
 
 


### PR DESCRIPTION
## Description

<!-- PR description !-->

Fixes # (issue id)

## Checklist

<!-- Delete not relevant items !-->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of unit-test scenarios that produce error outcomes.
  * Benchmark catalogs now exclude cases with error results.
* **Tests**
  * Added coverage for missing, malformed, and incomplete configuration, as well as unsupported EOS versions.
* **Documentation**
  * Clarified that test results must be terminal and may include error outcomes.
  * Updated documented status options and expected diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->