### PR TITLE
feat(anta): [PREVIEW] Add anta psirt table view

### DIFF
--- a/anta/_advisory/reporter/md_reporter.py
+++ b/anta/_advisory/reporter/md_reporter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, ClassVar
 
 from anta._advisory.models import _ADVISORY_VULNERABILITY_SEVERITY_RANK, _AdvisoryMetadata, _AdvisoryVulnerabilitySeverity
-from anta._advisory.reporter.reporting import SecurityAdvisoryRunOverviewData, _get_advisory_result
+from anta._advisory.reporter.reporting import SecurityAdvisoryRunOverviewData, _get_advisory_findings, _get_advisory_result
 from anta._advisory.results import _AdvisoryAtomicTestResult, _AdvisoryTestResult, _get_atomic_vulnerability_ids
 from anta.reporter.md_reporter import MDReportBase
 from anta.result_manager.models import AntaTestStatus
@@ -107,21 +107,7 @@ class SecurityAdvisoryMDReportBase(MDReportBase):
 
     def format_findings(self, result: TestResult) -> str:
         """Format findings and label associated atomic findings with vulnerability IDs."""
-        messages = list(result.messages)
-        if isinstance(result, _AdvisoryTestResult):
-            for atomic in result.atomic_results:
-                vulnerability_ids = _get_atomic_vulnerability_ids(atomic)
-                if not vulnerability_ids:
-                    continue
-                prefix = f"{', '.join(vulnerability_ids)}: "
-                for message in atomic.messages:
-                    inherited_message = f"{atomic.description} - {message}"
-                    try:
-                        index = messages.index(inherited_message)
-                    except ValueError:
-                        continue
-                    messages[index] = f"{prefix}{message}"
-        return self.safe_markdown("<br>".join(messages)) or "-"
+        return self.safe_markdown("<br>".join(_get_advisory_findings(result))) or "-"
 
 
 class ANTASecurityAdvisoryReport(SecurityAdvisoryMDReportBase):

--- a/anta/_advisory/reporter/reporting.py
+++ b/anta/_advisory/reporter/reporting.py
@@ -139,6 +139,20 @@ def _get_advisory_severity(advisory: _AdvisoryMetadata) -> _AdvisoryVulnerabilit
     )
 
 
+def _format_advisory_result(result: TestResult | AtomicTestResult) -> str:
+    """Translate an ANTA status to advisory-facing result wording."""
+    if result.result is AntaTestStatus.SUCCESS:
+        mitigated_opening = "The device is affected but mitigated because "
+        return "mitigated" if any(mitigated_opening in message for message in result.messages) else "not affected"
+    return {
+        AntaTestStatus.UNSET: "unset",
+        AntaTestStatus.INCONCLUSIVE: "inconclusive",
+        AntaTestStatus.FAILURE: "affected",
+        AntaTestStatus.ERROR: "error",
+        AntaTestStatus.SKIPPED: "skipped",
+    }[result.result]
+
+
 def validate_advisory_results(results: Sequence[TestResult]) -> list[tuple[TestResult, _AdvisoryMetadata]]:
     """Return results paired with metadata, rejecting empty or mixed result sets."""
     if not results:

--- a/anta/_advisory/reporter/reporting.py
+++ b/anta/_advisory/reporter/reporting.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from anta._advisory.models import _ADVISORY_VULNERABILITY_SEVERITY_RANK, _AdvisoryVulnerabilitySeverity
-from anta._advisory.results import _get_advisory_metadata
+from anta._advisory.results import _AdvisoryTestResult, _get_advisory_metadata, _get_atomic_vulnerability_ids
 from anta.logger import anta_log_exception
 from anta.result_manager.models import AntaTestStatus
 
@@ -48,6 +48,27 @@ def _get_advisory_result(result: TestResult | AtomicTestResult) -> str:
         AntaTestStatus.ERROR: "error",
         AntaTestStatus.SKIPPED: "skipped",
     }[result.result]
+
+
+def _get_advisory_findings(result: TestResult) -> list[str]:
+    """Return parent findings with associated atomic messages labelled by vulnerability ID."""
+    messages = list(result.messages)
+    if not isinstance(result, _AdvisoryTestResult):
+        return messages
+
+    for atomic in result.atomic_results:
+        vulnerability_ids = _get_atomic_vulnerability_ids(atomic)
+        if not vulnerability_ids:
+            continue
+        prefix = f"{', '.join(vulnerability_ids)}: "
+        for message in atomic.messages:
+            inherited_message = f"{atomic.description} - {message}"
+            try:
+                index = messages.index(inherited_message)
+            except ValueError:
+                continue
+            messages[index] = f"{prefix}{message}"
+    return messages
 
 
 @dataclass
@@ -137,20 +158,6 @@ def _get_advisory_severity(advisory: _AdvisoryMetadata) -> _AdvisoryVulnerabilit
         key=_ADVISORY_VULNERABILITY_SEVERITY_RANK.__getitem__,
         default=_AdvisoryVulnerabilitySeverity.UNKNOWN,
     )
-
-
-def _format_advisory_result(result: TestResult | AtomicTestResult) -> str:
-    """Translate an ANTA status to advisory-facing result wording."""
-    if result.result is AntaTestStatus.SUCCESS:
-        mitigated_opening = "The device is affected but mitigated because "
-        return "mitigated" if any(mitigated_opening in message for message in result.messages) else "not affected"
-    return {
-        AntaTestStatus.UNSET: "unset",
-        AntaTestStatus.INCONCLUSIVE: "inconclusive",
-        AntaTestStatus.FAILURE: "affected",
-        AntaTestStatus.ERROR: "error",
-        AntaTestStatus.SKIPPED: "skipped",
-    }[result.result]
 
 
 def validate_advisory_results(results: Sequence[TestResult]) -> list[tuple[TestResult, _AdvisoryMetadata]]:

--- a/anta/_advisory/reporter/table_reporter.py
+++ b/anta/_advisory/reporter/table_reporter.py
@@ -13,7 +13,7 @@ from rich.text import Text
 
 from anta import RICH_COLOR_PALETTE
 from anta._advisory.models import _ADVISORY_VULNERABILITY_SEVERITY_RANK, _AdvisoryVulnerabilitySeverity
-from anta._advisory.reporter.reporting import _format_advisory_result, _get_advisory_severity
+from anta._advisory.reporter.reporting import _get_advisory_findings, _get_advisory_result, _get_advisory_severity
 from anta._advisory.results import _AdvisoryAtomicTestResult, _AdvisoryTestResult, _get_atomic_vulnerability_ids
 
 if TYPE_CHECKING:
@@ -85,7 +85,7 @@ class SecurityAdvisoryReportTable:
     @classmethod
     def _result_text(cls, result: TestResult | AtomicTestResult) -> Text:
         """Return an advisory-facing result label with the ANTA status color."""
-        value = _format_advisory_result(result)
+        value = _get_advisory_result(result)
         return Text(value.title(), style=cls._RESULT_STYLES[value])
 
     @staticmethod
@@ -98,9 +98,9 @@ class SecurityAdvisoryReportTable:
         """Render a list as bulleted table-cell lines or an explicit empty marker."""
         return "\n".join(f"• {value}" for value in values) if values else "—"
 
-    @staticmethod
-    def _remediations(result: TestResult | AtomicTestResult) -> list[str]:
-        """Return stable, deduplicated remediation entries for an advisory result."""
+    @classmethod
+    def _remediations(cls, result: TestResult | AtomicTestResult) -> list[str]:
+        """Return stable, deduplicated remediation entries with parent vulnerability attribution."""
         if not isinstance(result, (_AdvisoryTestResult, _AdvisoryAtomicTestResult)):
             return []
 
@@ -109,7 +109,58 @@ class SecurityAdvisoryReportTable:
             remediations.extend(
                 remediation for atomic in result.atomic_results if isinstance(atomic, _AdvisoryAtomicTestResult) for remediation in atomic.remediations
             )
