### PR TITLE
refactor: Update and rename advisory models

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
   "pylint.args": [
     "--rcfile=pyproject.toml"
   ],
-  "python-envs.defaultEnvManager": "ms-python.python:pyenv",
-  "python-envs.pythonProjects": [],
+  "python-envs.defaultEnvManager": "ms-python.python:venv",
 
 }

--- a/anta/_advisory/base.py
+++ b/anta/_advisory/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import sys
 from typing import ClassVar
 
-from anta._advisory.models import AdvisoryMetadata
+from anta._advisory.models import _AdvisoryMetadata
 from anta._advisory.results import _AdvisoryTestResult
 from anta.models import AntaCommand, AntaTemplate, AntaTest, _description_from_docstring
 
@@ -18,7 +18,7 @@ else:
     from typing_extensions import override
 
 
-class AntaAdvisoryTest(AntaTest):
+class _AntaAdvisoryTest(AntaTest):
     """Base class for ANTA security advisory tests."""
 
     # `_create_result` guarantees this narrower runtime type. Pyright cannot infer
@@ -26,7 +26,7 @@ class AntaAdvisoryTest(AntaTest):
     result: _AdvisoryTestResult  # pyright: ignore[reportIncompatibleVariableOverride]
     categories: ClassVar[list[str]] = ["advisories"]
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = []
-    advisory: ClassVar[AdvisoryMetadata]
+    advisory: ClassVar[_AdvisoryMetadata]
 
     @override
     def _create_result(self) -> _AdvisoryTestResult:
@@ -55,8 +55,8 @@ class AntaAdvisoryTest(AntaTest):
         if "advisory" not in cls.__dict__:
             msg = f"Class {cls.__module__}.{cls.__name__} is missing required class attribute: advisory"
             raise AttributeError(msg)
-        if not isinstance(cls.advisory, AdvisoryMetadata):
-            msg = f"Class {cls.__module__}.{cls.__name__} class attribute 'advisory' must be an AdvisoryMetadata instance"
+        if not isinstance(cls.advisory, _AdvisoryMetadata):
+            msg = f"Class {cls.__module__}.{cls.__name__} class attribute 'advisory' must be an _AdvisoryMetadata instance"
             raise TypeError(msg)
         if not cls.commands:
             msg = f"Class {cls.__module__}.{cls.__name__} must define at least one command"

--- a/anta/_advisory/models.py
+++ b/anta/_advisory/models.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
-class AdvisorySeverity(str, Enum):
+class _AdvisoryCVESeverity(str, Enum):
     """Severity levels for security advisories and CVEs."""
 
     UNKNOWN = "unknown"
@@ -20,82 +20,42 @@ class AdvisorySeverity(str, Enum):
     CRITICAL = "critical"
 
 
