### PR TITLE
doc: Add auto generation of advisory section in _AdvisoryAntaTests

### DIFF
--- a/anta/tests/advisories/sa_117.py
+++ b/anta/tests/advisories/sa_117.py
@@ -98,8 +98,6 @@ def _evaluate_risky_trace_configuration(running_config_output: dict[str, Any]) -
 class VerifySA117(_AntaAdvisoryTest):
     """Verify that the device is not exposed to Arista Security Advisory 0117 (CVE-2025-0936).
 
-    TODO: See if we can display the advisory details from _AdvisoryMetadata in the documentation.
-
     Notes
     -----
     This test does not evaluate advisory mitigations such as disabling the gNOI File service or blocking TransferToRemote with gNSI Authz.

--- a/docs/stylesheets/extra.zensical.css
+++ b/docs/stylesheets/extra.zensical.css
@@ -7,6 +7,8 @@
 }
 
 :root {
+  --md-admonition-icon--security-advisory: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M11 13h2v1h-2zm10-8v6c0 5.5-3.8 10.7-9 12-5.2-1.3-9-6.5-9-12V5l9-4zm-4 5h-2.2c-.2-.6-.6-1.1-1.1-1.5l1.2-1.2-.7-.7L12.8 8H12c-.2 0-.5 0-.7.1L9.9 6.6l-.8.8 1.2 1.2c-.5.3-.9.8-1.1 1.4H7v1h2v1H7v1h2v1H7v1h2.2c.4 1.2 1.5 2 2.8 2s2.4-.8 2.8-2H17v-1h-2v-1h2v-1h-2v-1h2zm-6 2h2v-1h-2z'/%3E%3C/svg%3E");
+
   /* Color schema based on Arista Color Schema */
   /* Default color shades */
   --md-default-fg-color:               #000000;
@@ -196,6 +198,23 @@
 
 .md-typeset .caution > .admonition-title::after, .md-typeset .caution > summary::after {
   color: #ff1744;
+}
+
+.md-typeset .admonition.security-advisory {
+  margin: .75em 0;
+  border-color: #d32f2f;
+  box-shadow: none;
+}
+
+.md-typeset .security-advisory > .admonition-title {
+  margin-bottom: 0;
+  background-color: #d32f2f1a;
+}
+
+.md-typeset .security-advisory > .admonition-title::before {
+  background-color: #d32f2f;
+  -webkit-mask-image: var(--md-admonition-icon--security-advisory);
+  mask-image: var(--md-admonition-icon--security-advisory);
 }
 
 .md-tooltip2 {

--- a/docs/templates/python/material/anta_advisory_test.html.jinja
+++ b/docs/templates/python/material/anta_advisory_test.html.jinja
@@ -1,0 +1,22 @@
+{% set advisory = namespace(title=none, url=none) %}
+{% if "advisory" in class.members and class.members["advisory"].value.arguments is defined %}
+{%   for argument in class.members["advisory"].value.arguments %}
+{%     if argument.name == "title" %}
+{%       set advisory.title = argument.value[1:-1] %}
+{%     elif argument.name == "url" %}
+{%       if argument.value.name is defined and argument.value.name in class.members %}
+{%         set advisory.url = class.members[argument.value.name].value[1:-1] %}
+{%       else %}
+{%         set advisory.url = argument.value[1:-1] %}
+{%       endif %}
+{%     endif %}
+{%   endfor %}
+{% endif %}
+
+{% if advisory.title is none or advisory.url is none %}
+{{ log.warning("Unable to render the security advisory link for " + class.path) }}
+{% else %}
+<div class="admonition security-advisory">
+  <p class="admonition-title">Security advisory: <a href="{{ advisory.url | e }}">{{ advisory.title | e }}</a></p>
+</div>
+{% endif %}

--- a/docs/templates/python/material/class.html.jinja
+++ b/docs/templates/python/material/class.html.jinja
@@ -1,10 +1,14 @@
 {% extends "_base/class.html.jinja" %}
 {% set anta_test = namespace(found=false) %}
+{% set anta_advisory_test = namespace(found=false) %}
 {% set anta_test_input_model = namespace(found=false) %}
 {% for base in class.bases %}
 {%   set basestr = base | string %}
 {%   if "AntaTest" == basestr %}
 {%     set anta_test.found = True %}
+{%   endif %}
+{%   if "_AntaAdvisoryTest" == basestr %}
+{%     set anta_advisory_test.found = True %}
 {%   endif %}
 {% endfor %}
 {# TODO make this nicer #}
@@ -53,6 +57,13 @@
   {{ super() }}
 {%   endif %}
 {% endblock source %}
+
+{% block docstring %}
+{{ super() }}
+{% if anta_advisory_test.found %}
+{% include "anta_advisory_test.html.jinja" with context %}
+{% endif %}
+{% endblock docstring %}
 
 {# overwrite block base to render some stuff on deprecation for anta_test #}
 {% block bases %}


### PR DESCRIPTION
## Description

cf title

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added styled security-advisory notices with clear visual treatment.
  * Advisory references in API documentation now render as links to the relevant security advisory.
  * Documentation warns when advisory titles or links are missing.
  * Integrated advisory details into security test class documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->