-        return list(dict.fromkeys(remediations))
+        formatted_remediations = []
+        for remediation in dict.fromkeys(remediations):
+            vulnerability_ids = cls._remediation_vulnerability_ids(result, remediation)
+            prefix = f"{', '.join(vulnerability_ids)}: " if vulnerability_ids else ""
+            formatted_remediations.append(f"{prefix}{remediation}")
+        return formatted_remediations
+
+    @staticmethod
+    def _remediation_vulnerability_ids(result: TestResult | AtomicTestResult, remediation: str) -> tuple[str, ...]:
+        """Return advisory-ordered vulnerability IDs sharing a parent remediation."""
+        if not isinstance(result, _AdvisoryTestResult):
+            return ()
+
+        associated_ids: set[str] = set()
+        for atomic in result.atomic_results:
+            if not isinstance(atomic, _AdvisoryAtomicTestResult) or remediation not in atomic.remediations:
+                continue
+            if not atomic.vulnerability_ids:
+                return ()
+            associated_ids.update(atomic.vulnerability_ids)
+        return tuple(vulnerability.id for vulnerability in result.advisory.vulnerabilities if vulnerability.id in associated_ids)
+
+    @staticmethod
+    def _atomic_summary(result: TestResult) -> str:
+        """Summarize detailed findings using advisory-facing terminology."""
+        total = len(result.atomic_results)
+        labels = {
+            "affected": "affected",
+            "inconclusive": "inconclusive",
+            "mitigated": "mitigated",
+            "error": "errored",
+            "skipped": "skipped",
+            "unset": "unset",
+        }
+        advisory_results = [_get_advisory_result(atomic) for atomic in result.atomic_results]
+        summaries = [f"{count}/{total} checks {label}" for advisory_result, label in labels.items() if (count := advisory_results.count(advisory_result))]
+        return "; ".join(summaries) if summaries else f"All {total} checks not affected"
+
+    @classmethod
+    def _expanded_findings(cls, result: TestResult) -> str:
+        """Return a detailed-result summary followed by the authoritative evidence."""
+        if not result.atomic_results:
+            return cls._findings(result)
+        findings = f"Detailed findings: {cls._atomic_summary(result)}"
+        if result.messages:
+            findings += f"\nOverall evidence:\n{cls._findings(result)}"
+        return findings
+
+    @classmethod
+    def _findings(cls, result: TestResult) -> str:
+        """Return parent findings with associated atomic messages labelled by vulnerability ID."""
+        return cls._lines(_get_advisory_findings(result))
 
     @staticmethod
     def _advisory_text(group: AdvisoryResultGroup) -> Text:
@@ -119,84 +170,84 @@ class SecurityAdvisoryReportTable:
         text.append(advisory.url, style=Style(underline=True, link=advisory.url))
         return text
 
+    @classmethod
+    def _device_findings_title(cls, group: AdvisoryResultGroup) -> Text:
+        """Return a per-advisory device findings title."""
+        advisory = group.advisory
+        text = Text("Device Findings — ")
+        text.append(f"SA{advisory.sa_number}: ")
+        text.append(advisory.title, style=Style(underline=True, link=advisory.url))
+        text.append(" — ")
+        text.append_text(cls._severity_text(_get_advisory_severity(advisory)))
+        return text
+
     def generate_summary(self, report: SecurityAdvisoryReport) -> Table:
         """Generate the advisory exposure summary table."""
         table = Table(title="Security Advisory Summary", show_lines=True)
         table.add_column("Severity", no_wrap=True)
         table.add_column("Advisory", overflow="fold")
         table.add_column("Devices", justify="right", no_wrap=True)
-        for column in ("Affected", "Mitigated", "Not affected", "Inconclusive", "Error", "Skipped", "Unset"):
+        for column in ("Affected", "Inconclusive", "Mitigated", "Not affected", "Error", "Skipped", "Unset"):
             table.add_column(column, justify="right", no_wrap=True)
 
         for group in self._groups_by_severity(report):
             severity = _get_advisory_severity(group.advisory)
             counts = dict.fromkeys(self._RESULT_ORDER, 0)
             for result in group.results:
-                counts[_format_advisory_result(result)] += 1
+                counts[_get_advisory_result(result)] += 1
             table.add_row(
                 self._severity_text(severity),
                 self._advisory_text(group),
                 str(len({result.name for result in group.results})),
                 str(counts["affected"]),
+                str(counts["inconclusive"]),
                 str(counts["mitigated"]),
                 str(counts["not affected"]),
-                str(counts["inconclusive"]),
                 str(counts["error"]),
                 str(counts["skipped"]),
                 str(counts["unset"]),
             )
         return table
 
-    def generate_device_findings(self, report: SecurityAdvisoryReport, *, expand_results: bool = False) -> Table:
-        """Generate per-device advisory findings, optionally with atomic results."""
-        table = Table(title="Security Advisory Device Findings", show_lines=True)
-        table.add_column("Severity", no_wrap=True)
-        table.add_column("Advisory", no_wrap=True)
-        table.add_column("Device", no_wrap=True)
+    def generate_device_findings(self, report: SecurityAdvisoryReport, *, expand_results: bool = False) -> list[Table]:
+        """Generate one per-advisory device findings table, optionally with atomic results."""
+        return [self._generate_advisory_device_findings(group, expand_results=expand_results) for group in self._groups_by_severity(report)]
+
+    def _generate_advisory_device_findings(self, group: AdvisoryResultGroup, *, expand_results: bool) -> Table:
+        """Generate the device findings table for one advisory."""
+        table = Table(title=self._device_findings_title(group), expand=True)
+        table.add_column("Device", width=18, overflow="fold")
         if expand_results:
-            table.add_column("Description")
-            table.add_column("Vulnerability ID(s)")
-        table.add_column("Result", no_wrap=True)
-        table.add_column("Findings")
-        table.add_column("Remediations")
+            table.add_column("Vulnerability ID(s)", width=24, overflow="fold")
+        table.add_column("Result", width=12, no_wrap=True)
+        table.add_column("Findings", ratio=3)
+        table.add_column("Remediations", ratio=2)
 
-        for group in self._groups_by_severity(report):
-            severity = _get_advisory_severity(group.advisory)
-            vulnerability_by_id = {vulnerability.id: vulnerability for vulnerability in group.advisory.vulnerabilities}
-            ordered_results = sorted(
-                group.results,
-                key=lambda result: (self._RESULT_ORDER[_format_advisory_result(result)], str(result.name), result.test),
-            )
-            for result in ordered_results:
-                row: list[str | Text] = [
-                    self._severity_text(severity),
-                    f"SA{group.advisory.sa_number}",
-                    str(result.name),
-                ]
-                if expand_results:
-                    row.extend(["Overall advisory", "—"])
-                row.extend([self._result_text(result), self._lines(result.messages), self._bullets(self._remediations(result))])
-                table.add_row(*row)
+        vulnerability_by_id = {vulnerability.id: vulnerability for vulnerability in group.advisory.vulnerabilities}
+        ordered_results = sorted(
+            group.results,
+            key=lambda result: (self._RESULT_ORDER[_get_advisory_result(result)], str(result.name), result.test),
+        )
+        for result in ordered_results:
+            row: list[str | Text] = [str(result.name)]
+            if expand_results:
+                row.append("—")
+            findings = self._expanded_findings(result) if expand_results else self._findings(result)
+            row.extend([self._result_text(result), findings, self._bullets(self._remediations(result))])
+            table.add_row(*row, end_section=not expand_results or not result.atomic_results)
 
-                if not expand_results:
-                    continue
-                for index, atomic in enumerate(result.atomic_results):
-                    tree = "└──" if index == len(result.atomic_results) - 1 else "├──"
-                    vulnerability_ids = _get_atomic_vulnerability_ids(atomic)
-                    if vulnerability_ids:
-                        description = "\n".join(vulnerability_by_id[vulnerability_id].description for vulnerability_id in vulnerability_ids)
-                        vulnerabilities = self._vulnerability_text(vulnerability_ids, vulnerability_by_id)
-                    else:
-                        description = atomic.description
-                        vulnerabilities = "—"
-                    table.add_row(
-                        "",
-                        "",
-                        "",
-                        f"{tree} {description}",
-                        vulnerabilities,
-                        self._result_text(atomic),
-                        self._lines(atomic.messages),
-                        self._bullets(self._remediations(atomic)),
-                    )
+            if not expand_results:
+                continue
+            for index, atomic in enumerate(result.atomic_results):
+                tree = "└──" if index == len(result.atomic_results) - 1 else "├──"
+                vulnerability_ids = _get_atomic_vulnerability_ids(atomic)
+                vulnerabilities: str | Text = self._vulnerability_text(vulnerability_ids, vulnerability_by_id) if vulnerability_ids else "—"
+                table.add_row(
+                    f"  {tree}",
+                    vulnerabilities,
+                    self._result_text(atomic),
+                    self._lines(atomic.messages),
+                    self._bullets(self._remediations(atomic)),
+                    end_section=index == len(result.atomic_results) - 1,
+                )
         return table

--- a/anta/_advisory/reporter/table_reporter.py
+++ b/anta/_advisory/reporter/table_reporter.py
@@ -17,17 +17,18 @@ from anta._advisory.reporter.reporting import _format_advisory_result, _get_advi
 from anta._advisory.results import _AdvisoryAtomicTestResult, _AdvisoryTestResult, _get_atomic_vulnerability_ids
 
 if TYPE_CHECKING:
+    from anta._advisory.models import _AdvisoryVulnerability
     from anta._advisory.reporter.reporting import AdvisoryResultGroup, SecurityAdvisoryReport
     from anta.result_manager.models import AtomicTestResult, TestResult
 
 
