### PR TITLE
refactor: Generate preview and deprecation warnings once for all devices for a given AntaTest

### DIFF
--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from functools import wraps
+from functools import cache, wraps
 from typing import Any, ParamSpec
 
 from anta.models import AntaTest, logger
@@ -121,9 +121,14 @@ def preview_test_class(cls: type[AntaTest]) -> type[AntaTest]:
     """
     orig_init = cls.__init__
 
+    @cache
+    def emit_warning() -> None:
+        """Emit the preview warning once per test class."""
+        logger.warning("%s test is in preview. Input models and behavior may change between minor releases.", cls.name)
+
     def new_init(*args: Any, **kwargs: Any) -> None:
         """Overload __init__ to generate a warning message for preview tests."""
-        logger.warning("%s test is in preview. Input models and behavior may change between minor releases.", cls.name)
+        emit_warning()
         orig_init(*args, **kwargs)
 
     cls.__init__ = new_init

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -49,14 +49,19 @@ def deprecated_test(new_tests: list[str] | None = None) -> T_TestAsyncDecorator:
 
         """
 
+        @cache
+        def emit_warning(test_name: str) -> None:
+            """Emit the deprecation warning once per test function."""
+            if new_tests:
+                new_test_names = ", ".join(new_tests)
+                logger.warning("%s test is deprecated. Consider using the following new tests: %s.", test_name, new_test_names)
+            else:
+                logger.warning("%s test is deprecated.", test_name)
+
         @wraps(function)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             anta_test = args[0]
-            if new_tests:
-                new_test_names = ", ".join(new_tests)
-                logger.warning("%s test is deprecated. Consider using the following new tests: %s.", anta_test.name, new_test_names)
-            else:
-                logger.warning("%s test is deprecated.", anta_test.name)
+            emit_warning(anta_test.name)
             return await function(*args, **kwargs)
 
         return wrapper
@@ -96,13 +101,18 @@ def deprecated_test_class(new_tests: list[str] | None = None, removal_in_version
         """
         orig_init = cls.__init__
 
-        def new_init(*args: Any, **kwargs: Any) -> None:
-            """Overload __init__ to generate a warning message for deprecation."""
+        @cache
+        def emit_warning() -> None:
+            """Emit the deprecation warning once per test class."""
             if new_tests:
                 new_test_names = ", ".join(new_tests)
                 logger.warning("%s test is deprecated. Consider using the following new tests: %s.", cls.name, new_test_names)
             else:
                 logger.warning("%s test is deprecated.", cls.name)
+
+        def new_init(*args: Any, **kwargs: Any) -> None:
+            """Overload __init__ to generate a warning message for deprecation."""
+            emit_warning()
             orig_init(*args, **kwargs)
 
         if removal_in_version is not None:

--- a/tests/units/test_decorators.py
+++ b/tests/units/test_decorators.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
-from anta.decorators import deprecated_test_class, preview_test_class, skip_on_platforms
+from anta.decorators import deprecated_test, deprecated_test_class, preview_test_class, skip_on_platforms
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 
 if TYPE_CHECKING:
@@ -38,18 +38,43 @@ class ExampleTest(AntaTest):
     ],
 )
 def test_deprecated_test_class(caplog: pytest.LogCaptureFixture, device: AntaDevice, new_tests: list[str] | None) -> None:
-    """Test deprecated_test_class decorator."""
+    """Test deprecated_test_class decorator only logs the warning once per test class."""
     caplog.set_level(logging.INFO)
 
     decorated_test_class = deprecated_test_class(new_tests=new_tests)(ExampleTest)
 
-    # Initialize the decorated test
+    decorated_test_class(device)
     decorated_test_class(device)
 
     if new_tests is None:
-        assert "ExampleTest test is deprecated." in caplog.messages
+        warning = "ExampleTest test is deprecated."
     else:
-        assert f"ExampleTest test is deprecated. Consider using the following new tests: {', '.join(new_tests)}." in caplog.messages
+        warning = f"ExampleTest test is deprecated. Consider using the following new tests: {', '.join(new_tests)}."
+    assert caplog.messages.count(warning) == 1
+
+
+@pytest.mark.parametrize(
+    "new_tests",
+    [
+        pytest.param(None, id="No new_tests"),
+        pytest.param(["NewExampleTest"], id="one new_tests"),
+        pytest.param(["NewExampleTest1", "NewExampleTest2"], id="multiple new_tests"),
+    ],
+)
+async def test_deprecated_test(caplog: pytest.LogCaptureFixture, device: AntaDevice, new_tests: list[str] | None) -> None:
+    """Test deprecated_test decorator only logs the warning once per test function."""
+    test_instance = ExampleTest(device)
+    caplog.clear()
+    decorated_test = deprecated_test(new_tests=new_tests)(ExampleTest.test)
+
+    await decorated_test(test_instance)
+    await decorated_test(test_instance)
+
+    if new_tests is None:
+        warning = "ExampleTest test is deprecated."
+    else:
+        warning = f"ExampleTest test is deprecated. Consider using the following new tests: {', '.join(new_tests)}."
+    assert caplog.messages.count(warning) == 1
 
 
 def test_preview_test_class_warns_once(caplog: pytest.LogCaptureFixture, device: AntaDevice) -> None:

--- a/tests/units/test_decorators.py
+++ b/tests/units/test_decorators.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
-from anta.decorators import deprecated_test_class, skip_on_platforms
+from anta.decorators import deprecated_test_class, preview_test_class, skip_on_platforms
 from anta.models import AntaCommand, AntaTemplate, AntaTest
 
 if TYPE_CHECKING:
@@ -50,6 +50,18 @@ def test_deprecated_test_class(caplog: pytest.LogCaptureFixture, device: AntaDev
         assert "ExampleTest test is deprecated." in caplog.messages
     else:
         assert f"ExampleTest test is deprecated. Consider using the following new tests: {', '.join(new_tests)}." in caplog.messages
+
+
+def test_preview_test_class_warns_once(caplog: pytest.LogCaptureFixture, device: AntaDevice) -> None:
+    """Test preview_test_class decorator only logs the warning once per test class."""
+    caplog.set_level(logging.WARNING)
+    decorated_test_class = preview_test_class(ExampleTest)
+
+    decorated_test_class(device)
+    decorated_test_class(device)
+
+    warning = "ExampleTest test is in preview. Input models and behavior may change between minor releases."
+    assert caplog.messages.count(warning) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

title

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deprecation warnings now appear only once per test function or class.
  - Preview warnings now appear only once per class.
  - Warning messages continue to include optional replacement test information.

- **Tests**
  - Added coverage for asynchronous deprecated tests.
  - Added verification that preview warnings are emitted exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->