### PR TITLE
ci: Add prerelease support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,11 +188,16 @@ jobs:
       - name: 'Build Zensical content to site folder'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           pip install --group doc -e tools/zensical_extensions
-          mike deploy --update-alias --push "$REF_NAME" stable
+          if [[ "$PRERELEASE" == "true" ]]; then
+            mike deploy --push "$REF_NAME"
+          else
+            mike deploy --update-alias --push "$REF_NAME" stable
+          fi
 
   docker:
     name: Docker Image Build


### PR DESCRIPTION
## Description

<!-- PR description !-->

In CI, when releasing a prerelease version of ANTA, do not update the documentation stable alias to the prerelease version.

## Checklist

<!-- Delete not relevant items !-->

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have run pre-commit for code linting and typing (`pre-commit run`)
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved release documentation handling so prerelease versions are published separately without replacing the stable documentation alias.
  * Stable releases continue to update the stable documentation version as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->