-SEVERITY_ICONS = {
-    _AdvisoryVulnerabilitySeverity.CRITICAL: "🔴",
-    _AdvisoryVulnerabilitySeverity.HIGH: "🟠",
-    _AdvisoryVulnerabilitySeverity.MEDIUM: "🟡",
-    _AdvisoryVulnerabilitySeverity.LOW: "🔵",
-    _AdvisoryVulnerabilitySeverity.NONE: "🟢",
-    _AdvisoryVulnerabilitySeverity.UNKNOWN: "⚪",
+SEVERITY_STYLES = {
+    _AdvisoryVulnerabilitySeverity.CRITICAL: "red",
+    _AdvisoryVulnerabilitySeverity.HIGH: "orange3",
+    _AdvisoryVulnerabilitySeverity.MEDIUM: "yellow3",
+    _AdvisoryVulnerabilitySeverity.LOW: "blue",
+    _AdvisoryVulnerabilitySeverity.NONE: "green4",
+    _AdvisoryVulnerabilitySeverity.UNKNOWN: "grey74",
 }
 
 
@@ -62,9 +63,24 @@ class SecurityAdvisoryReportTable:
         )
 
     @staticmethod
-    def _severity_text(severity: _AdvisoryVulnerabilitySeverity) -> str:
+    def _severity_text(severity: _AdvisoryVulnerabilitySeverity) -> Text:
         """Return a severity label that does not rely on color alone."""
-        return f"{SEVERITY_ICONS[severity]} {severity.value.title()}"
+        text = Text()
+        text.append("●", style=SEVERITY_STYLES[severity])
+        text.append(f" {severity.value.title()}")
+        return text
+
+    @staticmethod
+    def _vulnerability_text(vulnerability_ids: tuple[str, ...], vulnerability_by_id: dict[str, _AdvisoryVulnerability]) -> Text:
+        """Return vulnerability IDs colored by severity."""
+        text = Text()
+        for index, vulnerability_id in enumerate(vulnerability_ids):
+            if index:
+                text.append("\n")
+            vulnerability = vulnerability_by_id[vulnerability_id]
+            text.append("●", style=SEVERITY_STYLES[vulnerability.severity])
+            text.append(f" {vulnerability_id}")
+        return text
 
     @classmethod
     def _result_text(cls, result: TestResult | AtomicTestResult) -> Text:
@@ -78,11 +94,22 @@ class SecurityAdvisoryReportTable:
         return "\n".join(values) if values else "—"
 
     @staticmethod
+    def _bullets(values: list[str]) -> str:
+        """Render a list as bulleted table-cell lines or an explicit empty marker."""
+        return "\n".join(f"• {value}" for value in values) if values else "—"
+
+    @staticmethod
     def _remediations(result: TestResult | AtomicTestResult) -> list[str]:
-        """Return remediation entries carried by an advisory result."""
-        if isinstance(result, (_AdvisoryTestResult, _AdvisoryAtomicTestResult)):
-            return result.remediations
-        return []
+        """Return stable, deduplicated remediation entries for an advisory result."""
+        if not isinstance(result, (_AdvisoryTestResult, _AdvisoryAtomicTestResult)):
+            return []
+
+        remediations = list(result.remediations)
+        if isinstance(result, _AdvisoryTestResult):
+            remediations.extend(
+                remediation for atomic in result.atomic_results if isinstance(atomic, _AdvisoryAtomicTestResult) for remediation in atomic.remediations
+            )
+        return list(dict.fromkeys(remediations))
 
     @staticmethod
     def _advisory_text(group: AdvisoryResultGroup) -> Text:
@@ -95,7 +122,7 @@ class SecurityAdvisoryReportTable:
     def generate_summary(self, report: SecurityAdvisoryReport) -> Table:
         """Generate the advisory exposure summary table."""
         table = Table(title="Security Advisory Summary", show_lines=True)
-        table.add_column("Severity", style=RICH_COLOR_PALETTE.HEADER, no_wrap=True)
+        table.add_column("Severity", no_wrap=True)
         table.add_column("Advisory", overflow="fold")
         table.add_column("Devices", justify="right", no_wrap=True)
         for column in ("Affected", "Mitigated", "Not affected", "Inconclusive", "Error", "Skipped", "Unset"):
@@ -123,18 +150,19 @@ class SecurityAdvisoryReportTable:
     def generate_device_findings(self, report: SecurityAdvisoryReport, *, expand_results: bool = False) -> Table:
         """Generate per-device advisory findings, optionally with atomic results."""
         table = Table(title="Security Advisory Device Findings", show_lines=True)
-        table.add_column("Severity", style=RICH_COLOR_PALETTE.HEADER, no_wrap=True)
+        table.add_column("Severity", no_wrap=True)
         table.add_column("Advisory", no_wrap=True)
         table.add_column("Device", no_wrap=True)
         if expand_results:
-            table.add_column("Finding")
+            table.add_column("Description")
             table.add_column("Vulnerability ID(s)")
         table.add_column("Result", no_wrap=True)
-        table.add_column("Evidence")
-        table.add_column("Remediation")
+        table.add_column("Findings")
+        table.add_column("Remediations")
 
         for group in self._groups_by_severity(report):
             severity = _get_advisory_severity(group.advisory)
+            vulnerability_by_id = {vulnerability.id: vulnerability for vulnerability in group.advisory.vulnerabilities}
             ordered_results = sorted(
                 group.results,
                 key=lambda result: (self._RESULT_ORDER[_format_advisory_result(result)], str(result.name), result.test),
@@ -147,7 +175,7 @@ class SecurityAdvisoryReportTable:
                 ]
                 if expand_results:
                     row.extend(["Overall advisory", "—"])
-                row.extend([self._result_text(result), self._lines(result.messages), self._lines(self._remediations(result))])
+                row.extend([self._result_text(result), self._lines(result.messages), self._bullets(self._remediations(result))])
                 table.add_row(*row)
 
                 if not expand_results:
@@ -155,14 +183,20 @@ class SecurityAdvisoryReportTable:
                 for index, atomic in enumerate(result.atomic_results):
                     tree = "└──" if index == len(result.atomic_results) - 1 else "├──"
                     vulnerability_ids = _get_atomic_vulnerability_ids(atomic)
+                    if vulnerability_ids:
+                        description = "\n".join(vulnerability_by_id[vulnerability_id].description for vulnerability_id in vulnerability_ids)
+                        vulnerabilities = self._vulnerability_text(vulnerability_ids, vulnerability_by_id)
+                    else:
+                        description = atomic.description
+                        vulnerabilities = "—"
                     table.add_row(
                         "",
                         "",
                         "",
-                        f"{tree} {atomic.description}",
-                        ", ".join(vulnerability_ids) if vulnerability_ids else "—",
+                        f"{tree} {description}",
+                        vulnerabilities,
                         self._result_text(atomic),
                         self._lines(atomic.messages),
-                        self._lines(self._remediations(atomic)),
+                        self._bullets(self._remediations(atomic)),
                     )
         return table

