### PR TITLE
refactor(anta): Add description to Advisory CVE model

### DIFF
--- a/anta/_advisory/models.py
+++ b/anta/_advisory/models.py
@@ -40,6 +40,7 @@ class _AdvisoryCVE(_AdvisoryModel):
 
     cve_id: str
     severity: _AdvisoryCVESeverity
+    description: str
 
 
 class _AdvisoryMetadata(_AdvisoryModel):

--- a/anta/tests/advisories/sa_117.py
+++ b/anta/tests/advisories/sa_117.py
@@ -126,6 +126,7 @@ class VerifySA117(_AntaAdvisoryTest):
             _AdvisoryCVE(
                 cve_id="CVE-2025-0936",
                 severity=_AdvisoryCVESeverity.MEDIUM,
+                description="CVE-2025-0936 Remote server credentials may be exposed through gNOI File TransferToRemote logging or accounting.",
             ),
         ),
         url=_ADVISORY_URL,

--- a/tests/units/_advisory/conftest.py
+++ b/tests/units/_advisory/conftest.py
@@ -18,10 +18,12 @@ ADVISORY = _AdvisoryMetadata(
         _AdvisoryCVE(
             cve_id="CVE-2026-0001",
             severity=_AdvisoryCVESeverity.MEDIUM,
+            description="CVE-2026-0001 Test vulnerability affecting the management API.",
         ),
         _AdvisoryCVE(
             cve_id="CVE-2026-0002",
             severity=_AdvisoryCVESeverity.HIGH,
+            description="CVE-2026-0002 Test vulnerability affecting access controls.",
         ),
     ),
     url="https://example.com/advisory",

--- a/tests/units/_advisory/reporting_data.py
+++ b/tests/units/_advisory/reporting_data.py
@@ -25,10 +25,12 @@ EXAMPLE_CRITICAL_ADVISORY = _AdvisoryMetadata(
         _AdvisoryCVE(
             cve_id="CVE-2026-12001",
             severity=_AdvisoryCVESeverity.CRITICAL,
+            description="CVE-2026-12001 Authentication bypass in an enabled management API.",
         ),
         _AdvisoryCVE(
             cve_id="CVE-2026-12002",
             severity=_AdvisoryCVESeverity.HIGH,
+            description="CVE-2026-12002 Authorization flaw affecting management API access controls.",
         ),
     ),
     url="https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120",
@@ -45,6 +47,7 @@ EXAMPLE_HIGH_ADVISORY = _AdvisoryMetadata(
         _AdvisoryCVE(
             cve_id="CVE-2026-12101",
             severity=_AdvisoryCVESeverity.HIGH,
+            description="CVE-2026-12101 Malformed packet may restart an exposed EOS process.",
         ),
     ),
     url="https://www.arista.com/en/support/advisories-notices/security-advisory/example-0121",

--- a/tests/units/_advisory/test_models.py
+++ b/tests/units/_advisory/test_models.py
@@ -24,7 +24,11 @@ _BASE_ADVISORY_FIELDS = {
 
 def test_advisory_metadata_rejects_duplicate_cve_ids() -> None:
     """Verify an advisory cannot declare the same CVE more than once."""
-    cve = _AdvisoryCVE(cve_id="CVE-2026-0001", severity=_AdvisoryCVESeverity.MEDIUM)
+    cve = _AdvisoryCVE(
+        cve_id="CVE-2026-0001",
+        severity=_AdvisoryCVESeverity.MEDIUM,
+        description="CVE-2026-0001 Test vulnerability description.",
+    )
 
     with pytest.raises(ValidationError, match="Advisory CVE IDs must be unique"):
         _AdvisoryMetadata(**_BASE_ADVISORY_FIELDS, cves=(cve, cve))


### PR DESCRIPTION
## Description

<!-- PR description !-->
Add description to Advisory CVE model

This field will be used in psirt reports per atomic result

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security advisory entries now include a clear description for each listed CVE, alongside its identifier and severity.
  * Updated Security Advisory 0117 metadata with the relevant CVE description.
* **Bug Fixes**
  * Improved advisory data completeness and consistency, ensuring vulnerability descriptions are available wherever CVE details are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->