### PR TITLE
fix(anta): Fix EOS compatibility for security advisories

### DIFF
--- a/anta/constants.py
+++ b/anta/constants.py
@@ -86,6 +86,7 @@ UNSUPPORTED_PLATFORM_ERRORS = [
     "Invalid input (at token 1: 'supervisor-peer:/mnt/flash')",
     "Incomplete command (at token 1: 'module')",
     "Incomplete command (at token 1: 'ptp')",
+    "Invalid input (at token 1: 'directflow')",
 ]
 """Error messages indicating platform or hardware unsupported commands. Includes both general hardware
 platform errors and specific ASIC family limitations.

--- a/anta/tests/advisories/sa_117.py
+++ b/anta/tests/advisories/sa_117.py
@@ -75,16 +75,32 @@ ADVISORY = _AdvisoryMetadata(
 )
 
 
-def _evaluate_gnmi_transport_enabled(gnmi_output: Mapping[str, object]) -> bool | None:
-    """Return whether at least one gNMI transport is enabled."""
+def _gnmi_transport_values(gnmi_output: Mapping[str, object]) -> tuple[object, ...] | None:
+    """Return transport values from nested or flattened EOS gNMI output.
+
+    EOS 4.33 eAPI revision 1 exposes a single transport at the top level, while
+    newer schemas expose named transports below ``transports``.
+    """
+    if "transports" not in gnmi_output:
+        enabled = gnmi_output.get("enabled")
+        if not isinstance(enabled, bool):
+            return None
+        return (gnmi_output,) if enabled else ()
+
     transports = gnmi_output.get("transports")
     if not isinstance(transports, Mapping):
         return None
-    if not transports:
-        return False
+    return tuple(transports.values())
+
+
+def _evaluate_gnmi_transport_enabled(gnmi_output: Mapping[str, object]) -> bool | None:
+    """Return whether at least one gNMI transport is enabled."""
+    transports = _gnmi_transport_values(gnmi_output)
+    if transports is None:
+        return None
 
     unknown = False
-    for transport in transports.values():
+    for transport in transports:
         if not isinstance(transport, Mapping):
             unknown = True
             continue
@@ -99,12 +115,12 @@ def _evaluate_gnmi_transport_enabled(gnmi_output: Mapping[str, object]) -> bool 
 
 def _evaluate_gnmi_accounting_enabled(gnmi_output: Mapping[str, object]) -> bool | None:
     """Return whether an enabled gNMI transport has accounting enabled."""
-    transports = gnmi_output.get("transports")
-    if not isinstance(transports, Mapping):
+    transports = _gnmi_transport_values(gnmi_output)
+    if transports is None:
         return None
 
     unknown = False
-    for transport in transports.values():
+    for transport in transports:
         if not isinstance(transport, Mapping):
             unknown = True
             continue

--- a/anta/tests/advisories/sa_146.py
+++ b/anta/tests/advisories/sa_146.py
@@ -474,7 +474,7 @@ class VerifySA146(OptionalCommandsMixin, _AntaAdvisoryTest):
         AntaCommand(command="show version detail", revision=1),
         OptionalAntaCommand(command="show management api gnmi", revision=1),
         OptionalAntaCommand(command="show management api gribi", revision=1),
-        OptionalAntaCommand(command="show daemon TerminAttr", revision=1),
+        OptionalAntaCommand(command="show daemon", revision=1),
         OptionalAntaCommand(command="show running-config section grpcaddr", ofmt="text"),
         OptionalAntaCommand(command="show management security ssl profile", revision=1),
     ]

--- a/tests/units/anta_tests/advisories/test_sa_117.py
+++ b/tests/units/anta_tests/advisories/test_sa_117.py
@@ -73,6 +73,18 @@ _DATA: AntaUnitTestData = {
             "Upgrade to",
         ),
     },
+    (VerifySA117, "inconclusive-flattened-accounting-enabled"): {
+        "version": "4.33.0F",
+        "eos_data": [
+            {"enabled": True, "accounting": True},
+            "",
+        ],
+        "expected": expected_result(
+            AntaTestStatus.INCONCLUSIVE,
+            "The assessment is inconclusive and the device may be affected because EOS version '4.33.0F' has an enabled gNMI transport with accounting enabled",
+            "Upgrade to",
+        ),
+    },
     (VerifySA117, "inconclusive-risky-trace-configured"): {
         "version": "4.32.4M",
         "eos_data": [
@@ -103,6 +115,18 @@ _DATA: AntaUnitTestData = {
         "version": "4.32.4M",
         "eos_data": [
             {"transports": {"default": {"enabled": False, "accounting": True}}},
+            "",
+        ],
+        "expected": expected_result(
+            AntaTestStatus.SUCCESS,
+            "The device is not affected because no gNMI transport is enabled",
+            "",
+        ),
+    },
+    (VerifySA117, "success-flattened-disabled-transport"): {
+        "version": "4.33.0F",
+        "eos_data": [
+            {"enabled": False, "accounting": True},
             "",
         ],
         "expected": expected_result(
@@ -204,7 +228,11 @@ class TestSA117Evidence(unittest.TestCase):
     def test_transport_enabled_truth_table(self) -> None:
         cases = (
             ({}, None),
+            ({"enabled": False}, False),
+            ({"enabled": True}, True),
+            ({"enabled": "invalid"}, None),
             ({"transports": {}}, False),
+            ({"transports": None}, None),
             ({"transports": {"default": {"enabled": False}}}, False),
             ({"transports": {"default": {"enabled": True}}}, True),
             ({"transports": {"default": {}}}, None),
@@ -218,7 +246,13 @@ class TestSA117Evidence(unittest.TestCase):
     def test_accounting_only_applies_to_enabled_transports(self) -> None:
         cases = (
             ({}, None),
+            ({"enabled": False, "accounting": True}, False),
+            ({"enabled": True, "accounting": False}, False),
+            ({"enabled": True, "accounting": True}, True),
+            ({"enabled": True}, None),
+            ({"enabled": "invalid", "accounting": True}, None),
             ({"transports": {}}, False),
+            ({"transports": None}, None),
             ({"transports": {"default": {"enabled": False, "accounting": True}}}, False),
             ({"transports": {"default": {"enabled": True, "accounting": False}}}, False),
             ({"transports": {"default": {"enabled": True, "accounting": True}}}, True),

--- a/tests/units/anta_tests/advisories/test_sa_142.py
+++ b/tests/units/anta_tests/advisories/test_sa_142.py
@@ -617,6 +617,27 @@ class TestVerifySA142(unittest.IsolatedAsyncioTestCase):
 
         assert test.result.result is AntaTestStatus.SUCCESS
 
+    async def test_unsupported_directflow_parser_rejection_proves_path_absent(self) -> None:
+        device = OfflineAntaDevice("unit-test")
+        device.version = parse_eos_version("4.33.0F")
+        device.hw_model = "cEOSLab"
+        await device.refresh()
+        eos_data = [
+            {"policyMaps": {}},
+            "",
+            {"trafficPolicies": {}},
+            "Flows: 0 programmed, 0 rejected",
+            {"policies": {}},
+            "",
+        ]
+        test = cast("Any", VerifySA142)(device=device, eos_data=eos_data)
+        test.instance_commands[3].output = None
+        test.instance_commands[3].errors = ["Invalid input (at token 1: 'directflow')"]
+        test.collect = AsyncMock()
+        await test.test()
+
+        assert test.result.result is AntaTestStatus.SUCCESS
+
     async def test_unsupported_required_control_command_is_error(self) -> None:
         device = OfflineAntaDevice("unit-test")
         device.version = parse_eos_version("4.35.4M")

--- a/tests/units/anta_tests/advisories/test_sa_146.py
+++ b/tests/units/anta_tests/advisories/test_sa_146.py
@@ -225,6 +225,15 @@ _DATA: AntaUnitTestData = {
             "",
         ),
     },
+    (VerifySA146, "success-terminattr-not-configured"): {
+        "version": "4.35.5M",
+        "eos_data": sa146_eos_data(terminattr={"daemons": {}}),
+        "expected": expected_result(
+            AntaTestStatus.SUCCESS,
+            "The device is not affected because no enabled gRPC server is on an affected software version",
+            "",
+        ),
+    },
     (VerifySA146, "success-fixed-versions-ignore-malformed-service-output"): {
         "version": "4.35.6M",
         "eos_data": sa146_eos_data(


### PR DESCRIPTION
## Description

<!-- PR description !-->
Fix EOS compatibility for SA117 & SA142 & SA146

Testing on EOS 4.33.0F ceos-lab:
- SA0117 gnmi output is flatter for same revision - accept both.
- SA0142 reported invalid directflow command - should be a sign of unsupported.

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gNMI transport data across legacy and newer EOS response formats.
  * Correctly handles missing or malformed gNMI transport information.
  * Recognizes unsupported DirectFlow commands and skips affected checks with an appropriate warning.
  * Improved detection of TerminAttr configuration when daemon information is unavailable.

* **Tests**
  * Added coverage for flattened gNMI responses, unsupported DirectFlow commands, and missing TerminAttr daemon data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->