--- a/anta/_advisory/reporter/table_reporter.py
+++ b/anta/_advisory/reporter/table_reporter.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Rich table reporting for ANTA security advisory results."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from rich.style import Style
+from rich.table import Table
+from rich.text import Text
+
+from anta import RICH_COLOR_PALETTE
+from anta._advisory.models import _ADVISORY_VULNERABILITY_SEVERITY_RANK, _AdvisoryVulnerabilitySeverity
+from anta._advisory.reporter.reporting import _format_advisory_result, _get_advisory_severity
+from anta._advisory.results import _AdvisoryAtomicTestResult, _AdvisoryTestResult, _get_atomic_vulnerability_ids
+
+if TYPE_CHECKING:
+    from anta._advisory.reporter.reporting import AdvisoryResultGroup, SecurityAdvisoryReport
+    from anta.result_manager.models import AtomicTestResult, TestResult
+
+
+SEVERITY_ICONS = {
+    _AdvisoryVulnerabilitySeverity.CRITICAL: "🔴",
+    _AdvisoryVulnerabilitySeverity.HIGH: "🟠",
+    _AdvisoryVulnerabilitySeverity.MEDIUM: "🟡",
+    _AdvisoryVulnerabilitySeverity.LOW: "🔵",
+    _AdvisoryVulnerabilitySeverity.NONE: "🟢",
+    _AdvisoryVulnerabilitySeverity.UNKNOWN: "⚪",
+}
+
+
+class SecurityAdvisoryReportTable:
+    """Generate summary and per-device Rich tables for security advisory results."""
+
+    _RESULT_ORDER: ClassVar[dict[str, int]] = {
+        "affected": 0,
+        "error": 1,
+        "inconclusive": 2,
+        "mitigated": 3,
+        "not affected": 4,
+        "skipped": 5,
+        "unset": 6,
+    }
+    _RESULT_STYLES: ClassVar[dict[str, str]] = {
+        "affected": RICH_COLOR_PALETTE.FAILURE,
+        "error": RICH_COLOR_PALETTE.ERROR,
+        "inconclusive": RICH_COLOR_PALETTE.INCONCLUSIVE,
+        "mitigated": RICH_COLOR_PALETTE.SUCCESS,
+        "not affected": RICH_COLOR_PALETTE.SUCCESS,
+        "skipped": RICH_COLOR_PALETTE.SKIPPED,
+        "unset": RICH_COLOR_PALETTE.UNSET,
+    }
+
+    @staticmethod
+    def _groups_by_severity(report: SecurityAdvisoryReport) -> list[AdvisoryResultGroup]:
+        """Return advisory groups ordered by descending severity and advisory number."""
+        return sorted(
+            report.groups,
+            key=lambda group: (-_ADVISORY_VULNERABILITY_SEVERITY_RANK[_get_advisory_severity(group.advisory)], group.advisory.sa_number),
+        )
+
+    @staticmethod
+    def _severity_text(severity: _AdvisoryVulnerabilitySeverity) -> str:
+        """Return a severity label that does not rely on color alone."""
+        return f"{SEVERITY_ICONS[severity]} {severity.value.title()}"
+
+    @classmethod
+    def _result_text(cls, result: TestResult | AtomicTestResult) -> Text:
+        """Return an advisory-facing result label with the ANTA status color."""
+        value = _format_advisory_result(result)
+        return Text(value.title(), style=cls._RESULT_STYLES[value])
+
+    @staticmethod
+    def _lines(values: list[str]) -> str:
+        """Render a list as table-cell lines or an explicit empty marker."""
+        return "\n".join(values) if values else "—"
+
+    @staticmethod
+    def _remediations(result: TestResult | AtomicTestResult) -> list[str]:
+        """Return remediation entries carried by an advisory result."""
+        if isinstance(result, (_AdvisoryTestResult, _AdvisoryAtomicTestResult)):
+            return result.remediations
+        return []
+
+    @staticmethod
+    def _advisory_text(group: AdvisoryResultGroup) -> Text:
+        """Return advisory identity and a visible, clickable source URL."""
+        advisory = group.advisory
+        text = Text(f"SA{advisory.sa_number}: {advisory.title}\n")
+        text.append(advisory.url, style=Style(underline=True, link=advisory.url))
+        return text
+
+    def generate_summary(self, report: SecurityAdvisoryReport) -> Table:
+        """Generate the advisory exposure summary table."""
+        table = Table(title="Security Advisory Summary", show_lines=True)
+        table.add_column("Severity", style=RICH_COLOR_PALETTE.HEADER, no_wrap=True)
+        table.add_column("Advisory", overflow="fold")
+        table.add_column("Devices", justify="right", no_wrap=True)
+        for column in ("Affected", "Mitigated", "Not affected", "Inconclusive", "Error", "Skipped", "Unset"):
+            table.add_column(column, justify="right", no_wrap=True)
+
+        for group in self._groups_by_severity(report):
+            severity = _get_advisory_severity(group.advisory)
+            counts = dict.fromkeys(self._RESULT_ORDER, 0)
+            for result in group.results:
+                counts[_format_advisory_result(result)] += 1
+            table.add_row(
+                self._severity_text(severity),
+                self._advisory_text(group),
+                str(len({result.name for result in group.results})),
+                str(counts["affected"]),
+                str(counts["mitigated"]),
+                str(counts["not affected"]),
+                str(counts["inconclusive"]),
+                str(counts["error"]),
+                str(counts["skipped"]),
+                str(counts["unset"]),
+            )
+        return table
+
+    def generate_device_findings(self, report: SecurityAdvisoryReport, *, expand_results: bool = False) -> Table:
+        """Generate per-device advisory findings, optionally with atomic results."""
+        table = Table(title="Security Advisory Device Findings", show_lines=True)
+        table.add_column("Severity", style=RICH_COLOR_PALETTE.HEADER, no_wrap=True)
+        table.add_column("Advisory", no_wrap=True)
+        table.add_column("Device", no_wrap=True)
+        if expand_results:
+            table.add_column("Finding")
+            table.add_column("Vulnerability ID(s)")
+        table.add_column("Result", no_wrap=True)
+        table.add_column("Evidence")
+        table.add_column("Remediation")
+
+        for group in self._groups_by_severity(report):
+            severity = _get_advisory_severity(group.advisory)
+            ordered_results = sorted(
+                group.results,
+                key=lambda result: (self._RESULT_ORDER[_format_advisory_result(result)], str(result.name), result.test),
+            )
+            for result in ordered_results:
+                row: list[str | Text] = [
+                    self._severity_text(severity),
+                    f"SA{group.advisory.sa_number}",
+                    str(result.name),
+                ]
+                if expand_results:
+                    row.extend(["Overall advisory", "—"])
+                row.extend([self._result_text(result), self._lines(result.messages), self._lines(self._remediations(result))])
+                table.add_row(*row)
+
+                if not expand_results:
+                    continue
+                for index, atomic in enumerate(result.atomic_results):
+                    tree = "└──" if index == len(result.atomic_results) - 1 else "├──"
+                    vulnerability_ids = _get_atomic_vulnerability_ids(atomic)
+                    table.add_row(
+                        "",
+                        "",
+                        "",
+                        f"{tree} {atomic.description}",
+                        ", ".join(vulnerability_ids) if vulnerability_ids else "—",
+                        self._result_text(atomic),
+                        self._lines(atomic.messages),
+                        self._lines(self._remediations(atomic)),
+                    )
+        return table

--- a/anta/cli/nrfu/__init__.py
+++ b/anta/cli/nrfu/__init__.py
@@ -68,6 +68,7 @@ def _build_nrfu_command(
     name: str,
     help_text: str,
     default_catalog_factory: Callable[[], AntaCatalog] | None = None,
+    default_report_command: click.Command | None = None,
 ) -> click.Group:
     """Build an NRFU command group, optionally with a programmatic default catalog."""
 
@@ -168,7 +169,7 @@ def _build_nrfu_command(
         ctx.obj["disconnect"] = disconnect
 
         if not ctx.invoked_subcommand:
-            ctx.invoke(commands.table)
+            ctx.invoke(default_report_command or commands.table)
 
     group = cast("click.Group", command)
     for report_command in (commands.table, commands.csv, commands.json, commands.text, commands.tpl_report, commands.md_report):

--- a/anta/cli/psirt.py
+++ b/anta/cli/psirt.py
@@ -16,10 +16,14 @@ from anta._advisory.reporter.reporting import (
     generate_security_advisory_csv_report,
     generate_security_advisory_md_report,
 )
+from anta._advisory.reporter.table_reporter import SecurityAdvisoryReportTable
+from anta._advisory.results import _get_advisory_metadata
 from anta.cli.console import console
 from anta.cli.nrfu import _build_nrfu_command
 from anta.cli.nrfu.utils import _get_result_manager, run_tests
 from anta.cli.utils import ExitCode, exit_with_code
+from anta.reporter.table_reporter import ReportTable
+from anta.result_manager import ResultManager
 from anta.tests.advisories import get_catalog
 
 if TYPE_CHECKING:
@@ -34,6 +38,72 @@ def _load_default_catalog() -> AntaCatalog:
 def _build_advisory_report(ctx: click.Context, *, allow_empty: bool = False) -> SecurityAdvisoryReport:
     """Build a security advisory report from the visible test results."""
     return SecurityAdvisoryReport.from_result_manager(_get_result_manager(ctx), allow_empty=allow_empty)
+
+
+def _partition_results(manager: ResultManager) -> tuple[ResultManager, ResultManager]:
+    """Partition visible results into advisory and ordinary result managers."""
+    advisory_results = ResultManager()
+    ordinary_results = ResultManager()
+    for result in manager.results:
+        target = advisory_results if _get_advisory_metadata(result) is not None else ordinary_results
+        target.add(result)
+    return advisory_results, ordinary_results
+
+
+@click.command(name="table")
+@click.pass_context
+@click.option(
+    "--summary-only",
+    default=False,
+    show_envvar=True,
+    is_flag=True,
+    show_default=True,
+    help="Only show summary tables.",
+)
+@click.option(
+    "--expand",
+    "-x",
+    default=False,
+    show_envvar=True,
+    is_flag=True,
+    show_default=True,
+    help="Show atomic findings in the per-device table.",
+)
+def _table(ctx: click.Context, *, summary_only: bool, expand: bool) -> None:
+    """Render security advisory summary and per-device tables."""
+    if summary_only and expand:
+        message = "--summary-only and --expand cannot be used together."
+        raise click.UsageError(message)
+
+    _ = run_tests(ctx)
+    visible_results = _get_result_manager(ctx)
+    advisory_results, ordinary_results = _partition_results(visible_results)
+    console.print()
+
+    if advisory_results.results:
+        try:
+            report = SecurityAdvisoryReport.from_result_manager(advisory_results)
+        except ValueError as error:
+            console.print(f"Failed to generate security advisory table report: {error} ❌", style="cyan")
+            ctx.exit(ExitCode.USAGE_ERROR)
+        reporter = SecurityAdvisoryReportTable()
+        console.print(reporter.generate_summary(report))
+        if not summary_only:
+            console.print(reporter.generate_device_findings(report, expand_results=expand))
+
+    if ordinary_results.results:
+        reporter = ReportTable()
+        if summary_only:
+            console.print(reporter.generate_summary_by_test(ordinary_results))
+        elif expand:
+            console.print(reporter.generate_expanded(ordinary_results))
+        else:
+            console.print(reporter.generate(ordinary_results))
+
+    if not visible_results.results:
+        console.print("No results to display.", style="cyan")
+
+    exit_with_code(ctx)
 
 
 @click.command(name="csv")
@@ -98,11 +168,13 @@ psirt = _build_nrfu_command(
         "deprecation notice."
     ),
     default_catalog_factory=_load_default_catalog,
+    default_report_command=_table,
 )
 # Override the generic NRFU commands registered by the factory with the
 # security-advisory-specific reporters under the same Click command names.
 psirt.add_command(_csv)
 psirt.add_command(_md_report)
