### PR TITLE
refactor(anta): Generalize the test progress message

### DIFF
--- a/anta/_runner.py
+++ b/anta/_runner.py
@@ -308,7 +308,7 @@ class AntaRunner:
                 return ctx
 
             if AntaTest.progress is not None:
-                AntaTest.nrfu_task = AntaTest.progress.add_task("Running NRFU Tests ...", total=ctx.total_tests_scheduled)
+                AntaTest.nrfu_task = AntaTest.progress.add_task("Running Tests ...", total=ctx.total_tests_scheduled)
 
             with Catchtime(logger=logger, message="Running Tests"):
                 sem = Semaphore(self._settings.max_concurrency)

--- a/anta/models.py
+++ b/anta/models.py
@@ -370,6 +370,7 @@ class AntaTest(ABC):
 
     # Class variables to handle the progress bar of ANTA CLI
     progress: Progress | None = None
+    # TODO(ANTA 2.0): Rename `nrfu_task` to `_progress_task`.
     nrfu_task: TaskID | None = None
     # Instance attributes
     device: AntaDevice

--- a/tests/units/test__runner.py
+++ b/tests/units/test__runner.py
@@ -521,7 +521,12 @@ class TestAntaRunner:
         catalog = AntaCatalog(tests=tests)
         runner = AntaRunner()
 
-        ctx = await runner.run(inventory, catalog)
+        with patch.object(AntaTest, "progress") as progress:
+            ctx = await runner.run(inventory, catalog)
+
+        progress.add_task.assert_called_once_with("Running Tests ...", total=15)
+        assert AntaTest.nrfu_task == progress.add_task.return_value
+        AntaTest.nrfu_task = None
 
         assert ctx.total_devices_selected_for_testing == 3
         assert ctx.total_tests_scheduled == 15

--- a/tests/units/test__runner.py
+++ b/tests/units/test__runner.py
@@ -511,7 +511,7 @@ class TestAntaRunner:
 
     @pytest.mark.parametrize(("inventory"), [{"count": 3}], indirect=True)
     @respx.mock
-    async def test_run(self, inventory: AntaInventory) -> None:
+    async def test_run(self, inventory: AntaInventory, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test AntaRunner.run()."""
         # Mock the eAPI requests
         respx.post(path="/command-api", headers={"Content-Type": "application/json-rpc"}, json__params__cmds__0__cmd="show ip route vrf default").respond(
@@ -520,13 +520,13 @@ class TestAntaRunner:
         tests = [AntaTestDefinition(test=VerifyRoutingTableEntry, inputs={"routes": [f"10.1.0.{i}"], "collect": "all"}) for i in range(5)]
         catalog = AntaCatalog(tests=tests)
         runner = AntaRunner()
+        monkeypatch.setattr(AntaTest, "nrfu_task", None)
 
         with patch.object(AntaTest, "progress") as progress:
             ctx = await runner.run(inventory, catalog)
 
         progress.add_task.assert_called_once_with("Running Tests ...", total=15)
         assert AntaTest.nrfu_task == progress.add_task.return_value
-        AntaTest.nrfu_task = None
 
         assert ctx.total_devices_selected_for_testing == 3
         assert ctx.total_tests_scheduled == 15


### PR DESCRIPTION
## Description

Update the shared Rich progress task label from `Running NRFU Tests ...` to `Running Tests ...`. The runner is also used by `anta psirt`, so the generic wording accurately describes both NRFU and security advisory test runs.

Keep the existing `nrfu_task` attribute for compatibility in this minor release and add a TODO to rename it to `_progress_task` in ANTA 2.0.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing on the changed files
- [x] I have added tests that prove my fix is effective
- [x] Relevant existing unit tests pass locally with my changes (`tests/units/test__runner.py`: 35 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **User Experience**
  * Updated the test runner’s progress message to display “Running Tests ...” for clearer status reporting.

* **Tests**
  * Added coverage to verify progress task creation and tracking during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->