-_ADVISORY_SEVERITY_RANK = {
-    AdvisorySeverity.UNKNOWN: 0,
-    AdvisorySeverity.LOW: 1,
-    AdvisorySeverity.MEDIUM: 2,
-    AdvisorySeverity.HIGH: 3,
-    AdvisorySeverity.CRITICAL: 4,
+_ADVISORY_CVE_SEVERITY_RANK = {
+    _AdvisoryCVESeverity.UNKNOWN: 0,
+    _AdvisoryCVESeverity.LOW: 1,
+    _AdvisoryCVESeverity.MEDIUM: 2,
+    _AdvisoryCVESeverity.HIGH: 3,
+    _AdvisoryCVESeverity.CRITICAL: 4,
 }
 
 
-class AdvisoryModel(BaseModel):
+class _AdvisoryModel(BaseModel):
     """Base model for immutable advisory metadata."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
 
-class AdvisoryCVSSScore(AdvisoryModel):
-    """A versioned CVSS base score and vector."""
-
-    version: str
-    score: float = Field(ge=0, le=10)
-    vector: str
-
-
-class AdvisoryCVE(AdvisoryModel):
+class _AdvisoryCVE(_AdvisoryModel):
     """A CVE associated with a security advisory."""
 
     cve_id: str
-    severity: AdvisorySeverity
-    cvss_scores: tuple[AdvisoryCVSSScore, ...] = ()
+    severity: _AdvisoryCVESeverity
 
 
-class AdvisoryMitigation(AdvisoryModel):
-    """A temporary mitigation or workaround for a security advisory."""
-
-    name: str
-    details: str
-    url: str | None = None
-
-
-class AdvisoryResolution(AdvisoryModel):
-    """A resolution for a security advisory."""
-
-    name: str
-    details: str
-    url: str | None = None
-
-
-class AdvisoryMetadata(AdvisoryModel):
+class _AdvisoryMetadata(_AdvisoryModel):
     """Metadata associated with a security advisory test."""
 
     sa_number: str
     title: str
-    severity: AdvisorySeverity
-    cves: tuple[AdvisoryCVE, ...]
+    cves: tuple[_AdvisoryCVE, ...]
     url: str
     description: str
-    resolutions: tuple[AdvisoryResolution, ...]
-    mitigations: tuple[AdvisoryMitigation, ...] = ()
 
     @field_validator("cves")
     @classmethod
-    def cve_ids_are_unique(cls, cves: tuple[AdvisoryCVE, ...]) -> tuple[AdvisoryCVE, ...]:
+    def cve_ids_are_unique(cls, cves: tuple[_AdvisoryCVE, ...]) -> tuple[_AdvisoryCVE, ...]:
         """Ensure CVE IDs are unique within the advisory."""
         if len({cve.cve_id for cve in cves}) != len(cves):
             msg = "Advisory CVE IDs must be unique"
             raise ValueError(msg)
         return cves
-
-    @model_validator(mode="after")
-    def advisory_severity_is_not_below_cve_severity(self) -> AdvisoryMetadata:
-        """Ensure the advisory severity is at least as high as every included CVE."""
-        if not self.cves:
-            return self
-
-        highest_cve = max(self.cves, key=lambda cve: _ADVISORY_SEVERITY_RANK[cve.severity])
-        if _ADVISORY_SEVERITY_RANK[self.severity] < _ADVISORY_SEVERITY_RANK[highest_cve.severity]:
-            msg = f"Advisory severity '{self.severity.value}' cannot be below CVE '{highest_cve.cve_id}' severity '{highest_cve.severity.value}'"
-            raise ValueError(msg)
-        return self

--- a/anta/_advisory/results.py
+++ b/anta/_advisory/results.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from anta._advisory.models import AdvisoryMetadata  # noqa: TC001  # Pydantic resolves this annotation at runtime.
+from anta._advisory.models import _AdvisoryMetadata  # noqa: TC001  # Pydantic resolves this annotation at runtime.
 from anta.result_manager.models import AntaTestStatus, AtomicTestResult, TestResult
 
 
@@ -20,7 +20,7 @@ class _AdvisoryAtomicTestResult(AtomicTestResult):
 class _AdvisoryTestResult(TestResult):
     """Test result carrying private security advisory metadata."""
 
-    advisory: AdvisoryMetadata = Field(exclude=True)
+    advisory: _AdvisoryMetadata = Field(exclude=True)
 
     def add(
         self,
@@ -50,11 +50,11 @@ class _AdvisoryTestResult(TestResult):
         return result
 
 
-def get_advisory_metadata(result: TestResult) -> AdvisoryMetadata | None:
+def _get_advisory_metadata(result: TestResult) -> _AdvisoryMetadata | None:
     """Return advisory metadata from an advisory result, otherwise None."""
     return result.advisory if isinstance(result, _AdvisoryTestResult) else None
 
 
-def get_atomic_cve_ids(result: AtomicTestResult) -> tuple[str, ...] | None:
+def _get_atomic_cve_ids(result: AtomicTestResult) -> tuple[str, ...] | None:
     """Return explicitly associated CVE IDs from an advisory atomic result."""
     return result.cve_ids if isinstance(result, _AdvisoryAtomicTestResult) else None

--- a/anta/tests/advisories/sa_117.py
+++ b/anta/tests/advisories/sa_117.py
@@ -7,15 +7,12 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from anta._advisory.base import AntaAdvisoryTest
+from anta._advisory.base import _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule, require_affected_version
 from anta._advisory.models import (
-    AdvisoryCVE,
-    AdvisoryCVSSScore,
-    AdvisoryMetadata,
-    AdvisoryMitigation,
-    AdvisoryResolution,
-    AdvisorySeverity,
+    _AdvisoryCVE,
+    _AdvisoryCVESeverity,
+    _AdvisoryMetadata,
 )
 from anta.decorators import preview_test_class
 from anta.models import AntaCommand, AntaTemplate
@@ -98,10 +95,10 @@ def _evaluate_risky_trace_configuration(running_config_output: dict[str, Any]) -
 
 
 @preview_test_class
-class VerifySA117(AntaAdvisoryTest):
+class VerifySA117(_AntaAdvisoryTest):
     """Verify that the device is not exposed to Arista Security Advisory 0117 (CVE-2025-0936).
 
-    TODO: See if we can display the advisory details from AdvisoryMetadata in the documentation.
+    TODO: See if we can display the advisory details from _AdvisoryMetadata in the documentation.
 
     Notes
     -----
@@ -122,21 +119,13 @@ class VerifySA117(AntaAdvisoryTest):
     """
 
     _ADVISORY_URL: ClassVar[str] = "https://www.arista.com/en/support/advisories-notices/security-advisory/21394-security-advisory-0117"
-    advisory: ClassVar[AdvisoryMetadata] = AdvisoryMetadata(
+    advisory: ClassVar[_AdvisoryMetadata] = _AdvisoryMetadata(
         sa_number="0117",
         title="Security Advisory 0117",
-        severity=AdvisorySeverity.MEDIUM,
         cves=(
-            AdvisoryCVE(
+            _AdvisoryCVE(
                 cve_id="CVE-2025-0936",
-                severity=AdvisorySeverity.MEDIUM,
-                cvss_scores=(
-                    AdvisoryCVSSScore(
-                        version="3.1",
-                        score=6.5,
-                        vector="CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
-                    ),
-                ),
+                severity=_AdvisoryCVESeverity.MEDIUM,
             ),
         ),
         url=_ADVISORY_URL,
@@ -146,33 +135,6 @@ class VerifySA117(AntaAdvisoryTest):
             "credentials to be logged or accounted on the local EOS device or possibly on other remote "
             "accounting servers (i.e. TACACS, RADIUS, etc)."
         ),
-        resolutions=(
-            AdvisoryResolution(
-                name="Upgrade to a remediated EOS release",
-                details=(
-                    "Upgrade to 4.30.10M or later in the 4.30.x train, 4.31.7M or later in the 4.31.x train, "
-                    "4.32.5M or later in the 4.32.x train, or 4.33.2F or later."
-                ),
-                url=_ADVISORY_URL,
-            ),
-        ),
-        mitigations=(
-            AdvisoryMitigation(
-                name="Disable accounting and logging",
-                details="Disable accounting requests for enabled OpenConfig transports and disable OpenConfig tracing.",
-                url=_ADVISORY_URL,
-            ),
-            AdvisoryMitigation(
-                name="Disable the gNOI File service",
-                details="Set OCGNOIFileToggle to 0 and restart the OpenConfig agent.",
-                url=_ADVISORY_URL,
-            ),
-            AdvisoryMitigation(
-                name="Block TransferToRemote using gNSI Authz",
-                details="Use gNSI Authz to deny the /gnoi.file.File/TransferToRemote RPC on EOS 4.31.0F and later.",
-                url=_ADVISORY_URL,
-            ),
-        ),
     )
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [
         AntaCommand(command="show management api gnmi", revision=1),
@@ -180,7 +142,7 @@ class VerifySA117(AntaAdvisoryTest):
         AntaCommand(command="show version", revision=1),
     ]
 
-    @AntaAdvisoryTest.anta_test
+    @_AntaAdvisoryTest.anta_test
     def test(self) -> None:
         """Fail when the exposure signals and every applicable affected condition are present."""
         gnmi_output = self.instance_commands[0].json_output

--- a/tests/units/_advisory/conftest.py
+++ b/tests/units/_advisory/conftest.py
@@ -6,46 +6,24 @@
 from __future__ import annotations
 
 from anta._advisory.models import (
-    AdvisoryCVE,
-    AdvisoryCVSSScore,
-    AdvisoryMetadata,
-    AdvisoryMitigation,
-    AdvisoryResolution,
-    AdvisorySeverity,
+    _AdvisoryCVE,
+    _AdvisoryCVESeverity,
+    _AdvisoryMetadata,
 )
 
-ADVISORY = AdvisoryMetadata(
+ADVISORY = _AdvisoryMetadata(
     sa_number="0001",
     title="Test advisory",
-    severity=AdvisorySeverity.HIGH,
     cves=(
-        AdvisoryCVE(
+        _AdvisoryCVE(
             cve_id="CVE-2026-0001",
-            severity=AdvisorySeverity.MEDIUM,
-            cvss_scores=(
-                AdvisoryCVSSScore(version="3.1", score=6.5, vector="CVSS:3.1/TEST"),
-                AdvisoryCVSSScore(version="4.0", score=7.0, vector="CVSS:4.0/TEST"),
-            ),
+            severity=_AdvisoryCVESeverity.MEDIUM,
         ),
-        AdvisoryCVE(
+        _AdvisoryCVE(
             cve_id="CVE-2026-0002",
-            severity=AdvisorySeverity.HIGH,
+            severity=_AdvisoryCVESeverity.HIGH,
         ),
     ),
     url="https://example.com/advisory",
     description="Test advisory description.",
-    resolutions=(
-        AdvisoryResolution(
-            name="Upgrade",
-            details="Upgrade to a fixed release.",
-            url="https://example.com/resolution",
-        ),
-    ),
-    mitigations=(
-        AdvisoryMitigation(
-            name="Workaround",
-            details="Apply the temporary workaround.",
-            url="https://example.com/mitigation",
-        ),
-    ),
 )

--- a/tests/units/_advisory/test_base.py
+++ b/tests/units/_advisory/test_base.py
@@ -10,24 +10,24 @@ from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
-from anta._advisory.base import AntaAdvisoryTest
-from anta._advisory.results import _AdvisoryTestResult, get_advisory_metadata
+from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.results import _AdvisoryTestResult, _get_advisory_metadata
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 from anta.result_manager.models import TestResult as AntaTestResult
 from tests.units._advisory.conftest import ADVISORY
 
 if TYPE_CHECKING:
-    from anta._advisory.models import AdvisoryMetadata
+    from anta._advisory.models import _AdvisoryMetadata
     from anta.device import AntaDevice
 
 
-class FakeAdvisoryTest(AntaAdvisoryTest):
+class FakeAdvisoryTest(_AntaAdvisoryTest):
     """Fake security advisory test."""
 
-    advisory: ClassVar[AdvisoryMetadata] = ADVISORY
+    advisory: ClassVar[_AdvisoryMetadata] = ADVISORY
     commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version")]
 
-    @AntaAdvisoryTest.anta_test
+    @_AntaAdvisoryTest.anta_test
     def test(self) -> None:
         """Set the test result to success."""
         self.result.is_success()
@@ -35,9 +35,9 @@ class FakeAdvisoryTest(AntaAdvisoryTest):
 
 def test_advisory_base_is_abstract() -> None:
     """Verify the advisory base inherits the abstract test contract."""
-    assert inspect.isabstract(AntaAdvisoryTest)
-    assert AntaAdvisoryTest.test is AntaTest.test
-    assert not AntaAdvisoryTest.commands
+    assert inspect.isabstract(_AntaAdvisoryTest)
+    assert _AntaAdvisoryTest.test is AntaTest.test
+    assert not _AntaAdvisoryTest.commands
 
 
 def test_advisory_result(device: AntaDevice) -> None:
@@ -59,7 +59,7 @@ def test_advisory_result(device: AntaDevice) -> None:
     assert test_instance.result.description == "Overridden description."
     assert test_instance.result.custom_field == "Overridden custom field."
     assert isinstance(test_instance.result, _AdvisoryTestResult)
-    assert get_advisory_metadata(test_instance.result) is ADVISORY
+    assert _get_advisory_metadata(test_instance.result) is ADVISORY
     dumped_result = test_instance.result.model_dump(mode="json", exclude_none=True)
     assert "metadata" not in dumped_result
     assert "advisory" not in dumped_result
@@ -69,7 +69,7 @@ def test_non_advisory_result_has_no_metadata() -> None:
     """Verify advisory metadata remains optional for ordinary test results."""
     result = AntaTestResult(name="device", test="test", categories=["test"], description="Test description.")
 
-    assert get_advisory_metadata(result) is None
+    assert _get_advisory_metadata(result) is None
     assert "metadata" not in result.model_dump(mode="json", exclude_none=True)
 
 
@@ -77,12 +77,12 @@ def test_advisory_test_requires_metadata() -> None:
     """Verify each advisory test must declare its own metadata."""
     with pytest.raises(AttributeError, match="missing required class attribute: advisory"):
 
-        class MissingAdvisoryTest(AntaAdvisoryTest):
+        class MissingAdvisoryTest(_AntaAdvisoryTest):
             """Advisory test without metadata."""
 
             commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version")]
 
-            @AntaAdvisoryTest.anta_test
+            @_AntaAdvisoryTest.anta_test
             def test(self) -> None:
                 """Set the test result to success."""
                 self.result.is_success()
@@ -90,15 +90,15 @@ def test_advisory_test_requires_metadata() -> None:
 
 def test_advisory_test_rejects_invalid_metadata() -> None:
     """Verify advisory metadata must use the private metadata model."""
-    with pytest.raises(TypeError, match="must be an AdvisoryMetadata instance"):
+    with pytest.raises(TypeError, match="must be an _AdvisoryMetadata instance"):
 
-        class InvalidAdvisoryTest(AntaAdvisoryTest):
+        class InvalidAdvisoryTest(_AntaAdvisoryTest):
             """Advisory test with invalid metadata."""
 
-            advisory: ClassVar[AdvisoryMetadata] = "invalid"  # type: ignore[assignment]
+            advisory: ClassVar[_AdvisoryMetadata] = "invalid"  # type: ignore[assignment]
             commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version")]
 
-            @AntaAdvisoryTest.anta_test
+            @_AntaAdvisoryTest.anta_test
             def test(self) -> None:
                 """Set the test result to success."""
                 self.result.is_success()
@@ -108,12 +108,12 @@ def test_advisory_test_requires_commands() -> None:
     """Verify advisory tests must collect evidence."""
     with pytest.raises(AttributeError, match="must define at least one command"):
 
-        class MissingCommandsAdvisoryTest(AntaAdvisoryTest):
+        class MissingCommandsAdvisoryTest(_AntaAdvisoryTest):
             """Advisory test without commands."""
 
-            advisory: ClassVar[AdvisoryMetadata] = ADVISORY
+            advisory: ClassVar[_AdvisoryMetadata] = ADVISORY
 
-            @AntaAdvisoryTest.anta_test
+            @_AntaAdvisoryTest.anta_test
             def test(self) -> None:
                 """Set the test result to success."""
                 self.result.is_success()
@@ -123,11 +123,11 @@ def test_advisory_test_requires_description() -> None:
     """Verify advisory tests must declare a description or docstring."""
     with pytest.raises(AttributeError, match="Cannot set the description"):
 
-        class MissingDescriptionAdvisoryTest(AntaAdvisoryTest):  # pylint: disable=missing-class-docstring
-            advisory: ClassVar[AdvisoryMetadata] = ADVISORY
+        class MissingDescriptionAdvisoryTest(_AntaAdvisoryTest):  # pylint: disable=missing-class-docstring
+            advisory: ClassVar[_AdvisoryMetadata] = ADVISORY
             commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version")]
 
-            @AntaAdvisoryTest.anta_test
+            @_AntaAdvisoryTest.anta_test
             def test(self) -> None:
                 """Set the test result to success."""
                 self.result.is_success()
@@ -137,7 +137,7 @@ def test_advisory_test_normalizes_docstring_description() -> None:
     """Verify advisory descriptions use the first normalized docstring line."""
     normalized_description_test = type(
         "NormalizedDescriptionAdvisoryTest",
-        (AntaAdvisoryTest,),
+        (_AntaAdvisoryTest,),
         {
             "__doc__": "\n        Advisory description on the next line.\n\n            Additional indented details.\n        ",
             "advisory": ADVISORY,
@@ -151,16 +151,16 @@ def test_advisory_test_normalizes_docstring_description() -> None:
 def test_advisory_test_preserves_explicit_identity() -> None:
     """Verify explicit names, descriptions, and categories are preserved."""
 
-    class CustomAdvisoryTest(AntaAdvisoryTest):
+    class CustomAdvisoryTest(_AntaAdvisoryTest):
         """Advisory test with an explicit identity."""
 
         name: ClassVar[str] = "CustomAdvisoryName"
         description: ClassVar[str] = "Custom advisory description."
         categories: ClassVar[list[str]] = ["overridden"]
-        advisory: ClassVar[AdvisoryMetadata] = ADVISORY
+        advisory: ClassVar[_AdvisoryMetadata] = ADVISORY
         commands: ClassVar[list[AntaCommand | AntaTemplate]] = [AntaCommand(command="show version")]
 
-        @AntaAdvisoryTest.anta_test
+        @_AntaAdvisoryTest.anta_test
         def test(self) -> None:
             """Set the test result to success."""
             self.result.is_success()

--- a/tests/units/_advisory/test_models.py
+++ b/tests/units/_advisory/test_models.py
@@ -9,10 +9,9 @@ import pytest
 from pydantic import ValidationError
 
 from anta._advisory.models import (
-    AdvisoryCVE,
-    AdvisoryMetadata,
-    AdvisoryResolution,
-    AdvisorySeverity,
+    _AdvisoryCVE,
+    _AdvisoryCVESeverity,
+    _AdvisoryMetadata,
 )
 
 _BASE_ADVISORY_FIELDS = {
@@ -20,48 +19,20 @@ _BASE_ADVISORY_FIELDS = {
     "title": "Test advisory",
     "url": "https://example.com/advisory",
     "description": "Test advisory description.",
-    "resolutions": (
-        AdvisoryResolution(
-            name="Upgrade",
-            details="Upgrade to a fixed release.",
-            url="https://example.com/resolution",
-        ),
-    ),
 }
-
-
-def test_advisory_metadata_accepts_severity_at_or_above_cve_severity() -> None:
-    """Verify advisory severity may match or exceed the highest CVE severity."""
-    AdvisoryMetadata(
-        **_BASE_ADVISORY_FIELDS,
-        severity=AdvisorySeverity.HIGH,
-        cves=(
-            AdvisoryCVE(cve_id="CVE-2026-0001", severity=AdvisorySeverity.MEDIUM),
-            AdvisoryCVE(cve_id="CVE-2026-0002", severity=AdvisorySeverity.HIGH),
-        ),
-    )
-
-
-def test_advisory_metadata_rejects_severity_below_cve_severity() -> None:
-    """Verify advisory severity cannot be lower than an included CVE."""
-    cve1 = AdvisoryCVE(cve_id="CVE-2026-0001", severity=AdvisorySeverity.MEDIUM)
-    cve2 = AdvisoryCVE(cve_id="CVE-2026-0002", severity=AdvisorySeverity.HIGH)
-    with pytest.raises(ValidationError, match=f"cannot be below CVE '{cve2.cve_id}' severity '{cve2.severity.value}'"):
-        AdvisoryMetadata(**_BASE_ADVISORY_FIELDS, severity=AdvisorySeverity.MEDIUM, cves=(cve1, cve2))
 
 
 def test_advisory_metadata_rejects_duplicate_cve_ids() -> None:
     """Verify an advisory cannot declare the same CVE more than once."""
-    cve = AdvisoryCVE(cve_id="CVE-2026-0001", severity=AdvisorySeverity.MEDIUM)
+    cve = _AdvisoryCVE(cve_id="CVE-2026-0001", severity=_AdvisoryCVESeverity.MEDIUM)
 
     with pytest.raises(ValidationError, match="Advisory CVE IDs must be unique"):
-        AdvisoryMetadata(**_BASE_ADVISORY_FIELDS, severity=AdvisorySeverity.MEDIUM, cves=(cve, cve))
+        _AdvisoryMetadata(**_BASE_ADVISORY_FIELDS, cves=(cve, cve))
 
 
-def test_advisory_metadata_allows_empty_cve_list() -> None:
-    """Verify advisory severity is not validated when no CVEs are included."""
-    AdvisoryMetadata(
+def test_advisory_metadata_allows_empty_cve_tuple() -> None:
+    """Verify advisory accepts empty CVE tuple."""
+    _AdvisoryMetadata(
         **_BASE_ADVISORY_FIELDS,
-        severity=AdvisorySeverity.LOW,
         cves=(),
     )

--- a/tests/units/_advisory/test_results.py
+++ b/tests/units/_advisory/test_results.py
@@ -12,8 +12,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from anta._advisory.base import AntaAdvisoryTest
-from anta._advisory.results import _AdvisoryAtomicTestResult, get_advisory_metadata, get_atomic_cve_ids
+from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.results import (
+    _AdvisoryAtomicTestResult,
+    _get_advisory_metadata,
+    _get_atomic_cve_ids,
+)
 from anta.models import AntaTest
 from anta.result_manager import ResultManager
 from anta.result_manager.models import AntaTestStatus
@@ -34,14 +38,17 @@ def test_advisory_result_survives_result_manager_operations(device: AntaDevice) 
     manager.add(advisory_result)
 
     assert manager.results[1] is advisory_result
-    assert get_advisory_metadata(manager.results[1]) is ADVISORY
+    assert _get_advisory_metadata(manager.results[1]) is ADVISORY
     manager.sort(["name"])
-    sorted_advisory_result = next(result for result in manager.results if get_advisory_metadata(result) is not None)
+    sorted_advisory_result = next(result for result in manager.results if _get_advisory_metadata(result) is not None)
     assert sorted_advisory_result is advisory_result
-    for derived_manager in (manager.filter(set()), ResultManager.merge_results([manager])):
-        derived_advisory_result = next(result for result in derived_manager.results if get_advisory_metadata(result) is not None)
+    for derived_manager in (
+        manager.filter(set()),
+        ResultManager.merge_results([manager]),
+    ):
+        derived_advisory_result = next(result for result in derived_manager.results if _get_advisory_metadata(result) is not None)
         assert derived_advisory_result is advisory_result
-        assert get_advisory_metadata(derived_advisory_result) is ADVISORY
+        assert _get_advisory_metadata(derived_advisory_result) is ADVISORY
     for dumped_result in json.loads(manager.json):
         assert "advisory" not in dumped_result
         assert "metadata" not in dumped_result
@@ -55,7 +62,7 @@ def test_advisory_atomic_result_without_cve_association(device: AntaDevice) -> N
 
     assert isinstance(atomic_result, _AdvisoryAtomicTestResult)
     assert atomic_result.parent is result
-    assert get_atomic_cve_ids(atomic_result) is None
+    assert _get_atomic_cve_ids(atomic_result) is None
     assert result.result is AntaTestStatus.SUCCESS
 
 
@@ -65,7 +72,7 @@ def test_advisory_atomic_result_with_cve_association(device: AntaDevice) -> None
 
     atomic_result = result.add("CVE-specific check", cve_ids=("CVE-2026-0002", "CVE-2026-0001"))
 
-    assert get_atomic_cve_ids(atomic_result) == ("CVE-2026-0001", "CVE-2026-0002")
+    assert _get_atomic_cve_ids(atomic_result) == ("CVE-2026-0001", "CVE-2026-0002")
 
 
 @pytest.mark.parametrize(
@@ -90,14 +97,14 @@ def test_advisory_result_copy_and_pickle(device: AntaDevice) -> None:
     result.add("CVE-specific check", cve_ids=("CVE-2026-0001",))
 
     deep_copy = copy.deepcopy(result)
-    assert get_advisory_metadata(deep_copy) == ADVISORY
-    assert get_atomic_cve_ids(deep_copy.atomic_results[0]) == ("CVE-2026-0001",)
-    assert get_advisory_metadata(deep_copy.atomic_results[0].parent) == ADVISORY
+    assert _get_advisory_metadata(deep_copy) == ADVISORY
+    assert _get_atomic_cve_ids(deep_copy.atomic_results[0]) == ("CVE-2026-0001",)
+    assert _get_advisory_metadata(deep_copy.atomic_results[0].parent) == ADVISORY
 
     for restored in (result.model_copy(deep=False), pickle.loads(pickle.dumps(result))):  # noqa: S301
         assert restored is not result
-        assert get_advisory_metadata(restored) == ADVISORY
-        assert get_atomic_cve_ids(restored.atomic_results[0]) == ("CVE-2026-0001",)
+        assert _get_advisory_metadata(restored) == ADVISORY
+        assert _get_atomic_cve_ids(restored.atomic_results[0]) == ("CVE-2026-0001",)
 
     restored_from_pickle = pickle.loads(pickle.dumps(result))  # noqa: S301
     assert restored_from_pickle.atomic_results[0].parent is restored_from_pickle
@@ -105,5 +112,5 @@ def test_advisory_result_copy_and_pickle(device: AntaDevice) -> None:
 
 def test_advisory_result_class_is_private_to_advisory_tests() -> None:
     """Keep ordinary tests on the core TestResult class."""
-    assert AntaAdvisoryTest._create_result is not AntaTest._create_result
+    assert _AntaAdvisoryTest._create_result is not AntaTest._create_result
     assert AntaTestResult.__private_attributes__ == {}

--- a/tests/units/cli/get/test_utils.py
+++ b/tests/units/cli/get/test_utils.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from anta._advisory.base import AntaAdvisoryTest
+from anta._advisory.base import _AntaAdvisoryTest
 from anta.cli.get.utils import (
     create_inventory_from_ansible,
     create_inventory_from_cvp,
@@ -236,7 +236,7 @@ def test_find_tests_in_module() -> None:
     """
     with pytest.raises(ValueError, match=r"Error when importing"):
         find_tests_in_module("blah", "UnusedTestName")
-    assert AntaAdvisoryTest not in find_tests_in_module("anta._advisory.base", None)
+    assert _AntaAdvisoryTest not in find_tests_in_module("anta._advisory.base", None)
 
 
 def test_find_tests_examples_excludes_abstract_classes() -> None:


### PR DESCRIPTION
## Description

<!-- PR description !-->
Update and rename preview advisory models
- Prefix preview advisory classes and accessor functions with underscores so the API can evolve while in preview.
- Remove metadata that would duplicate frequently changing advisory content:
  - CVSS scores
  - Static resolutions
  - Static mitigations
- Remove advisory-level severity. Reports should derive it dynamically from the per-CVE severities.
- Preserve required CVE metadata while allowing an explicit empty CVE list for advisories without CVEs.
- Adapt SA117 metadata to the renamed models without changing its assessment logic.
Applicable resolution and mitigation guidance will instead be emitted dynamically as remediation messages in test results. Not-affected results will not emit a remediation message.
## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