+psirt.add_command(_table)
 
 
 __all__ = ["psirt"]

--- a/anta/cli/psirt.py
+++ b/anta/cli/psirt.py
@@ -89,7 +89,8 @@ def _table(ctx: click.Context, *, summary_only: bool, expand: bool) -> None:
         reporter = SecurityAdvisoryReportTable()
         console.print(reporter.generate_summary(report))
         if not summary_only:
-            console.print(reporter.generate_device_findings(report, expand_results=expand))
+            for table in reporter.generate_device_findings(report, expand_results=expand):
+                console.print(table)
 
     if ordinary_results.results:
         reporter = ReportTable()

--- a/docs/cli/psirt.md
+++ b/docs/cli/psirt.md
@@ -81,19 +81,21 @@ their vulnerability associations beneath each device result.
 --8<-- "anta_psirt_table_help.txt"
 ```
 
-The default table report first renders a summary grouped by advisory and then
-a table of every per-device finding. Advisories are ordered from critical to
-unknown severity. Device findings use advisory-facing results such as
-`affected`, `mitigated`, and `not affected`, and include their findings and
-remediations as bulleted actions. Parent rows aggregate and deduplicate
-test-level and atomic remediations. The advisory title and published URL appear
-together in the summary table.
+The default table report first renders a summary grouped by advisory, followed
+by one device findings table per advisory. Advisories are ordered from critical
+to unknown severity. Each findings table title identifies and links its
+advisory, and includes the advisory severity. Rows use advisory-facing results
+such as `affected`, `mitigated`, and `not affected`, with findings and
+remediations shown alongside the device. All per-advisory tables use the same
+full-width column layout so their fields remain aligned.
 
-Use `--summary-only` to omit per-device findings. Use `--expand` to add each
-atomic finding beneath its authoritative device result. Associated rows use
-the published vulnerability description and prefix each vulnerability ID with
-a severity-colored dot; unassociated rows retain the atomic description. These
-options cannot be combined.
+Use `--summary-only` to omit all per-advisory device findings tables. Use
+`--expand` to add each atomic finding as a `├──` or `└──` child beneath its
+authoritative device result. Child rows show their vulnerability associations,
+result, findings, and issue-specific remediation. Parent rows summarize their
+detailed checks and aggregate stable, deduplicated remediation as bulleted
+actions, prefixed by vulnerability IDs when the association is unambiguous.
+These options cannot be combined.
 
 The existing PSIRT `--device`, `--test`, and `--hide` options filter the visible
 results. For example, this command limits execution to one advisory test and

--- a/docs/cli/psirt.md
+++ b/docs/cli/psirt.md
@@ -59,12 +59,12 @@ advisory tests.
 
 ## Reports
 
-The table, text, JSON, and Jinja template reports reuse the generic NRFU
-renderers. CSV and Markdown use the security advisory reporters to include
+The text, JSON, and Jinja template reports reuse the generic NRFU renderers.
+Table, CSV, and Markdown use security-advisory-specific reporters to include
 advisory and vulnerability metadata with per-device findings. Markdown reports
 also include a run overview with execution timing, inventory and filter details,
-and assessment counts. CSV also includes result remediation when provided by
-the advisory test:
+and assessment counts. CSV and table reports include result remediation when
+provided by the advisory test:
 
 ```bash
 anta psirt --inventory inventory.yml --catalog sa.yml csv --csv-output sa-report.csv
@@ -74,6 +74,36 @@ anta psirt --inventory inventory.yml --catalog sa.yml md-report --md-output sa-r
 
 Use `--expand` on the Markdown report to include atomic advisory findings and
 their vulnerability associations beneath each device result.
+
+### Table report
+
+```bash
+--8<-- "anta_psirt_table_help.txt"
+```
+
+The default table report first renders a summary grouped by advisory and then
+a table of every per-device finding. Advisories are ordered from critical to
+unknown severity. Device findings use advisory-facing results such as
+`affected`, `mitigated`, and `not affected`, and include their evidence and
+remediation. The advisory title and published URL appear together in the
+summary table.
+
+Use `--summary-only` to omit per-device findings. Use `--expand` to add each
+atomic finding beneath its authoritative device result, including explicit
+vulnerability associations, evidence, and atomic remediation. These options
+cannot be combined.
+
+The existing PSIRT `--device`, `--test`, and `--hide` options filter the visible
+results. For example, this command limits execution to one advisory test and
+expands its findings:
+
+```bash
+anta psirt --inventory inventory.yml --test VerifySA117 table --expand
+```
+
+When a catalog override mixes advisory and ordinary ANTA tests, advisory
+results use the PSIRT tables and ordinary results follow in the generic ANTA
+table. With `--summary-only`, ordinary results use the generic per-test summary.
 
 See the [NRFU documentation](nrfu.md) for report options, filters, and dry-run
 behavior.

--- a/docs/cli/psirt.md
+++ b/docs/cli/psirt.md
@@ -84,14 +84,16 @@ their vulnerability associations beneath each device result.
 The default table report first renders a summary grouped by advisory and then
 a table of every per-device finding. Advisories are ordered from critical to
 unknown severity. Device findings use advisory-facing results such as
-`affected`, `mitigated`, and `not affected`, and include their evidence and
-remediation. The advisory title and published URL appear together in the
-summary table.
+`affected`, `mitigated`, and `not affected`, and include their findings and
+remediations as bulleted actions. Parent rows aggregate and deduplicate
+test-level and atomic remediations. The advisory title and published URL appear
+together in the summary table.
 
 Use `--summary-only` to omit per-device findings. Use `--expand` to add each
-atomic finding beneath its authoritative device result, including explicit
-vulnerability associations, evidence, and atomic remediation. These options
-cannot be combined.
+atomic finding beneath its authoritative device result. Associated rows use
+the published vulnerability description and prefix each vulnerability ID with
+a severity-colored dot; unassociated rows retain the atomic description. These
+options cannot be combined.
 
 The existing PSIRT `--device`, `--test`, and `--hide` options filter the visible
 results. For example, this command limits execution to one advisory test and

