### PR TITLE
refactor(anta): Add "remediations" field on Advisory result classes

### DIFF
--- a/anta/_advisory/results.py
+++ b/anta/_advisory/results.py
@@ -12,15 +12,17 @@ from anta.result_manager.models import AntaTestStatus, AtomicTestResult, TestRes
 
 
 class _AdvisoryAtomicTestResult(AtomicTestResult):
-    """Atomic advisory result with an optional association to specific CVEs."""
+    """Atomic advisory result with optional CVE associations and remediations."""
 
     cve_ids: tuple[str, ...] | None = Field(default=None, exclude=True)
+    remediations: list[str] = Field(default_factory=list, exclude=True)
 
 
 class _AdvisoryTestResult(TestResult):
-    """Test result carrying private security advisory metadata."""
+    """Test result carrying private security advisory metadata and optional remediations."""
 
     advisory: _AdvisoryMetadata = Field(exclude=True)
+    remediations: list[str] = Field(default_factory=list, exclude=True)
 
     def add(
         self,
@@ -29,8 +31,9 @@ class _AdvisoryTestResult(TestResult):
         messages: list[str] | None = None,
         *,
         cve_ids: tuple[str, ...] | None = None,
+        remediations: list[str] | None = None,
     ) -> _AdvisoryAtomicTestResult:
-        """Create an atomic advisory result and optionally associate it with CVEs."""
+        """Create an atomic advisory result with optional CVE associations and remediations."""
         if cve_ids is not None:
             if not cve_ids:
                 msg = "cve_ids must contain at least one CVE ID when provided"
@@ -45,7 +48,14 @@ class _AdvisoryTestResult(TestResult):
                 raise ValueError(msg)
             cve_ids = tuple(cve.cve_id for cve in self.advisory.cves if cve.cve_id in requested_cves)
 
-        result = _AdvisoryAtomicTestResult(description=description, parent=self, result=status, messages=messages or [], cve_ids=cve_ids)
+        result = _AdvisoryAtomicTestResult(
+            description=description,
+            parent=self,
+            result=status,
+            messages=messages or [],
+            cve_ids=cve_ids,
+            remediations=remediations or [],
+        )
         self.atomic_results.append(result)
         return result
 

--- a/tests/units/_advisory/test_results.py
+++ b/tests/units/_advisory/test_results.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
 def test_advisory_result_survives_result_manager_operations(device: AntaDevice) -> None:
     """Preserve advisory result identity and metadata through result manager operations."""
     advisory_result = FakeAdvisoryTest(device=device, eos_data=[{"version": "4.36.1F"}]).result
+    assert advisory_result.remediations == []
+    advisory_result.remediations = ["Upgrade EOS."]
     ordinary_result = AntaTestResult(name="ordinary", test="VerifyNTP", categories=["ntp"], description="Verify NTP.")
     manager = ResultManager()
     manager.add(ordinary_result)
@@ -39,6 +41,7 @@ def test_advisory_result_survives_result_manager_operations(device: AntaDevice) 
 
     assert manager.results[1] is advisory_result
     assert _get_advisory_metadata(manager.results[1]) is ADVISORY
+    assert advisory_result.remediations == ["Upgrade EOS."]
     manager.sort(["name"])
     sorted_advisory_result = next(result for result in manager.results if _get_advisory_metadata(result) is not None)
     assert sorted_advisory_result is advisory_result
@@ -52,6 +55,7 @@ def test_advisory_result_survives_result_manager_operations(device: AntaDevice) 
     for dumped_result in json.loads(manager.json):
         assert "advisory" not in dumped_result
         assert "metadata" not in dumped_result
+        assert "remediations" not in dumped_result
 
 
 def test_advisory_atomic_result_without_cve_association(device: AntaDevice) -> None:
@@ -63,6 +67,7 @@ def test_advisory_atomic_result_without_cve_association(device: AntaDevice) -> N
     assert isinstance(atomic_result, _AdvisoryAtomicTestResult)
     assert atomic_result.parent is result
     assert _get_atomic_cve_ids(atomic_result) is None
+    assert atomic_result.remediations == []
     assert result.result is AntaTestStatus.SUCCESS
 
 
@@ -70,9 +75,14 @@ def test_advisory_atomic_result_with_cve_association(device: AntaDevice) -> None
     """Associate an atomic result with a deterministic subset of advisory CVEs."""
     result = FakeAdvisoryTest(device=device, eos_data=[{"version": "4.36.1F"}]).result
 
-    atomic_result = result.add("CVE-specific check", cve_ids=("CVE-2026-0002", "CVE-2026-0001"))
+    atomic_result = result.add(
+        "CVE-specific check",
+        cve_ids=("CVE-2026-0002", "CVE-2026-0001"),
+        remediations=["Apply the security patch.", "Reload the device."],
+    )
 
     assert _get_atomic_cve_ids(atomic_result) == ("CVE-2026-0001", "CVE-2026-0002")
+    assert atomic_result.remediations == ["Apply the security patch.", "Reload the device."]
 
 
 @pytest.mark.parametrize(

--- a/tests/units/_advisory/test_results.py
+++ b/tests/units/_advisory/test_results.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 def test_advisory_result_survives_result_manager_operations(device: AntaDevice) -> None:
     """Preserve advisory result identity and metadata through result manager operations."""
     advisory_result = FakeAdvisoryTest(device=device, eos_data=[{"version": "4.36.1F"}]).result
-    assert advisory_result.remediations == []
+    assert not advisory_result.remediations
     advisory_result.remediations = ["Upgrade EOS."]
     ordinary_result = AntaTestResult(name="ordinary", test="VerifyNTP", categories=["ntp"], description="Verify NTP.")
     manager = ResultManager()
@@ -67,7 +67,7 @@ def test_advisory_atomic_result_without_cve_association(device: AntaDevice) -> N
     assert isinstance(atomic_result, _AdvisoryAtomicTestResult)
     assert atomic_result.parent is result
     assert _get_atomic_cve_ids(atomic_result) is None
-    assert atomic_result.remediations == []
+    assert not atomic_result.remediations
     assert result.result is AntaTestStatus.SUCCESS
 
 


### PR DESCRIPTION
## Description

<!-- PR description !-->
Add "remediations" field on Advisory result classes

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advisory test results now support tracking remediation guidance.
  * Remediation details are preserved when results are managed or retrieved.

* **Bug Fixes**
  * Remediation information is kept out of JSON output, preventing unintended serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->