--- a/docs/scripts/generate_doc_snippets.py
+++ b/docs/scripts/generate_doc_snippets.py
@@ -22,6 +22,7 @@ COMMANDS = [
     "anta nrfu tpl-report --help",
     "anta nrfu md-report --help",
     "anta psirt --help",
+    "anta psirt table --help",
     "anta get tags --help",
     "anta get inventory --help",
     "anta get tests --help",

--- a/docs/security-advisory-reports.md
+++ b/docs/security-advisory-reports.md
@@ -29,9 +29,9 @@ Severity can be `unknown`, `none`, `low`, `medium`, `high`, or `critical`. Advis
 
 ## Table report
 
-The terminal table report renders an advisory exposure summary followed by per-device findings. The summary is ordered from critical to unknown severity and links each advisory to its published source. Device findings show advisory-facing results, evidence, and the remediation supplied by the test.
+The terminal table report renders an advisory exposure summary followed by per-device findings. The summary is ordered from critical to unknown severity and links each advisory to its published source. Device findings show advisory-facing results, findings, and stable, deduplicated remediation aggregated from the parent and atomic results as bulleted actions.
 
-Use `--summary-only` for the exposure summary alone. Use `--expand` to include atomic findings, their vulnerability associations, evidence, and issue-specific remediation beneath the authoritative device result.
+Use `--summary-only` for the exposure summary alone. Use `--expand` to include atomic findings beneath the authoritative device result. Associated rows use published vulnerability descriptions and prefix vulnerability IDs with severity-colored dots; unassociated rows retain their atomic descriptions. Each row includes its findings and issue-specific remediation.
 
 ## Markdown report
 

--- a/docs/security-advisory-reports.md
+++ b/docs/security-advisory-reports.md
@@ -27,6 +27,12 @@ An advisory may contain zero or more vulnerabilities. Each vulnerability has one
 
 Severity can be `unknown`, `none`, `low`, `medium`, `high`, or `critical`. Advisory authors select the appropriate value from the source material.
 
+## Table report
+
+The terminal table report renders an advisory exposure summary followed by per-device findings. The summary is ordered from critical to unknown severity and links each advisory to its published source. Device findings show advisory-facing results, evidence, and the remediation supplied by the test.
+
+Use `--summary-only` for the exposure summary alone. Use `--expand` to include atomic findings, their vulnerability associations, evidence, and issue-specific remediation beneath the authoritative device result.
+
 ## Markdown report
 
 The Markdown report supports flattened and expanded device findings. Flattened output is the default and renders one row per advisory result with the authoritative parent advisory result and its issue-attributed messages. Each advisory detail presents its severity, published URL, and description in a standard Markdown blockquote.

--- a/docs/security-advisory-reports.md
+++ b/docs/security-advisory-reports.md
@@ -29,9 +29,9 @@ Severity can be `unknown`, `none`, `low`, `medium`, `high`, or `critical`. Advis
 
 ## Table report
 
-The terminal table report renders an advisory exposure summary followed by per-device findings. The summary is ordered from critical to unknown severity and links each advisory to its published source. Device findings show advisory-facing results, findings, and stable, deduplicated remediation aggregated from the parent and atomic results as bulleted actions.
+The terminal table report renders an advisory exposure summary followed by one device findings table per advisory. The summary and findings tables are ordered from critical to unknown severity. Each findings table title identifies and links its advisory and includes its severity. All per-advisory tables use a shared full-width column layout so fields remain aligned between advisories.
 
-Use `--summary-only` for the exposure summary alone. Use `--expand` to include atomic findings beneath the authoritative device result. Associated rows use published vulnerability descriptions and prefix vulnerability IDs with severity-colored dots; unassociated rows retain their atomic descriptions. Each row includes its findings and issue-specific remediation.
+Use `--summary-only` for the exposure summary alone. Use `--expand` to include atomic findings as indented children beneath the authoritative device result. Child rows show vulnerability associations, semantic results, findings, and issue-specific remediation. Parent rows summarize detailed checks and show stable, deduplicated remediation aggregated from the parent and atomic results as bulleted actions. Vulnerability IDs prefix parent remediation when the association is unambiguous.
 
 ## Markdown report
 
@@ -46,9 +46,9 @@ Likewise, `--hide` filters displayed findings without changing the assessment co
 
 Expanded output follows the regular ANTA Markdown parent/child layout:
 
-- The parent row contains the device, test description, authoritative advisory result, and a summary of its detailed findings. All parent messages, when present, follow the summary as labelled overall evidence. Messages propagated from detailed findings may therefore also appear in the child rows.
+- The parent row contains the device, authoritative advisory result, and a summary of its detailed findings. All parent messages, when present, follow the summary as labelled overall evidence. Messages propagated from detailed findings may therefore also appear in the child rows.
 - Each indented `├──` or `└──` row represents one detailed issue assessment emitted by the test.
-- `Description` uses the published vulnerability descriptions for associated findings and the atomic description for unassociated findings. `Vulnerability ID(s)` lists explicit vulnerability associations prefixed by their severity icons, while `Result` and `Findings` contain the final semantic conclusion and decisive device evidence.
+- `Vulnerability ID(s)` lists explicit vulnerability associations prefixed by their severity icons, while `Result` and `Findings` contain the final semantic conclusion and decisive device evidence.
 - `Remediations` contains issue-specific remediation on atomic rows. Parent rows in both flattened and expanded reports display the stable, deduplicated aggregation of test-level and atomic remediation entries as bullets when atomic remediation contributes to the aggregation.
 - One issue may cover multiple vulnerabilities or have no vulnerability association. Multiple independent issues associated with the same vulnerability remain separate rows.
 - When the test emits no detailed issue assessments, expanded output contains only the parent row.

--- a/docs/snippets/anta_psirt_help.txt
+++ b/docs/snippets/anta_psirt_help.txt
@@ -68,6 +68,6 @@ Commands:
   csv         Generate a detailed security advisory CSV report.
   json        ANTA command to check network state with JSON results.
   md-report   Generate a detailed security advisory Markdown report.
-  table       ANTA command to check network state with table results.
+  table       Render security advisory summary and per-device tables.
   text        ANTA command to check network state with text results.
   tpl-report  ANTA command to check network state with templated report.

--- a/docs/snippets/anta_psirt_table_help.txt
+++ b/docs/snippets/anta_psirt_table_help.txt
@@ -1,0 +1,11 @@
+$ anta psirt table --help
+Usage: anta psirt table [OPTIONS]
+
+  Render security advisory summary and per-device tables.
+
+Options:
+  --summary-only  Only show summary tables.  [env var:
+                  ANTA_PSIRT_TABLE_SUMMARY_ONLY]
+  -x, --expand    Show atomic findings in the per-device table.  [env var:
+                  ANTA_PSIRT_TABLE_EXPAND]
+  --help          Show this message and exit.

--- a/tests/units/_advisory/test_table_reporter.py
+++ b/tests/units/_advisory/test_table_reporter.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Unit tests for security advisory Rich table reporting."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from anta._advisory.reporter.reporting import SecurityAdvisoryReport
+from anta._advisory.reporter.table_reporter import SecurityAdvisoryReportTable
+from anta._advisory.results import _AdvisoryTestResult
+from anta.result_manager import ResultManager
+from anta.result_manager.models import AntaTestStatus
+from tests.units._advisory.conftest import ADVISORY
+from tests.units._advisory.reporting_data import build_security_advisory_result_manager
+
+if TYPE_CHECKING:
+    from rich.table import Table
+
+
+def _cells(table: Table, row_index: int) -> list[str]:
+    """Return plain text for a Rich table row."""
+    return [str(column._cells[row_index]) for column in table.columns]
+
+
+def test_security_advisory_summary_order_and_counts() -> None:
+    """Order summary rows by severity and expose advisory-facing counts."""
+    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_result_manager())
+
+    table = SecurityAdvisoryReportTable().generate_summary(report)
+
+    assert table.row_count == 3
+    assert [_cells(table, index)[0] for index in range(table.row_count)] == ["🔴 Critical", "🟠 High", "🟡 Medium"]
+    assert _cells(table, 0)[2:] == ["8", "4", "0", "2", "0", "1", "1", "0"]
+    assert _cells(table, 1)[2:] == ["8", "1", "0", "5", "0", "1", "1", "0"]
+    assert _cells(table, 2)[2:] == ["8", "2", "0", "4", "0", "1", "1", "0"]
+    assert "SA0120: Example Management API Authentication Bypass" in _cells(table, 0)[1]
+    assert "https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120" in _cells(table, 0)[1]
+
+
+def test_security_advisory_summary_mitigated_and_unset() -> None:
+    """Represent mitigated and unset results without losing either state."""
+    manager = ResultManager()
+    manager.add(
+        _AdvisoryTestResult(
+            name="leaf1",
+            test="VerifySA1",
+            categories=["advisories"],
+            description="Test advisory.",
+            result=AntaTestStatus.SUCCESS,
+            messages=["The device is affected but mitigated because the vulnerable service is disabled."],
+            advisory=ADVISORY,
+        )
+    )
+    manager.add(
+        _AdvisoryTestResult(
+            name="leaf2",
+            test="VerifySA1",
+            categories=["advisories"],
+            description="Test advisory.",
+            result=AntaTestStatus.UNSET,
+            advisory=ADVISORY,
+        )
+    )
+
+    table = SecurityAdvisoryReportTable().generate_summary(SecurityAdvisoryReport.from_result_manager(manager))
+
+    assert _cells(table, 0)[2:] == ["2", "0", "1", "0", "0", "0", "0", "1"]
+
+
+def test_security_advisory_device_findings_remediation_and_order() -> None:
+    """Show actual remediation text and order urgent results first."""
+    manager = ResultManager()
+    manager.add(
+        _AdvisoryTestResult(
+            name="leaf2",
+            test="VerifySA1",
+            categories=["advisories"],
+            description="Test advisory.",
+            result=AntaTestStatus.SUCCESS,
+            messages=["The device is not affected."],
+            advisory=ADVISORY,
+        )
+    )
+    manager.add(
+        _AdvisoryTestResult(
+            name="leaf1",
+            test="VerifySA1",
+            categories=["advisories"],
+            description="Test advisory.",
+            result=AntaTestStatus.FAILURE,
+            messages=["The device is affected."],
+            advisory=ADVISORY,
+            remediations=["Upgrade EOS.", "Apply the configuration workaround."],
+        )
+    )
+
+    table = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager))
+
+    assert table.row_count == 2
+    assert _cells(table, 0) == [
+        "🟠 High",
+        "SA0001",
+        "leaf1",
+        "Affected",
+        "The device is affected.",
+        "Upgrade EOS.\nApply the configuration workaround.",
+    ]
+    assert _cells(table, 1)[-1] == "—"
+
+
+def test_security_advisory_expanded_atomic_findings() -> None:
+    """Render atomic evidence, associations, and remediation beneath the parent."""
+    result = _AdvisoryTestResult(
+        name="leaf1",
+        test="VerifySA1",
+        categories=["advisories"],
+        description="Test advisory.",
+        result=AntaTestStatus.FAILURE,
+        messages=["Overall exposure detected."],
+        advisory=ADVISORY,
+        remediations=["Apply the advisory remediation."],
+    )
+    result.add(
+        "Vulnerable service",
+        AntaTestStatus.FAILURE,
+        ["The service is exposed."],
+        vulnerability_ids=("CVE-2026-0001",),
+        remediations=["Disable the service."],
+    )
+    result.add("External condition", AntaTestStatus.INCONCLUSIVE, ["External evidence is unavailable."], remediations=["Collect external evidence."])
+    manager = ResultManager()
+    manager.add(result)
+
+    table = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager), expand_results=True)
+
+    assert table.row_count == 3
+    assert _cells(table, 0)[3:] == [
+        "Overall advisory",
+        "—",
+        "Affected",
+        "Overall exposure detected.\nVulnerable service - The service is exposed.\nExternal condition - External evidence is unavailable.",
+        "Apply the advisory remediation.",
+    ]
+    assert _cells(table, 1)[3:] == ["├── Vulnerable service", "CVE-2026-0001", "Affected", "The service is exposed.", "Disable the service."]
+    assert _cells(table, 2)[3:] == ["└── External condition", "—", "Inconclusive", "External evidence is unavailable.", "Collect external evidence."]

--- a/tests/units/_advisory/test_table_reporter.py
+++ b/tests/units/_advisory/test_table_reporter.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from anta._advisory.reporter.reporting import SecurityAdvisoryReport
 from anta._advisory.reporter.table_reporter import SecurityAdvisoryReportTable
@@ -17,6 +17,7 @@ from tests.units._advisory.reporting_data import build_security_advisory_result_
 
 if TYPE_CHECKING:
     from rich.table import Table
+    from rich.text import Text
 
 
 def _cells(table: Table, row_index: int) -> list[str]:
@@ -31,7 +32,8 @@ def test_security_advisory_summary_order_and_counts() -> None:
     table = SecurityAdvisoryReportTable().generate_summary(report)
 
     assert table.row_count == 3
-    assert [_cells(table, index)[0] for index in range(table.row_count)] == ["🔴 Critical", "🟠 High", "🟡 Medium"]
+    assert [_cells(table, index)[0] for index in range(table.row_count)] == ["● Critical", "● High", "● Medium"]
+    assert [str(cast("Text", table.columns[0]._cells[index]).spans[0].style) for index in range(table.row_count)] == ["red", "orange3", "yellow3"]
     assert _cells(table, 0)[2:] == ["8", "4", "0", "2", "0", "1", "1", "0"]
     assert _cells(table, 1)[2:] == ["8", "1", "0", "5", "0", "1", "1", "0"]
     assert _cells(table, 2)[2:] == ["8", "2", "0", "4", "0", "1", "1", "0"]
@@ -99,13 +101,14 @@ def test_security_advisory_device_findings_remediation_and_order() -> None:
     table = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager))
 
     assert table.row_count == 2
+    assert [str(column.header) for column in table.columns] == ["Severity", "Advisory", "Device", "Result", "Findings", "Remediations"]
     assert _cells(table, 0) == [
-        "🟠 High",
+        "● High",
         "SA0001",
         "leaf1",
         "Affected",
         "The device is affected.",
-        "Upgrade EOS.\nApply the configuration workaround.",
+        "• Upgrade EOS.\n• Apply the configuration workaround.",
     ]
     assert _cells(table, 1)[-1] == "—"
 
@@ -127,7 +130,7 @@ def test_security_advisory_expanded_atomic_findings() -> None:
         AntaTestStatus.FAILURE,
         ["The service is exposed."],
         vulnerability_ids=("CVE-2026-0001",),
-        remediations=["Disable the service."],
+        remediations=["Apply the advisory remediation.", "Disable the service."],
     )
     result.add("External condition", AntaTestStatus.INCONCLUSIVE, ["External evidence is unavailable."], remediations=["Collect external evidence."])
     manager = ResultManager()
@@ -136,12 +139,29 @@ def test_security_advisory_expanded_atomic_findings() -> None:
     table = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager), expand_results=True)
 
     assert table.row_count == 3
+    assert [str(column.header) for column in table.columns] == [
+        "Severity",
+        "Advisory",
+        "Device",
+        "Description",
+        "Vulnerability ID(s)",
+        "Result",
+        "Findings",
+        "Remediations",
+    ]
     assert _cells(table, 0)[3:] == [
         "Overall advisory",
         "—",
         "Affected",
         "Overall exposure detected.\nVulnerable service - The service is exposed.\nExternal condition - External evidence is unavailable.",
-        "Apply the advisory remediation.",
+        "• Apply the advisory remediation.\n• Disable the service.\n• Collect external evidence.",
     ]
-    assert _cells(table, 1)[3:] == ["├── Vulnerable service", "CVE-2026-0001", "Affected", "The service is exposed.", "Disable the service."]
-    assert _cells(table, 2)[3:] == ["└── External condition", "—", "Inconclusive", "External evidence is unavailable.", "Collect external evidence."]
+    assert _cells(table, 1)[3:] == [
+        "├── CVE-2026-0001 Test vulnerability affecting the management API.",
+        "● CVE-2026-0001",
+        "Affected",
+        "The service is exposed.",
+        "• Apply the advisory remediation.\n• Disable the service.",
+    ]
+    assert str(cast("Text", table.columns[4]._cells[1]).spans[0].style) == "yellow3"
+    assert _cells(table, 2)[3:] == ["└── External condition", "—", "Inconclusive", "External evidence is unavailable.", "• Collect external evidence."]

--- a/tests/units/_advisory/test_table_reporter.py
+++ b/tests/units/_advisory/test_table_reporter.py
@@ -34,9 +34,9 @@ def test_security_advisory_summary_order_and_counts() -> None:
     assert table.row_count == 3
     assert [_cells(table, index)[0] for index in range(table.row_count)] == ["● Critical", "● High", "● Medium"]
     assert [str(cast("Text", table.columns[0]._cells[index]).spans[0].style) for index in range(table.row_count)] == ["red", "orange3", "yellow3"]
-    assert _cells(table, 0)[2:] == ["8", "4", "0", "2", "0", "1", "1", "0"]
-    assert _cells(table, 1)[2:] == ["8", "1", "0", "5", "0", "1", "1", "0"]
-    assert _cells(table, 2)[2:] == ["8", "2", "0", "4", "0", "1", "1", "0"]
+    assert _cells(table, 0)[2:] == ["8", "4", "0", "0", "2", "1", "1", "0"]
+    assert _cells(table, 1)[2:] == ["8", "1", "0", "0", "5", "1", "1", "0"]
+    assert _cells(table, 2)[2:] == ["8", "0", "2", "0", "4", "1", "1", "0"]
     assert "SA0120: Example Management API Authentication Bypass" in _cells(table, 0)[1]
     assert "https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120" in _cells(table, 0)[1]
 
@@ -68,7 +68,7 @@ def test_security_advisory_summary_mitigated_and_unset() -> None:
 
     table = SecurityAdvisoryReportTable().generate_summary(SecurityAdvisoryReport.from_result_manager(manager))
 
-    assert _cells(table, 0)[2:] == ["2", "0", "1", "0", "0", "0", "0", "1"]
+    assert _cells(table, 0)[2:] == ["2", "0", "0", "1", "0", "0", "0", "1"]
 
 
 def test_security_advisory_device_findings_remediation_and_order() -> None:
@@ -98,13 +98,14 @@ def test_security_advisory_device_findings_remediation_and_order() -> None:
         )
     )
 
-    table = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager))
+    tables = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager))
 
+    assert len(tables) == 1
+    table = tables[0]
     assert table.row_count == 2
-    assert [str(column.header) for column in table.columns] == ["Severity", "Advisory", "Device", "Result", "Findings", "Remediations"]
+    assert "Device Findings — SA0001: Test advisory" in str(table.title)
+    assert [str(column.header) for column in table.columns] == ["Device", "Result", "Findings", "Remediations"]
     assert _cells(table, 0) == [
-        "● High",
-        "SA0001",
         "leaf1",
         "Affected",
         "The device is affected.",
@@ -136,32 +137,50 @@ def test_security_advisory_expanded_atomic_findings() -> None:
     manager = ResultManager()
     manager.add(result)
 
-    table = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager), expand_results=True)
+    tables = SecurityAdvisoryReportTable().generate_device_findings(SecurityAdvisoryReport.from_result_manager(manager), expand_results=True)
 
+    assert len(tables) == 1
+    table = tables[0]
     assert table.row_count == 3
+    assert [row.end_section for row in table.rows] == [False, False, True]
     assert [str(column.header) for column in table.columns] == [
-        "Severity",
-        "Advisory",
         "Device",
-        "Description",
         "Vulnerability ID(s)",
         "Result",
         "Findings",
         "Remediations",
     ]
-    assert _cells(table, 0)[3:] == [
-        "Overall advisory",
+    assert _cells(table, 0) == [
+        "leaf1",
         "—",
         "Affected",
-        "Overall exposure detected.\nVulnerable service - The service is exposed.\nExternal condition - External evidence is unavailable.",
-        "• Apply the advisory remediation.\n• Disable the service.\n• Collect external evidence.",
+        (
+            "Detailed findings: 1/2 checks affected; 1/2 checks inconclusive\n"
+            "Overall evidence:\n"
+            "Overall exposure detected.\n"
+            "CVE-2026-0001: The service is exposed.\n"
+            "External condition - External evidence is unavailable."
+        ),
+        "• CVE-2026-0001: Apply the advisory remediation.\n• CVE-2026-0001: Disable the service.\n• Collect external evidence.",
     ]
-    assert _cells(table, 1)[3:] == [
-        "├── CVE-2026-0001 Test vulnerability affecting the management API.",
+    assert _cells(table, 1) == [
+        "  ├──",
         "● CVE-2026-0001",
         "Affected",
         "The service is exposed.",
         "• Apply the advisory remediation.\n• Disable the service.",
     ]
-    assert str(cast("Text", table.columns[4]._cells[1]).spans[0].style) == "yellow3"
-    assert _cells(table, 2)[3:] == ["└── External condition", "—", "Inconclusive", "External evidence is unavailable.", "• Collect external evidence."]
+    assert str(cast("Text", table.columns[1]._cells[1]).spans[0].style) == "yellow3"
+    assert _cells(table, 2) == ["  └──", "—", "Inconclusive", "External evidence is unavailable.", "• Collect external evidence."]
+
+
+def test_security_advisory_device_findings_use_consistent_layout() -> None:
+    """Use the same full-width column layout for every advisory table."""
+    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_result_manager())
+
+    tables = SecurityAdvisoryReportTable().generate_device_findings(report, expand_results=True)
+
+    assert len(tables) == 3
+    assert all(table.expand for table in tables)
+    layouts = [[(column.width, column.ratio) for column in table.columns] for table in tables]
+    assert layouts == [[(18, None), (24, None), (12, None), (None, 3), (None, 2)]] * 3

--- a/tests/units/cli/test_psirt.py
+++ b/tests/units/cli/test_psirt.py
@@ -158,7 +158,7 @@ def test_partition_psirt_mixed_results() -> None:
     [
         pytest.param([], None, id="implicit-table"),
         pytest.param(["table"], None, id="explicit-table"),
-        pytest.param(["table", "--summary-only"], "Security Advisory Device Findings", id="summary-only"),
+        pytest.param(["table", "--summary-only"], "Device Findings", id="summary-only"),
     ],
 )
 def test_anta_psirt_table_output(click_runner: CliRunner, args: list[str], unexpected_title: str | None) -> None:
@@ -172,7 +172,7 @@ def test_anta_psirt_table_output(click_runner: CliRunner, args: list[str], unexp
     assert "Critical" in result.output
     assert "SA0120" in result.output
     if unexpected_title is None:
-        assert "Security Advisory Device Findings" in result.output
+        assert result.output.count("Device Findings") == 3
     else:
         assert unexpected_title not in result.output
 

--- a/tests/units/cli/test_psirt.py
+++ b/tests/units/cli/test_psirt.py
@@ -15,10 +15,16 @@ from anta._advisory.reporter.reporting import SecurityAdvisoryReportConfig
 from anta._runner import AntaRunContext, AntaRunFilters
 from anta.catalog import AntaCatalog
 from anta.cli import anta
+from anta.cli.psirt import _partition_results
 from anta.cli.utils import ExitCode
 from anta.result_manager import ResultManager
 from anta.result_manager.models import AntaTestStatus
-from tests.units._advisory.reporting_data import EXAMPLE_HIGH_ADVISORY, build_security_advisory_result
+from anta.result_manager.models import TestResult as AntaTestResult
+from tests.units._advisory.reporting_data import (
+    EXAMPLE_HIGH_ADVISORY,
+    build_security_advisory_result,
+    build_security_advisory_result_manager,
+)
 
 if TYPE_CHECKING:
     import click
@@ -107,6 +113,90 @@ def test_anta_psirt_report_help(click_runner: CliRunner, report: str) -> None:
 
     assert result.exit_code == ExitCode.OK
     assert f"Usage: anta psirt {report}" in result.output
+
+
+def test_anta_psirt_table_help(click_runner: CliRunner) -> None:
+    """Expose only the PSIRT-specific table options."""
+    result = click_runner.invoke(anta, ["psirt", "table", "--help"])
+
+    assert result.exit_code == ExitCode.OK
+    assert "--summary-only" in result.output
+    assert "--expand" in result.output
+    assert "--group-by" not in result.output
+    assert "--sort-by" not in result.output
+
+
+def test_anta_psirt_table_rejects_incompatible_options(click_runner: CliRunner) -> None:
+    """Reject summary-only output combined with atomic expansion."""
+    result = click_runner.invoke(anta, ["psirt", "table", "--summary-only", "--expand"])
+
+    assert result.exit_code == ExitCode.USAGE_ERROR
+    assert "--summary-only and --expand cannot be used together" in result.output
+
+
+def test_partition_psirt_mixed_results() -> None:
+    """Keep advisory and ordinary results in separate managers."""
+    manager = build_security_advisory_result_manager()
+    manager.add(
+        AntaTestResult(
+            name="leaf1",
+            test="VerifyOrdinaryTest",
+            categories=["system"],
+            description="Ordinary ANTA test.",
+            result=AntaTestStatus.SUCCESS,
+        )
+    )
+
+    advisory_results, ordinary_results = _partition_results(manager)
+
+    assert len(advisory_results.results) == 24
+    assert [result.test for result in ordinary_results.results] == ["VerifyOrdinaryTest"]
+
+
+@pytest.mark.parametrize(
+    ("args", "unexpected_title"),
+    [
+        pytest.param([], None, id="implicit-table"),
+        pytest.param(["table"], None, id="explicit-table"),
+        pytest.param(["table", "--summary-only"], "Security Advisory Device Findings", id="summary-only"),
+    ],
+)
+def test_anta_psirt_table_output(click_runner: CliRunner, args: list[str], unexpected_title: str | None) -> None:
+    """Render the advisory summary and optionally the per-device findings."""
+    manager = build_security_advisory_result_manager()
+    with patch("anta.cli.psirt.run_tests"), patch("anta.cli.psirt._get_result_manager", return_value=manager):
+        result = click_runner.invoke(anta, ["psirt", *args])
+
+    assert result.exit_code == ExitCode.OK
+    assert "Security Advisory Summary" in result.output
+    assert "Critical" in result.output
+    assert "SA0120" in result.output
+    if unexpected_title is None:
+        assert "Security Advisory Device Findings" in result.output
+    else:
+        assert unexpected_title not in result.output
+
+
+@pytest.mark.parametrize(("extra_args", "generic_title"), [([], "All tests results"), (["--summary-only"], "Summary per test")])
+def test_anta_psirt_table_mixed_catalog(click_runner: CliRunner, extra_args: list[str], generic_title: str) -> None:
+    """Render advisory and ordinary results in separate tables."""
+    manager = build_security_advisory_result_manager()
+    manager.add(
+        AntaTestResult(
+            name="leaf1",
+            test="VerifyOrdinaryTest",
+            categories=["system"],
+            description="Ordinary ANTA test.",
+            result=AntaTestStatus.SUCCESS,
+        )
+    )
+    with patch("anta.cli.psirt.run_tests"), patch("anta.cli.psirt._get_result_manager", return_value=manager):
+        result = click_runner.invoke(anta, ["psirt", "table", *extra_args])
+
+    assert result.exit_code == ExitCode.OK
+    assert "Security Advisory Summary" in result.output
+    assert generic_title in result.output
+    assert "VerifyOrdinaryTest" in result.output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Add temporary table view for ANTA PSIRT command

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated PSIRT table report for security advisory results.
  - Displays severity indicators, advisory statuses, vulnerability details, findings, and remediation guidance.
  - Supports summary-only and expanded per-device views, including mixed advisory and standard results.
  - Deduplicates remediation recommendations and presents atomic remediation steps clearly.
  - Added filtering and validation for incompatible report options.
  - Improved Markdown and CSV advisory report details.

- **Documentation**
  - Updated PSIRT help, reporting guides, and security advisory documentation.

- **Tests**
  - Expanded coverage for report formatting, ordering, mixed results, remediation, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->