### PR TITLE
refactor(anta): Update ANTA PSIRT markdown report

### DIFF
--- a/anta/_advisory/reporter/md_reporter.py
+++ b/anta/_advisory/reporter/md_reporter.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
 
-from anta._advisory.models import _AdvisoryMetadata, _AdvisoryVulnerabilitySeverity
+from anta._advisory.models import _ADVISORY_VULNERABILITY_SEVERITY_RANK, _AdvisoryMetadata, _AdvisoryVulnerabilitySeverity
 from anta._advisory.reporter.reporting import SecurityAdvisoryRunOverviewData, _get_advisory_result
-from anta._advisory.results import _get_atomic_vulnerability_ids
+from anta._advisory.results import _AdvisoryAtomicTestResult, _AdvisoryTestResult, _get_atomic_vulnerability_ids
 from anta.reporter.md_reporter import MDReportBase
 from anta.result_manager.models import AntaTestStatus
 
@@ -64,6 +64,27 @@ class SecurityAdvisoryMDReportBase(MDReportBase):
         """Format an ANTA result using advisory-facing terminology."""
         return f"{RESULT_ICONS[result.result]}&nbsp;{_get_advisory_result(result).title()}"
 
+    @staticmethod
+    def format_severity(severity: _AdvisoryVulnerabilitySeverity) -> str:
+        """Format a vulnerability severity with its identifying icon."""
+        return f"{SEVERITY_ICONS[severity]}&nbsp;{severity.value.title()}"
+
+    def format_remediations(self, result: TestResult | AtomicTestResult) -> str:
+        """Format advisory remediation entries for a Markdown table cell."""
+        if not isinstance(result, (_AdvisoryTestResult, _AdvisoryAtomicTestResult)):
+            return "-"
+        remediations = list(result.remediations)
+        atomic_remediations: list[str] = []
+        if isinstance(result, _AdvisoryTestResult):
+            atomic_remediations = [
+                remediation for atomic in result.atomic_results if isinstance(atomic, _AdvisoryAtomicTestResult) for remediation in atomic.remediations
+            ]
+            remediations.extend(atomic_remediations)
+        unique_remediations = dict.fromkeys(remediations)
+        if atomic_remediations:
+            return "<br>".join(f"•&nbsp;{self.safe_markdown(remediation)}" for remediation in unique_remediations)
+        return self.safe_markdown("\n".join(unique_remediations)) or "-"
+
 
 class ANTASecurityAdvisoryReport(SecurityAdvisoryMDReportBase):
     """Generate the title and table of contents for a security advisory report."""
@@ -72,15 +93,18 @@ class ANTASecurityAdvisoryReport(SecurityAdvisoryMDReportBase):
 
     def generate_section(self) -> None:
         """Generate the security advisory report heading and table of contents."""
-        self.write_heading(heading_level=1)
-        toc = "**Table of Contents:**\n\n- [ANTA Security Advisory Report](#anta-security-advisory-report)\n"
+        self.mdfile.write('<h1 id="anta-security-advisory-report" align="center">🛡️ ANTA Security Advisory Report 🛡️</h1>\n\n')
+        toc = "**Table of Contents:**\n\n"
         if self.groups:
-            toc += "  - [Advisory Exposure Summary](#advisory-exposure-summary)\n  - [Security Advisory Details](#security-advisory-details)\n"
-        toc += "  - [Security Advisory Run Overview](#security-advisory-run-overview)"
+            toc += "- [Advisory Assessment Summary](#advisory-assessment-summary)\n- [Security Advisory Details](#security-advisory-details)\n"
+            for group in self.groups:
+                advisory = group.advisory
+                toc += f"  - [SA{advisory.sa_number}: {self.safe_markdown(advisory.title)}](#sa-{advisory.sa_number.lower()})\n"
+        toc += "- [Run Overview](#run-overview)"
         self.mdfile.write(toc + "\n\n")
 
 
-class AdvisoryExposureSummary(SecurityAdvisoryMDReportBase):
+class AdvisoryAssessmentSummary(SecurityAdvisoryMDReportBase):
     """Generate a compact status summary grouped by security advisory."""
 
     ICON = "📊"
@@ -107,8 +131,7 @@ class AdvisoryExposureSummary(SecurityAdvisoryMDReportBase):
         for group in self.groups:
             advisory = group.advisory
             advisory_link = f"[SA{advisory.sa_number}: {self.safe_markdown(advisory.title)}](#sa-{advisory.sa_number.lower()})"
-            advisory_severity = group.severity
-            severity = f"{SEVERITY_ICONS[advisory_severity]}&nbsp;{advisory_severity.value.title()}"
+            severity = self.format_severity(group.severity)
             devices = len({result.name for result in group.results})
             yield (
                 f"| {advisory_link} | {severity} | {devices} "
@@ -121,7 +144,7 @@ class AdvisoryExposureSummary(SecurityAdvisoryMDReportBase):
             )
 
     def generate_section(self) -> None:
-        """Generate the advisory exposure summary section."""
+        """Generate the advisory assessment summary section."""
         self.write_heading(heading_level=2)
         self.write_table(table_heading=self.TABLE_HEADING)
 
@@ -133,29 +156,34 @@ class SecurityAdvisoryDetails(SecurityAdvisoryMDReportBase):
 
     def _write_vulnerabilities(self, advisory: _AdvisoryMetadata) -> None:
         """Write vulnerability details for an advisory."""
-        self.mdfile.write("#### Vulnerabilities\n\n")
-        heading = self.generate_table_heading(["Vulnerability", "Description", "Severity"])
-        self.mdfile.write("\n".join(heading) + "\n")
-        for vulnerability in advisory.vulnerabilities:
+        # NOTE: Nested tables are not supported consistently by every Markdown renderer. Prefix every table line and pad it with quoted blank lines to maximize
+        # compatibility across renderers that support Markdown tables.
+        heading = self.generate_table_heading(["Vulnerability", "Severity", "Description"])
+        self.mdfile.write("\n".join(f"> {line}" for line in heading) + "\n")
+        vulnerabilities = sorted(
+            advisory.vulnerabilities,
+            key=lambda vulnerability: (-_ADVISORY_VULNERABILITY_SEVERITY_RANK[vulnerability.severity], vulnerability.id.casefold()),
+        )
+        for vulnerability in vulnerabilities:
             vulnerability_id = self.safe_markdown(vulnerability.id)
             description = self.safe_markdown(vulnerability.description)
-            self.mdfile.write(f"| {vulnerability_id} | {description} | {vulnerability.severity.value.title()} |\n")
-        self.mdfile.write("\n")
+            self.mdfile.write(f"> | {vulnerability_id} | {self.format_severity(vulnerability.severity)} | {description} |\n")
+        self.mdfile.write(">\n\n")
 
     def _write_findings(self, group: AdvisoryResultGroup) -> None:
         """Write per-device findings for an advisory."""
         # TODO: When revisiting Markdown reports, fall back to atomic descriptions and messages if the parent result has no messages.
-        # TODO: Render parent and atomic remediation lists once the Markdown remediation presentation is defined.
         self.mdfile.write("#### 🔎 Device Findings\n\n")
         if self.config.expand_results:
             self._write_expanded_findings(group)
             return
 
-        heading = self.generate_table_heading(["Device", "Test", "Result", "Messages"])
+        heading = self.generate_table_heading(["Device", "Result", "Findings", "Remediations"])
         self.mdfile.write("\n".join(heading) + "\n")
         for result in group.results:
-            messages = self.safe_markdown("<br>".join(result.messages)) or "-"
-            self.mdfile.write(f"| {self.safe_markdown(result.name)} | {self.safe_markdown(result.test)} | {self.format_advisory_result(result)} | {messages} |\n")
+            findings = self.safe_markdown("<br>".join(result.messages)) or "-"
+            remediation = self.format_remediations(result)
+            self.mdfile.write(f"| {self.safe_markdown(result.name)} | {self.format_advisory_result(result)} | {findings} | {remediation} |\n")
 
     @staticmethod
     def _atomic_summary(result: TestResult) -> str:
@@ -175,29 +203,39 @@ class SecurityAdvisoryDetails(SecurityAdvisoryMDReportBase):
 
     def _write_expanded_findings(self, group: AdvisoryResultGroup) -> None:
         """Write parent advisory results followed by their actual detailed issue results."""
-        heading = self.generate_table_heading(["Device", "Test", "Description", "Vulnerability ID(s)", "Result", "Messages"])
+        heading = self.generate_table_heading(["Device", "Description", "Vulnerability ID(s)", "Result", "Findings", "Remediations"])
         self.mdfile.write("\n".join(heading) + "\n")
+        vulnerability_by_id = {vulnerability.id: vulnerability for vulnerability in group.advisory.vulnerabilities}
         for result in group.results:
             has_details = bool(result.atomic_results)
             if has_details:
-                messages = f"**Detailed findings:** {self._atomic_summary(result)}"
+                findings = f"**Detailed findings:** {self._atomic_summary(result)}"
                 if result.messages:
-                    messages += f"<br>**Overall evidence:** {self.safe_markdown('<br>'.join(result.messages))}"
+                    findings += f"<br>**Overall evidence:** {self.safe_markdown('<br>'.join(result.messages))}"
             else:
-                messages = self.safe_markdown("<br>".join(result.messages)) or "-"
+                findings = self.safe_markdown("<br>".join(result.messages)) or "-"
             description = self.safe_markdown(result.description) or "-"
-            self.mdfile.write(
-                f"| {self.safe_markdown(result.name)} | {self.safe_markdown(result.test)} | {description} | - "
-                f"| {self.format_advisory_result(result)} | {messages} |\n"
-            )
+            remediation = self.format_remediations(result)
+            self.mdfile.write(f"| {self.safe_markdown(result.name)} | {description} | - | {self.format_advisory_result(result)} | {findings} | {remediation} |\n")
             for index, atomic in enumerate(result.atomic_results):
                 tree = "└──" if index == len(result.atomic_results) - 1 else "├──"
-                atomic_description = self.safe_markdown(atomic.description) or "-"
-                description = f"&nbsp;&nbsp;{tree}&nbsp;{atomic_description}"
                 vulnerability_ids = _get_atomic_vulnerability_ids(atomic)
-                vulnerabilities = self.safe_markdown(", ".join(vulnerability_ids)) if vulnerability_ids else "-"
-                atomic_messages = self.safe_markdown("<br>".join(atomic.messages)) or "-"
-                self.mdfile.write(f"| | | {description} | {vulnerabilities} | {self.format_advisory_result(atomic)} | {atomic_messages} |\n")
+                if vulnerability_ids:
+                    atomic_description = "<br>".join(self.safe_markdown(vulnerability_by_id[vulnerability_id].description) for vulnerability_id in vulnerability_ids)
+                else:
+                    atomic_description = self.safe_markdown(atomic.description) or "-"
+                description = f"&nbsp;&nbsp;{tree}&nbsp;{atomic_description}"
+                vulnerabilities = (
+                    "<br>".join(
+                        f"{SEVERITY_ICONS[vulnerability_by_id[vulnerability_id].severity]}&nbsp;{self.safe_markdown(vulnerability_id)}"
+                        for vulnerability_id in vulnerability_ids
+                    )
+                    if vulnerability_ids
+                    else "-"
+                )
+                atomic_findings = self.safe_markdown("<br>".join(atomic.messages)) or "-"
+                remediation = self.format_remediations(atomic)
+                self.mdfile.write(f"| | {description} | {vulnerabilities} | {self.format_advisory_result(atomic)} | {atomic_findings} | {remediation} |\n")
 
     def generate_section(self) -> None:
         """Generate detailed advisory metadata and findings."""
@@ -206,10 +244,11 @@ class SecurityAdvisoryDetails(SecurityAdvisoryMDReportBase):
             advisory = group.advisory
             anchor = f"sa-{advisory.sa_number.lower()}"
             title = self.safe_markdown(advisory.title)
-            self.mdfile.write(f'### [SA{advisory.sa_number}: {title}]({advisory.url}) <a id="{anchor}"></a>\n\n')
+            self.mdfile.write(f'### SA{advisory.sa_number}: {title} <a id="{anchor}"></a>\n\n')
             advisory_severity = group.severity
-            severity = f"{SEVERITY_ICONS[advisory_severity]} **Severity:** {advisory_severity.value.title()}"
-            self.mdfile.write(f"{severity}\n\n{self.safe_markdown(advisory.description)}\n\n")
+            severity = f"**Severity:** {SEVERITY_ICONS[advisory_severity]} {advisory_severity.value.title()}"
+            description = self.safe_markdown(advisory.description)
+            self.mdfile.write(f"> {severity}\\\n> **URL:** <{advisory.url}>\n>\n> {description}\n>\n")
             self._write_vulnerabilities(advisory)
             self._write_findings(group)
             if index < len(self.groups) - 1:
@@ -217,13 +256,10 @@ class SecurityAdvisoryDetails(SecurityAdvisoryMDReportBase):
         self.mdfile.write("\n")
 
 
-class SecurityAdvisoryRunOverview(SecurityAdvisoryMDReportBase):
+class RunOverview(SecurityAdvisoryMDReportBase):
     """Generate the Run Overview section for a security advisory report."""
 
     ICON = "📋"
-
-    _TABLE_COLUMNS: ClassVar[list[str]] = ["⚙️ Run Metric", "📝 Details"]
-    TABLE_HEADING: ClassVar[list[str]] = MDReportBase.generate_table_heading(columns=_TABLE_COLUMNS)
 
     def _format_row_value(self, value: object) -> str:
         """Format one run overview value for Markdown table rendering."""
@@ -241,14 +277,25 @@ class SecurityAdvisoryRunOverview(SecurityAdvisoryMDReportBase):
             return "<br>".join(items)
         return self.safe_markdown(self.format_value(value))
 
-    def generate_rows(self) -> Generator[str, None, None]:
-        """Generate the rows for the security advisory run overview table."""
-        run_overview = SecurityAdvisoryRunOverviewData.from_context(self.run_context)
-        for label, value in run_overview.iter_rows():
-            row_value = self._format_row_value(value)
-            yield f"| **{label}** | {row_value} |\n"
-
     def generate_section(self) -> None:
-        """Generate the security advisory run overview section."""
+        """Generate the Run Overview section."""
         self.write_heading(heading_level=2)
-        self.write_table(table_heading=self.TABLE_HEADING, last_table=True)
+        run_overview = SecurityAdvisoryRunOverviewData.from_context(self.run_context)
+        start_time = self._format_row_value(run_overview.test_execution_start_time)
+        end_time = self._format_row_value(run_overview.test_execution_end_time)
+        duration = self._format_row_value(run_overview.total_duration)
+        overview_metrics: list[tuple[str, object]] = [
+            ("ANTA Version", run_overview.anta_version),
+            ("Duration", f"{duration} ({start_time} → {end_time})"),
+            ("Security Advisories Tested", run_overview.security_advisories_assessed),
+            ("Total Devices In Inventory", run_overview.total_devices_in_inventory),
+            ("Devices Assessed", run_overview.devices_assessed),
+            ("Devices Unreachable At Setup", run_overview.devices_unreachable_at_setup),
+            ("Devices Filtered At Setup", run_overview.devices_filtered_at_setup),
+            ("Filters Applied", run_overview.filters_applied),
+        ]
+        if run_overview.warnings_at_setup:
+            overview_metrics.append(("Warnings At Setup", run_overview.warnings_at_setup))
+        self.mdfile.write("| | |\n| :- | :- |\n")
+        for label, value in overview_metrics:
+            self.mdfile.write(f"| **{label}** | {self._format_row_value(value)} |\n")

--- a/anta/_advisory/reporter/reporting.py
+++ b/anta/_advisory/reporter/reporting.py
@@ -220,19 +220,19 @@ def generate_security_advisory_md_report(
     validate_advisory_results(run_context.manager.results)
 
     from anta._advisory.reporter.md_reporter import (  # noqa: PLC0415
-        AdvisoryExposureSummary,
+        AdvisoryAssessmentSummary,
         ANTASecurityAdvisoryReport,
+        RunOverview,
         SecurityAdvisoryDetails,
-        SecurityAdvisoryRunOverview,
     )
 
     try:
         with md_filename.open("w", encoding="utf-8") as mdfile:
             ANTASecurityAdvisoryReport(mdfile, report, config, run_context).generate_section()
             if report.groups:
-                AdvisoryExposureSummary(mdfile, report, config, run_context).generate_section()
+                AdvisoryAssessmentSummary(mdfile, report, config, run_context).generate_section()
                 SecurityAdvisoryDetails(mdfile, report, config, run_context).generate_section()
-            SecurityAdvisoryRunOverview(mdfile, report, config, run_context).generate_section()
+            RunOverview(mdfile, report, config, run_context).generate_section()
     except OSError as exc:
         message = f"OSError caught while writing the Markdown file '{md_filename.resolve()}'."
         anta_log_exception(exc, message, logger)

--- a/docs/security-advisory-reports.md
+++ b/docs/security-advisory-reports.md
@@ -29,15 +29,11 @@ Severity can be `unknown`, `none`, `low`, `medium`, `high`, or `critical`. Advis
 
 ## Markdown report
 
-The Markdown report supports flattened and expanded device findings. Flattened output is the default and renders one row per advisory result with the authoritative parent advisory result and its issue-attributed messages.
+The Markdown report supports flattened and expanded device findings. Flattened output is the default and renders one row per advisory result with the authoritative parent advisory result and its issue-attributed messages. Each advisory detail presents its severity, published URL, and description in a standard Markdown blockquote.
 
-The exposure summary reports `mitigated` devices separately from `not affected` devices so that successful mitigations remain visible at a glance.
+The assessment summary reports `mitigated` devices separately from `not affected` devices so that successful mitigations remain visible at a glance. Advisories and their vulnerability metadata are ordered from critical to unknown severity.
 
-Every Markdown report ends with a **Security Advisory Run Overview** containing:
-
-- The ANTA version, execution start and end times, and total duration.
-- The initial inventory size, devices excluded by filters, devices unreachable during setup, applied filters, and setup warnings when present.
-- The number of security advisories and devices assessed.
+Every Markdown report ends with a **Run Overview** containing one vertical table. It lists the ANTA version, execution duration and timestamps, number of security advisories tested, initial inventory size, assessed devices, devices excluded by filters, devices unreachable during setup, applied filters, and setup warnings when present.
 
 The overview describes the execution context. The `--expand` option affects only the presentation of device findings.
 Likewise, `--hide` filters displayed findings without changing the assessment counts; when it hides every finding, the report still contains the run overview.
@@ -46,7 +42,8 @@ Expanded output follows the regular ANTA Markdown parent/child layout:
 
 - The parent row contains the device, test description, authoritative advisory result, and a summary of its detailed findings. All parent messages, when present, follow the summary as labelled overall evidence. Messages propagated from detailed findings may therefore also appear in the child rows.
 - Each indented `├──` or `└──` row represents one detailed issue assessment emitted by the test.
-- `Description` identifies the issue, `Vulnerability ID(s)` lists its explicit vulnerability associations, and `Result` and `Messages` contain its final semantic conclusion and decisive device evidence.
+- `Description` uses the published vulnerability descriptions for associated findings and the atomic description for unassociated findings. `Vulnerability ID(s)` lists explicit vulnerability associations prefixed by their severity icons, while `Result` and `Findings` contain the final semantic conclusion and decisive device evidence.
+- `Remediations` contains issue-specific remediation on atomic rows. Parent rows in both flattened and expanded reports display the stable, deduplicated aggregation of test-level and atomic remediation entries as bullets when atomic remediation contributes to the aggregation.
 - One issue may cover multiple vulnerabilities or have no vulnerability association. Multiple independent issues associated with the same vulnerability remain separate rows.
 - When the test emits no detailed issue assessments, expanded output contains only the parent row.
 

--- a/tests/data/test_security_advisory_md_report.md
+++ b/tests/data/test_security_advisory_md_report.md
@@ -1,13 +1,15 @@
-# 🛡️ ANTA Security Advisory Report <a id="anta-security-advisory-report"></a>
+<h1 id="anta-security-advisory-report" align="center">🛡️ ANTA Security Advisory Report 🛡️</h1>
 
 **Table of Contents:**
 
-- [ANTA Security Advisory Report](#anta-security-advisory-report)
-  - [Advisory Exposure Summary](#advisory-exposure-summary)
-  - [Security Advisory Details](#security-advisory-details)
-  - [Security Advisory Run Overview](#security-advisory-run-overview)
+- [Advisory Assessment Summary](#advisory-assessment-summary)
+- [Security Advisory Details](#security-advisory-details)
+  - [SA0120: Example Management API Authentication Bypass](#sa-0120)
+  - [SA0121: Example EOS Process Denial of Service](#sa-0121)
+  - [SA0117: Security Advisory 0117](#sa-0117)
+- [Run Overview](#run-overview)
 
-## 📊 Advisory Exposure Summary <a id="advisory-exposure-summary"></a>
+## 📊 Advisory Assessment Summary <a id="advisory-assessment-summary"></a>
 
 | Security Advisory | Severity | Devices | ❌&nbsp;Affected | ❓&nbsp;Inconclusive | ✅&nbsp;Mitigated | ✅&nbsp;Not Affected | ❗&nbsp;Error | ⏭️&nbsp;Skipped |
 | :- | :- | :- | :- | :- | :- | :- | :- | :- |
@@ -17,93 +19,93 @@
 
 ## 🔐 Security Advisory Details <a id="security-advisory-details"></a>
 
-### [SA0120: Example Management API Authentication Bypass](https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120) <a id="sa-0120"></a>
+### SA0120: Example Management API Authentication Bypass <a id="sa-0120"></a>
 
-🔴 **Severity:** Critical
-
-An example vulnerability in an enabled management API could allow an unauthenticated remote actor to bypass authentication under specific configurations. This fictional advisory is used only to exercise realistic report rendering.
-
-#### Vulnerabilities
-
-| Vulnerability | Description | Severity |
-| :- | :- | :- |
-| CVE-2026-12001 | CVE-2026-12001 Authentication bypass in an enabled management API. | Critical |
-| GHSA-2345-6789-cfgh | GHSA-2345-6789-cfgh Authorization flaw affecting management API access controls. | High |
-
-#### 🔎 Device Findings
-
-| Device | Test | Result | Messages |
-| :- | :- | :- | :- |
-| DC1-LEAF1 | VerifySA120 | ❌&nbsp;Affected | Affected API is enabled and reachable from an untrusted network.<br>CVE-2026-12001 vulnerable management API - The device is affected because the vulnerable management API is enabled.<br>External network reachability - The assessment is inconclusive because external reachability could not be verified.<br>GHSA-2345-6789-cfgh authorization controls - The device is not affected by this issue because authorization controls are enabled. |
-| DC1-LEAF3 | VerifySA120 | ❌&nbsp;Affected | Affected API is enabled without a control-plane ACL. |
-| DC1-SPINE2 | VerifySA120 | ❌&nbsp;Affected | Affected release detected; management API exposure requires remediation. |
-| DC2-LEAF2 | VerifySA120 | ❌&nbsp;Affected | Affected API is exposed through the default VRF. |
-| DC1-LEAF2 | VerifySA120 | ✅&nbsp;Not Affected | The management API is restricted to the trusted management VRF. |
-| DC1-SPINE1 | VerifySA120 | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. |
-| DC2-LEAF1 | VerifySA120 | ❗&nbsp;Error | Management API configuration could not be parsed. |
-| DC1-LEAF4 | VerifySA120 | ⏭️&nbsp;Skipped | Device was unreachable during test execution. |
-
-### [SA0121: Example EOS Process Denial of Service](https://www.arista.com/en/support/advisories-notices/security-advisory/example-0121) <a id="sa-0121"></a>
-
-🟠 **Severity:** High
-
-An example malformed packet could restart an EOS process when received on an exposed service. This fictional advisory demonstrates a larger fleet with mixed findings and no published mitigation.
-
-#### Vulnerabilities
-
-| Vulnerability | Description | Severity |
-| :- | :- | :- |
-| GTI-EXAMPLE-12101 | GTI-EXAMPLE-12101 Malformed packet may restart an exposed EOS process. | High |
+> **Severity:** 🔴 Critical\
+> **URL:** <https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120>
+>
+> An example vulnerability in an enabled management API could allow an unauthenticated remote actor to bypass authentication under specific configurations. This fictional advisory is used only to exercise realistic report rendering.
+>
+> | Vulnerability | Severity | Description |
+> | :- | :- | :- |
+> | CVE-2026-12001 | 🔴&nbsp;Critical | CVE-2026-12001 Authentication bypass in an enabled management API. |
+> | GHSA-2345-6789-cfgh | 🟠&nbsp;High | GHSA-2345-6789-cfgh Authorization flaw affecting management API access controls. |
+>
 
 #### 🔎 Device Findings
 
-| Device | Test | Result | Messages |
+| Device | Result | Findings | Remediations |
 | :- | :- | :- | :- |
-| DC1-SPINE1 | VerifySA121 | ❌&nbsp;Affected | Affected EOS release and exposed service detected. |
-| DC1-LEAF1 | VerifySA121 | ✅&nbsp;Not Affected | The affected service is disabled. |
-| DC1-LEAF2 | VerifySA121 | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. |
-| DC1-LEAF3 | VerifySA121 | ✅&nbsp;Not Affected | The service is limited to a trusted interface. |
-| DC1-SPINE2 | VerifySA121 | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. |
-| DC2-LEAF2 | VerifySA121 | ✅&nbsp;Not Affected | The affected service is disabled. |
-| DC2-LEAF1 | VerifySA121 | ❗&nbsp;Error | Service state could not be determined. |
-| DC1-LEAF4 | VerifySA121 | ⏭️&nbsp;Skipped | Device was unreachable during test execution. |
+| DC1-LEAF1 | ❌&nbsp;Affected | Affected API is enabled and reachable from an untrusted network.<br>CVE-2026-12001 vulnerable management API - The device is affected because the vulnerable management API is enabled.<br>External network reachability - The assessment is inconclusive because external reachability could not be verified.<br>GHSA-2345-6789-cfgh authorization controls - The device is not affected by this issue because authorization controls are enabled. | - |
+| DC1-LEAF3 | ❌&nbsp;Affected | Affected API is enabled without a control-plane ACL. | - |
+| DC1-SPINE2 | ❌&nbsp;Affected | Affected release detected; management API exposure requires remediation. | - |
+| DC2-LEAF2 | ❌&nbsp;Affected | Affected API is exposed through the default VRF. | - |
+| DC1-LEAF2 | ✅&nbsp;Not Affected | The management API is restricted to the trusted management VRF. | - |
+| DC1-SPINE1 | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. | - |
+| DC2-LEAF1 | ❗&nbsp;Error | Management API configuration could not be parsed. | - |
+| DC1-LEAF4 | ⏭️&nbsp;Skipped | Device was unreachable during test execution. | - |
 
-### [SA0117: Security Advisory 0117](https://www.arista.com/en/support/advisories-notices/security-advisory/21394-security-advisory-0117) <a id="sa-0117"></a>
+### SA0121: Example EOS Process Denial of Service <a id="sa-0121"></a>
 
-🟡 **Severity:** Medium
-
-On affected platforms running Arista EOS with a gNMI transport enabled, running the gNOI File TransferToRemote RPC with credentials for a remote server may cause these remote-server credentials to be logged or accounted on the local EOS device or possibly on other remote accounting servers (i.e. TACACS, RADIUS, etc).
-
-#### Vulnerabilities
-
-| Vulnerability | Description | Severity |
-| :- | :- | :- |
-| CVE-2025-0936 | CVE-2025-0936: gNOI TransferToRemote credential exposure through OpenConfig accounting or tracing. | Medium |
+> **Severity:** 🟠 High\
+> **URL:** <https://www.arista.com/en/support/advisories-notices/security-advisory/example-0121>
+>
+> An example malformed packet could restart an EOS process when received on an exposed service. This fictional advisory demonstrates a larger fleet with mixed findings and no published mitigation.
+>
+> | Vulnerability | Severity | Description |
+> | :- | :- | :- |
+> | GTI-EXAMPLE-12101 | 🟠&nbsp;High | GTI-EXAMPLE-12101 Malformed packet may restart an exposed EOS process. |
+> | CVE-2026-12102 | 🔵&nbsp;Low | CVE-2026-12102 Low-impact information disclosure in process diagnostics. |
+> | CVE-2026-12103 | ⚪&nbsp;Unknown | CVE-2026-12103 Process behavior with severity pending assessment. |
+>
 
 #### 🔎 Device Findings
 
-| Device | Test | Result | Messages |
+| Device | Result | Findings | Remediations |
 | :- | :- | :- | :- |
-| DC1-LEAF1 | VerifySA117 | ❓&nbsp;Inconclusive | The assessment is inconclusive and the device may be affected because EOS version '4.32.4M' has an enabled gNMI transport with accounting enabled, but the gNOI File and effective gNSI Authz controls cannot be determined. |
-| DC1-SPINE2 | VerifySA117 | ❓&nbsp;Inconclusive | The assessment is inconclusive and the device may be affected because EOS version '4.31.6M' has an enabled gNMI transport and OpenConfig tracing includes a selector identified by the advisory, but the gNOI File and effective gNSI Authz controls cannot be determined. |
-| DC1-LEAF2 | VerifySA117 | ✅&nbsp;Not Affected | EOS 4.32.5M is not affected by this advisory. |
-| DC1-SPINE1 | VerifySA117 | ✅&nbsp;Not Affected | EOS 4.33.2F is not affected by this advisory. |
-| DC2-LEAF1 | VerifySA117 | ✅&nbsp;Not Affected | The device configuration is not affected by this advisory. |
-| DC2-LEAF2 | VerifySA117 | ✅&nbsp;Not Affected | EOS 4.30.10M is not affected by this advisory. |
-| DC1-LEAF3 | VerifySA117 | ❗&nbsp;Error | The EOS version could not be determined from the available command output. |
-| DC1-LEAF4 | VerifySA117 | ⏭️&nbsp;Skipped | Device was unreachable during test execution. |
+| DC1-SPINE1 | ❌&nbsp;Affected | Affected EOS release and exposed service detected.<br>GTI-EXAMPLE-12101 Malformed packet may restart an exposed EOS process. - The device is affected because an affected EOS release and exposed service were detected.<br>CVE-2026-12102 Low-impact information disclosure in process diagnostics. - The device is not affected by the low-severity issue because process diagnostics are restricted.<br>CVE-2026-12103 Process behavior with severity pending assessment. - The assessment is inconclusive because the severity and affected conditions are still being investigated. | •&nbsp;Disable or restrict the exposed service and upgrade to a fixed EOS release.<br>•&nbsp;Monitor the advisory for updated severity and remediation guidance.<br>•&nbsp;Keep process diagnostics restricted to trusted operators. |
+| DC1-LEAF1 | ✅&nbsp;Not Affected | The affected service is disabled. | - |
+| DC1-LEAF2 | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. | - |
+| DC1-LEAF3 | ✅&nbsp;Not Affected | The service is limited to a trusted interface. | - |
+| DC1-SPINE2 | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. | - |
+| DC2-LEAF2 | ✅&nbsp;Not Affected | The affected service is disabled. | - |
+| DC2-LEAF1 | ❗&nbsp;Error | Service state could not be determined. | - |
+| DC1-LEAF4 | ⏭️&nbsp;Skipped | Device was unreachable during test execution. | - |
 
-## 📋 Security Advisory Run Overview <a id="security-advisory-run-overview"></a>
+### SA0117: Security Advisory 0117 <a id="sa-0117"></a>
 
-| ⚙️ Run Metric | 📝 Details |
+> **Severity:** 🟡 Medium\
+> **URL:** <https://www.arista.com/en/support/advisories-notices/security-advisory/21394-security-advisory-0117>
+>
+> On affected platforms running Arista EOS with a gNMI transport enabled, running the gNOI File TransferToRemote RPC with credentials for a remote server may cause these remote-server credentials to be logged or accounted on the local EOS device or possibly on other remote accounting servers (i.e. TACACS, RADIUS, etc).
+>
+> | Vulnerability | Severity | Description |
+> | :- | :- | :- |
+> | CVE-2025-0936 | 🟡&nbsp;Medium | CVE-2025-0936: gNOI TransferToRemote credential exposure through OpenConfig accounting or tracing. |
+>
+
+#### 🔎 Device Findings
+
+| Device | Result | Findings | Remediations |
+| :- | :- | :- | :- |
+| DC1-LEAF1 | ❓&nbsp;Inconclusive | The assessment is inconclusive and the device may be affected because EOS version '4.32.4M' has an enabled gNMI transport with accounting enabled, but the gNOI File and effective gNSI Authz controls cannot be determined.<br>CVE-2025-0936: gNOI TransferToRemote credential exposure through OpenConfig accounting or tracing. - The assessment is inconclusive because required gNOI File and gNSI Authz evidence is unavailable. | •&nbsp;Upgrade to a fixed EOS release when one is published, then rerun the test. |
+| DC1-SPINE2 | ❓&nbsp;Inconclusive | The assessment is inconclusive and the device may be affected because EOS version '4.31.6M' has an enabled gNMI transport and OpenConfig tracing includes a selector identified by the advisory, but the gNOI File and effective gNSI Authz controls cannot be determined. | Upgrade to a fixed EOS release when one is published, then rerun the test. |
+| DC1-LEAF2 | ✅&nbsp;Not Affected | EOS 4.32.5M is not affected by this advisory. | - |
+| DC1-SPINE1 | ✅&nbsp;Not Affected | EOS 4.33.2F is not affected by this advisory. | - |
+| DC2-LEAF1 | ✅&nbsp;Not Affected | The device configuration is not affected by this advisory. | - |
+| DC2-LEAF2 | ✅&nbsp;Not Affected | EOS 4.30.10M is not affected by this advisory. | - |
+| DC1-LEAF3 | ❗&nbsp;Error | The EOS version could not be determined from the available command output. | Collect valid EOS version evidence and rerun the test. |
+| DC1-LEAF4 | ⏭️&nbsp;Skipped | Device was unreachable during test execution. | Restore device reachability and rerun the test. |
+
+## 📋 Run Overview <a id="run-overview"></a>
+
+| | |
 | :- | :- |
 | **ANTA Version** | v1.4.0 |
-| **Test Execution Start Time** | 2025-05-20 08:30:00.000+00:00 |
-| **Test Execution End Time** | 2025-05-20 08:35:30.500+00:00 |
-| **Total Duration** | 5 minutes, 30 seconds |
+| **Duration** | 5 minutes, 30 seconds (2025-05-20 08:30:00.000+00:00 → 2025-05-20 08:35:30.500+00:00) |
+| **Security Advisories Tested** | 3 |
 | **Total Devices In Inventory** | 8 |
+| **Devices Assessed** | 8 |
 | **Devices Unreachable At Setup** | s1-spine2 |
 | **Devices Filtered At Setup** | s1-leaf1<br>s1-leaf2 |
 | **Filters Applied** | Tags: spine |
-| **Security Advisories Assessed** | 3 |
-| **Devices Assessed** | 8 |

--- a/tests/data/test_security_advisory_md_report_expanded.md
+++ b/tests/data/test_security_advisory_md_report_expanded.md
@@ -1,13 +1,15 @@
-# 🛡️ ANTA Security Advisory Report <a id="anta-security-advisory-report"></a>
+<h1 id="anta-security-advisory-report" align="center">🛡️ ANTA Security Advisory Report 🛡️</h1>
 
 **Table of Contents:**
 
-- [ANTA Security Advisory Report](#anta-security-advisory-report)
-  - [Advisory Exposure Summary](#advisory-exposure-summary)
-  - [Security Advisory Details](#security-advisory-details)
-  - [Security Advisory Run Overview](#security-advisory-run-overview)
+- [Advisory Assessment Summary](#advisory-assessment-summary)
+- [Security Advisory Details](#security-advisory-details)
+  - [SA0120: Example Management API Authentication Bypass](#sa-0120)
+  - [SA0121: Example EOS Process Denial of Service](#sa-0121)
+  - [SA0117: Security Advisory 0117](#sa-0117)
+- [Run Overview](#run-overview)
 
-## 📊 Advisory Exposure Summary <a id="advisory-exposure-summary"></a>
+## 📊 Advisory Assessment Summary <a id="advisory-assessment-summary"></a>
 
 | Security Advisory | Severity | Devices | ❌&nbsp;Affected | ❓&nbsp;Inconclusive | ✅&nbsp;Mitigated | ✅&nbsp;Not Affected | ❗&nbsp;Error | ⏭️&nbsp;Skipped |
 | :- | :- | :- | :- | :- | :- | :- | :- | :- |
@@ -17,96 +19,100 @@
 
 ## 🔐 Security Advisory Details <a id="security-advisory-details"></a>
 
-### [SA0120: Example Management API Authentication Bypass](https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120) <a id="sa-0120"></a>
+### SA0120: Example Management API Authentication Bypass <a id="sa-0120"></a>
 
-🔴 **Severity:** Critical
-
-An example vulnerability in an enabled management API could allow an unauthenticated remote actor to bypass authentication under specific configurations. This fictional advisory is used only to exercise realistic report rendering.
-
-#### Vulnerabilities
-
-| Vulnerability | Description | Severity |
-| :- | :- | :- |
-| CVE-2026-12001 | CVE-2026-12001 Authentication bypass in an enabled management API. | Critical |
-| GHSA-2345-6789-cfgh | GHSA-2345-6789-cfgh Authorization flaw affecting management API access controls. | High |
-
-#### 🔎 Device Findings
-
-| Device | Test | Description | Vulnerability ID(s) | Result | Messages |
-| :- | :- | :- | :- | :- | :- |
-| DC1-LEAF1 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | **Detailed findings:** 1/3&nbsp;checks&nbsp;affected; 1/3&nbsp;checks&nbsp;inconclusive<br>**Overall evidence:** Affected API is enabled and reachable from an untrusted network.<br>CVE-2026-12001 vulnerable management API - The device is affected because the vulnerable management API is enabled.<br>External network reachability - The assessment is inconclusive because external reachability could not be verified.<br>GHSA-2345-6789-cfgh authorization controls - The device is not affected by this issue because authorization controls are enabled. |
-| | | &nbsp;&nbsp;├──&nbsp;CVE-2026-12001 vulnerable management API | CVE-2026-12001 | ❌&nbsp;Affected | The device is affected because the vulnerable management API is enabled. |
-| | | &nbsp;&nbsp;├──&nbsp;External network reachability | - | ❓&nbsp;Inconclusive | The assessment is inconclusive because external reachability could not be verified. |
-| | | &nbsp;&nbsp;└──&nbsp;GHSA-2345-6789-cfgh authorization controls | GHSA-2345-6789-cfgh | ✅&nbsp;Not Affected | The device is not affected by this issue because authorization controls are enabled. |
-| DC1-LEAF3 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | Affected API is enabled without a control-plane ACL. |
-| DC1-SPINE2 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | Affected release detected; management API exposure requires remediation. |
-| DC2-LEAF2 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | Affected API is exposed through the default VRF. |
-| DC1-LEAF2 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ✅&nbsp;Not Affected | The management API is restricted to the trusted management VRF. |
-| DC1-SPINE1 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. |
-| DC2-LEAF1 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❗&nbsp;Error | Management API configuration could not be parsed. |
-| DC1-LEAF4 | VerifySA120 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ⏭️&nbsp;Skipped | Device was unreachable during test execution. |
-
-### [SA0121: Example EOS Process Denial of Service](https://www.arista.com/en/support/advisories-notices/security-advisory/example-0121) <a id="sa-0121"></a>
-
-🟠 **Severity:** High
-
-An example malformed packet could restart an EOS process when received on an exposed service. This fictional advisory demonstrates a larger fleet with mixed findings and no published mitigation.
-
-#### Vulnerabilities
-
-| Vulnerability | Description | Severity |
-| :- | :- | :- |
-| GTI-EXAMPLE-12101 | GTI-EXAMPLE-12101 Malformed packet may restart an exposed EOS process. | High |
+> **Severity:** 🔴 Critical\
+> **URL:** <https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120>
+>
+> An example vulnerability in an enabled management API could allow an unauthenticated remote actor to bypass authentication under specific configurations. This fictional advisory is used only to exercise realistic report rendering.
+>
+> | Vulnerability | Severity | Description |
+> | :- | :- | :- |
+> | CVE-2026-12001 | 🔴&nbsp;Critical | CVE-2026-12001 Authentication bypass in an enabled management API. |
+> | GHSA-2345-6789-cfgh | 🟠&nbsp;High | GHSA-2345-6789-cfgh Authorization flaw affecting management API access controls. |
+>
 
 #### 🔎 Device Findings
 
-| Device | Test | Description | Vulnerability ID(s) | Result | Messages |
+| Device | Description | Vulnerability ID(s) | Result | Findings | Remediations |
 | :- | :- | :- | :- | :- | :- |
-| DC1-SPINE1 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ❌&nbsp;Affected | Affected EOS release and exposed service detected. |
-| DC1-LEAF1 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | The affected service is disabled. |
-| DC1-LEAF2 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. |
-| DC1-LEAF3 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | The service is limited to a trusted interface. |
-| DC1-SPINE2 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. |
-| DC2-LEAF2 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | The affected service is disabled. |
-| DC2-LEAF1 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ❗&nbsp;Error | Service state could not be determined. |
-| DC1-LEAF4 | VerifySA121 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ⏭️&nbsp;Skipped | Device was unreachable during test execution. |
+| DC1-LEAF1 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | **Detailed findings:** 1/3&nbsp;checks&nbsp;affected; 1/3&nbsp;checks&nbsp;inconclusive<br>**Overall evidence:** Affected API is enabled and reachable from an untrusted network.<br>CVE-2026-12001 vulnerable management API - The device is affected because the vulnerable management API is enabled.<br>External network reachability - The assessment is inconclusive because external reachability could not be verified.<br>GHSA-2345-6789-cfgh authorization controls - The device is not affected by this issue because authorization controls are enabled. | - |
+| | &nbsp;&nbsp;├──&nbsp;CVE-2026-12001 Authentication bypass in an enabled management API. | 🔴&nbsp;CVE-2026-12001 | ❌&nbsp;Affected | The device is affected because the vulnerable management API is enabled. | - |
+| | &nbsp;&nbsp;├──&nbsp;External network reachability | - | ❓&nbsp;Inconclusive | The assessment is inconclusive because external reachability could not be verified. | - |
+| | &nbsp;&nbsp;└──&nbsp;GHSA-2345-6789-cfgh Authorization flaw affecting management API access controls. | 🟠&nbsp;GHSA-2345-6789-cfgh | ✅&nbsp;Not Affected | The device is not affected by this issue because authorization controls are enabled. | - |
+| DC1-LEAF3 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | Affected API is enabled without a control-plane ACL. | - |
+| DC1-SPINE2 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | Affected release detected; management API exposure requires remediation. | - |
+| DC2-LEAF2 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❌&nbsp;Affected | Affected API is exposed through the default VRF. | - |
+| DC1-LEAF2 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ✅&nbsp;Not Affected | The management API is restricted to the trusted management VRF. | - |
+| DC1-SPINE1 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. | - |
+| DC2-LEAF1 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ❗&nbsp;Error | Management API configuration could not be parsed. | - |
+| DC1-LEAF4 | Verify that the device is not exposed to Arista Security Advisory 0120. | - | ⏭️&nbsp;Skipped | Device was unreachable during test execution. | - |
 
-### [SA0117: Security Advisory 0117](https://www.arista.com/en/support/advisories-notices/security-advisory/21394-security-advisory-0117) <a id="sa-0117"></a>
+### SA0121: Example EOS Process Denial of Service <a id="sa-0121"></a>
 
-🟡 **Severity:** Medium
-
-On affected platforms running Arista EOS with a gNMI transport enabled, running the gNOI File TransferToRemote RPC with credentials for a remote server may cause these remote-server credentials to be logged or accounted on the local EOS device or possibly on other remote accounting servers (i.e. TACACS, RADIUS, etc).
-
-#### Vulnerabilities
-
-| Vulnerability | Description | Severity |
-| :- | :- | :- |
-| CVE-2025-0936 | CVE-2025-0936: gNOI TransferToRemote credential exposure through OpenConfig accounting or tracing. | Medium |
+> **Severity:** 🟠 High\
+> **URL:** <https://www.arista.com/en/support/advisories-notices/security-advisory/example-0121>
+>
+> An example malformed packet could restart an EOS process when received on an exposed service. This fictional advisory demonstrates a larger fleet with mixed findings and no published mitigation.
+>
+> | Vulnerability | Severity | Description |
+> | :- | :- | :- |
+> | GTI-EXAMPLE-12101 | 🟠&nbsp;High | GTI-EXAMPLE-12101 Malformed packet may restart an exposed EOS process. |
+> | CVE-2026-12102 | 🔵&nbsp;Low | CVE-2026-12102 Low-impact information disclosure in process diagnostics. |
+> | CVE-2026-12103 | ⚪&nbsp;Unknown | CVE-2026-12103 Process behavior with severity pending assessment. |
+>
 
 #### 🔎 Device Findings
 
-| Device | Test | Description | Vulnerability ID(s) | Result | Messages |
+| Device | Description | Vulnerability ID(s) | Result | Findings | Remediations |
 | :- | :- | :- | :- | :- | :- |
-| DC1-LEAF1 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ❓&nbsp;Inconclusive | The assessment is inconclusive and the device may be affected because EOS version '4.32.4M' has an enabled gNMI transport with accounting enabled, but the gNOI File and effective gNSI Authz controls cannot be determined. |
-| DC1-SPINE2 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ❓&nbsp;Inconclusive | The assessment is inconclusive and the device may be affected because EOS version '4.31.6M' has an enabled gNMI transport and OpenConfig tracing includes a selector identified by the advisory, but the gNOI File and effective gNSI Authz controls cannot be determined. |
-| DC1-LEAF2 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | EOS 4.32.5M is not affected by this advisory. |
-| DC1-SPINE1 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | EOS 4.33.2F is not affected by this advisory. |
-| DC2-LEAF1 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | The device configuration is not affected by this advisory. |
-| DC2-LEAF2 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | EOS 4.30.10M is not affected by this advisory. |
-| DC1-LEAF3 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ❗&nbsp;Error | The EOS version could not be determined from the available command output. |
-| DC1-LEAF4 | VerifySA117 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ⏭️&nbsp;Skipped | Device was unreachable during test execution. |
+| DC1-SPINE1 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ❌&nbsp;Affected | **Detailed findings:** 1/3&nbsp;checks&nbsp;affected; 1/3&nbsp;checks&nbsp;inconclusive<br>**Overall evidence:** Affected EOS release and exposed service detected.<br>GTI-EXAMPLE-12101 Malformed packet may restart an exposed EOS process. - The device is affected because an affected EOS release and exposed service were detected.<br>CVE-2026-12102 Low-impact information disclosure in process diagnostics. - The device is not affected by the low-severity issue because process diagnostics are restricted.<br>CVE-2026-12103 Process behavior with severity pending assessment. - The assessment is inconclusive because the severity and affected conditions are still being investigated. | •&nbsp;Disable or restrict the exposed service and upgrade to a fixed EOS release.<br>•&nbsp;Monitor the advisory for updated severity and remediation guidance.<br>•&nbsp;Keep process diagnostics restricted to trusted operators. |
+| | &nbsp;&nbsp;├──&nbsp;GTI-EXAMPLE-12101 Malformed packet may restart an exposed EOS process. | 🟠&nbsp;GTI-EXAMPLE-12101 | ❌&nbsp;Affected | The device is affected because an affected EOS release and exposed service were detected. | Disable or restrict the exposed service and upgrade to a fixed EOS release. |
+| | &nbsp;&nbsp;├──&nbsp;CVE-2026-12103 Process behavior with severity pending assessment. | ⚪&nbsp;CVE-2026-12103 | ❓&nbsp;Inconclusive | The assessment is inconclusive because the severity and affected conditions are still being investigated. | Monitor the advisory for updated severity and remediation guidance. |
+| | &nbsp;&nbsp;└──&nbsp;CVE-2026-12102 Low-impact information disclosure in process diagnostics. | 🔵&nbsp;CVE-2026-12102 | ✅&nbsp;Not Affected | The device is not affected by the low-severity issue because process diagnostics are restricted. | Keep process diagnostics restricted to trusted operators. |
+| DC1-LEAF1 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | The affected service is disabled. | - |
+| DC1-LEAF2 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. | - |
+| DC1-LEAF3 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | The service is limited to a trusted interface. | - |
+| DC1-SPINE2 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | Installed EOS release contains the security fix. | - |
+| DC2-LEAF2 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ✅&nbsp;Not Affected | The affected service is disabled. | - |
+| DC2-LEAF1 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ❗&nbsp;Error | Service state could not be determined. | - |
+| DC1-LEAF4 | Verify that the device is not exposed to Arista Security Advisory 0121. | - | ⏭️&nbsp;Skipped | Device was unreachable during test execution. | - |
 
-## 📋 Security Advisory Run Overview <a id="security-advisory-run-overview"></a>
+### SA0117: Security Advisory 0117 <a id="sa-0117"></a>
 
-| ⚙️ Run Metric | 📝 Details |
+> **Severity:** 🟡 Medium\
+> **URL:** <https://www.arista.com/en/support/advisories-notices/security-advisory/21394-security-advisory-0117>
+>
+> On affected platforms running Arista EOS with a gNMI transport enabled, running the gNOI File TransferToRemote RPC with credentials for a remote server may cause these remote-server credentials to be logged or accounted on the local EOS device or possibly on other remote accounting servers (i.e. TACACS, RADIUS, etc).
+>
+> | Vulnerability | Severity | Description |
+> | :- | :- | :- |
+> | CVE-2025-0936 | 🟡&nbsp;Medium | CVE-2025-0936: gNOI TransferToRemote credential exposure through OpenConfig accounting or tracing. |
+>
+
+#### 🔎 Device Findings
+
+| Device | Description | Vulnerability ID(s) | Result | Findings | Remediations |
+| :- | :- | :- | :- | :- | :- |
+| DC1-LEAF1 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ❓&nbsp;Inconclusive | **Detailed findings:** 1/1&nbsp;checks&nbsp;inconclusive<br>**Overall evidence:** The assessment is inconclusive and the device may be affected because EOS version '4.32.4M' has an enabled gNMI transport with accounting enabled, but the gNOI File and effective gNSI Authz controls cannot be determined.<br>CVE-2025-0936: gNOI TransferToRemote credential exposure through OpenConfig accounting or tracing. - The assessment is inconclusive because required gNOI File and gNSI Authz evidence is unavailable. | •&nbsp;Upgrade to a fixed EOS release when one is published, then rerun the test. |
+| | &nbsp;&nbsp;└──&nbsp;CVE-2025-0936: gNOI TransferToRemote credential exposure through OpenConfig accounting or tracing. | 🟡&nbsp;CVE-2025-0936 | ❓&nbsp;Inconclusive | The assessment is inconclusive because required gNOI File and gNSI Authz evidence is unavailable. | Upgrade to a fixed EOS release when one is published, then rerun the test. |
+| DC1-SPINE2 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ❓&nbsp;Inconclusive | The assessment is inconclusive and the device may be affected because EOS version '4.31.6M' has an enabled gNMI transport and OpenConfig tracing includes a selector identified by the advisory, but the gNOI File and effective gNSI Authz controls cannot be determined. | Upgrade to a fixed EOS release when one is published, then rerun the test. |
+| DC1-LEAF2 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | EOS 4.32.5M is not affected by this advisory. | - |
+| DC1-SPINE1 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | EOS 4.33.2F is not affected by this advisory. | - |
+| DC2-LEAF1 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | The device configuration is not affected by this advisory. | - |
+| DC2-LEAF2 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ✅&nbsp;Not Affected | EOS 4.30.10M is not affected by this advisory. | - |
+| DC1-LEAF3 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ❗&nbsp;Error | The EOS version could not be determined from the available command output. | Collect valid EOS version evidence and rerun the test. |
+| DC1-LEAF4 | Verify that the device is not exposed to Arista Security Advisory 0117. | - | ⏭️&nbsp;Skipped | Device was unreachable during test execution. | Restore device reachability and rerun the test. |
+
+## 📋 Run Overview <a id="run-overview"></a>
+
+| | |
 | :- | :- |
 | **ANTA Version** | v1.4.0 |
-| **Test Execution Start Time** | 2025-05-20 08:30:00.000+00:00 |
-| **Test Execution End Time** | 2025-05-20 08:35:30.500+00:00 |
-| **Total Duration** | 5 minutes, 30 seconds |
+| **Duration** | 5 minutes, 30 seconds (2025-05-20 08:30:00.000+00:00 → 2025-05-20 08:35:30.500+00:00) |
+| **Security Advisories Tested** | 3 |
 | **Total Devices In Inventory** | 8 |
+| **Devices Assessed** | 8 |
 | **Devices Unreachable At Setup** | s1-spine2 |
 | **Devices Filtered At Setup** | s1-leaf1<br>s1-leaf2 |
 | **Filters Applied** | Tags: spine |
-| **Security Advisories Assessed** | 3 |
-| **Devices Assessed** | 8 |

--- a/tests/units/_advisory/reporting_data.py
+++ b/tests/units/_advisory/reporting_data.py
@@ -62,7 +62,14 @@ EXAMPLE_HIGH_ADVISORY = _AdvisoryMetadata(
 )
 
 
-def build_security_advisory_result(name: str, status: AntaTestStatus, message: str, advisory: _AdvisoryMetadata) -> _AdvisoryTestResult:
+def build_security_advisory_result(
+    name: str,
+    status: AntaTestStatus,
+    message: str,
+    advisory: _AdvisoryMetadata,
+    *,
+    remediations: list[str] | None = None,
+) -> _AdvisoryTestResult:
     """Create a security advisory result for reporter tests."""
     return _AdvisoryTestResult(
         name=name,
@@ -72,6 +79,7 @@ def build_security_advisory_result(name: str, status: AntaTestStatus, message: s
         result=status,
         messages=[message],
         advisory=advisory,
+        remediations=remediations or [],
     )
 
 
@@ -165,4 +173,71 @@ def build_security_advisory_result_manager() -> ResultManager:
             ("DC2-LEAF2", AntaTestStatus.SUCCESS, "The affected service is disabled."),
         ],
     )
+    return manager
+
+
+def build_security_advisory_md_result_manager() -> ResultManager:
+    """Build the shared reporter dataset with Markdown-only SA117 remediation examples."""
+    manager = build_security_advisory_result_manager()
+    sa121_markdown_advisory = EXAMPLE_HIGH_ADVISORY.model_copy(
+        update={
+            "vulnerabilities": (
+                *EXAMPLE_HIGH_ADVISORY.vulnerabilities,
+                _AdvisoryVulnerability(
+                    id="CVE-2026-12102",
+                    severity=_AdvisoryVulnerabilitySeverity.LOW,
+                    description="CVE-2026-12102 Low-impact information disclosure in process diagnostics.",
+                ),
+                _AdvisoryVulnerability(
+                    id="CVE-2026-12103",
+                    severity=_AdvisoryVulnerabilitySeverity.UNKNOWN,
+                    description="CVE-2026-12103 Process behavior with severity pending assessment.",
+                ),
+            )
+        }
+    )
+    remediations = {
+        AntaTestStatus.INCONCLUSIVE: ["Upgrade to a fixed EOS release when one is published, then rerun the test."],
+        AntaTestStatus.ERROR: ["Collect valid EOS version evidence and rerun the test."],
+        AntaTestStatus.SKIPPED: ["Restore device reachability and rerun the test."],
+    }
+    for result in manager.results:
+        if isinstance(result, _AdvisoryTestResult) and result.advisory.sa_number == "0117":
+            result.remediations = remediations.get(result.result, [])
+            if result.name == "DC1-LEAF1":
+                vulnerability = result.advisory.vulnerabilities[0]
+                result.add(
+                    vulnerability.description,
+                    AntaTestStatus.INCONCLUSIVE,
+                    ["The assessment is inconclusive because required gNOI File and gNSI Authz evidence is unavailable."],
+                    vulnerability_ids=(vulnerability.id,),
+                    remediations=remediations[AntaTestStatus.INCONCLUSIVE],
+                )
+        if isinstance(result, _AdvisoryTestResult) and result.advisory.sa_number == "0121":
+            result.advisory = sa121_markdown_advisory
+        if isinstance(result, _AdvisoryTestResult) and result.advisory.sa_number == "0121" and result.name == "DC1-SPINE1":
+            high_vulnerability, low_vulnerability, unknown_vulnerability = result.advisory.vulnerabilities
+            remediation = "Disable or restrict the exposed service and upgrade to a fixed EOS release."
+            result.remediations = [remediation]
+            result.add(
+                high_vulnerability.description,
+                AntaTestStatus.FAILURE,
+                ["The device is affected because an affected EOS release and exposed service were detected."],
+                vulnerability_ids=(high_vulnerability.id,),
+                remediations=[remediation],
+            )
+            result.add(
+                low_vulnerability.description,
+                AntaTestStatus.SUCCESS,
+                ["The device is not affected by the low-severity issue because process diagnostics are restricted."],
+                vulnerability_ids=(low_vulnerability.id,),
+                remediations=["Keep process diagnostics restricted to trusted operators."],
+            )
+            result.add(
+                unknown_vulnerability.description,
+                AntaTestStatus.INCONCLUSIVE,
+                ["The assessment is inconclusive because the severity and affected conditions are still being investigated."],
+                vulnerability_ids=(unknown_vulnerability.id,),
+                remediations=["Monitor the advisory for updated severity and remediation guidance."],
+            )
     return manager

--- a/tests/units/_advisory/test_md_reporter.py
+++ b/tests/units/_advisory/test_md_reporter.py
@@ -29,12 +29,12 @@ from tests.units._advisory.conftest import (
     build_fleet_security_advisory_run_context,
     build_security_advisory_run_context,
 )
-from tests.units._advisory.reporting_data import EXAMPLE_HIGH_ADVISORY, build_security_advisory_result, build_security_advisory_result_manager
+from tests.units._advisory.reporting_data import EXAMPLE_HIGH_ADVISORY, build_security_advisory_md_result_manager, build_security_advisory_result
 
 
 def test_security_advisory_markdown_report(tmp_path: Path) -> None:
     """Verify a realistic fleet report is clean, grouped, and deterministic."""
-    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_result_manager())
+    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_md_result_manager())
     output = tmp_path / "advisories.md"
 
     generate_security_advisory_md_report(report, output, build_fleet_security_advisory_run_context(report), DEFAULT_ADVISORY_REPORT_CONFIG)
@@ -44,26 +44,32 @@ def test_security_advisory_markdown_report(tmp_path: Path) -> None:
 
 
 def test_security_advisory_markdown_report_with_run_overview(tmp_path: Path) -> None:
-    """Verify run context metadata is rendered in the security advisory run overview section."""
-    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_result_manager())
+    """Verify run context metadata is rendered in the Run Overview section."""
+    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_md_result_manager())
     output = tmp_path / "advisories.md"
     run_context = build_fleet_security_advisory_run_context(report)
 
     generate_security_advisory_md_report(report, output, run_context, DEFAULT_ADVISORY_REPORT_CONFIG)
 
     content = output.read_text(encoding="utf-8")
-    assert "  - [Security Advisory Run Overview](#security-advisory-run-overview)" in content
-    assert '## 📋 Security Advisory Run Overview <a id="security-advisory-run-overview"></a>' in content
-    assert f"**ANTA Version** | {ADVISORY_ANTA_VERSION}" in content
-    assert f"**Test Execution Start Time** | {ADVISORY_RUN_START_TIME_FORMATTED}" in content
-    assert f"**Test Execution End Time** | {ADVISORY_RUN_END_TIME_FORMATTED}" in content
-    assert f"**Total Duration** | {ADVISORY_RUN_DURATION_FORMATTED}" in content
-    assert "**Total Devices In Inventory** | 8" in content
-    assert f"**Devices Unreachable At Setup** | {ADVISORY_RUN_DEVICES_UNREACHABLE[0]}" in content
-    assert f"**Devices Filtered At Setup** | {'<br>'.join(ADVISORY_RUN_DEVICES_FILTERED)}" in content
-    assert "**Filters Applied** | Tags: spine" in content
-    assert "**Security Advisories Assessed** | 3" in content
-    assert "**Devices Assessed** | 8" in content
+    assert '<h1 id="anta-security-advisory-report" align="center">🛡️ ANTA Security Advisory Report 🛡️</h1>' in content
+    assert "- [ANTA Security Advisory Report](#anta-security-advisory-report)" not in content
+    assert "- [Run Overview](#run-overview)" in content
+    assert "  - [SA0120: Example Management API Authentication Bypass](#sa-0120)" in content
+    assert "  - [SA0121: Example EOS Process Denial of Service](#sa-0121)" in content
+    assert "  - [SA0117: Security Advisory 0117](#sa-0117)" in content
+    assert '## 📋 Run Overview <a id="run-overview"></a>' in content
+    assert f"| **ANTA Version** | {ADVISORY_ANTA_VERSION} |" in content
+    assert f"| **Duration** | {ADVISORY_RUN_DURATION_FORMATTED} ({ADVISORY_RUN_START_TIME_FORMATTED} → {ADVISORY_RUN_END_TIME_FORMATTED}) |" in content
+    assert "| **Security Advisories Tested** | 3 |" in content
+    assert "### Security Advisories" not in content
+    assert "### Devices" not in content
+    assert "| Device Metric | Details |" not in content
+    assert "| **Total Devices In Inventory** | 8 |" in content
+    assert "| **Devices Assessed** | 8 |" in content
+    assert f"| **Devices Unreachable At Setup** | {ADVISORY_RUN_DEVICES_UNREACHABLE[0]} |" in content
+    assert f"| **Devices Filtered At Setup** | {'<br>'.join(ADVISORY_RUN_DEVICES_FILTERED)} |" in content
+    assert "| **Filters Applied** | Tags: spine |" in content
 
 
 def test_security_advisory_markdown_run_overview_ignores_hidden_results(tmp_path: Path) -> None:
@@ -85,8 +91,8 @@ def test_security_advisory_markdown_run_overview_ignores_hidden_results(tmp_path
     content = output.read_text(encoding="utf-8")
     assert "| leaf1 |" not in content
     assert "| leaf2 |" in content
-    assert "**Security Advisories Assessed** | 2" in content
-    assert "**Devices Assessed** | 2" in content
+    assert "| **Total Devices In Inventory** | 2 |" in content
+    assert "| **Devices Assessed** | 2 |" in content
 
 
 def test_security_advisory_markdown_validates_unfiltered_results_before_writing(tmp_path: Path) -> None:
@@ -113,46 +119,104 @@ def test_security_advisory_markdown_validates_unfiltered_results_before_writing(
 
 def test_security_advisory_markdown_report_expanded(tmp_path: Path) -> None:
     """Verify expanded Markdown renders real issue assessments using the regular ANTA parent/child layout."""
-    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_result_manager())
+    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_md_result_manager())
     output = tmp_path / "advisories.md"
 
     generate_security_advisory_md_report(report, output, build_fleet_security_advisory_run_context(report), SecurityAdvisoryReportConfig(expand_results=True))
 
     expected = (Path(__file__).parents[2] / "data" / "test_security_advisory_md_report_expanded.md").read_text(encoding="utf-8")
-    assert output.read_text(encoding="utf-8") == expected
+    content = output.read_text(encoding="utf-8")
+    assert content == expected
+    assert "CVE-2025-0936" in content
+    assert "🟡&nbsp;CVE-2025-0936" in content
+    assert "🔵&nbsp;CVE-2026-12102" in content
+    assert "⚪&nbsp;CVE-2026-12103" in content
+    assert "Upgrade to a fixed EOS release when one is published, then rerun the test." in content
+    assert "GTI-EXAMPLE-12101" in content
+    assert "Disable or restrict the exposed service and upgrade to a fixed EOS release." in content
 
 
 def test_security_advisory_markdown_report_flattened_atomic_results(tmp_path: Path) -> None:
     """Verify default output retains issue attribution without exposing child rows."""
-    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_result_manager())
+    report = SecurityAdvisoryReport.from_result_manager(build_security_advisory_md_result_manager())
     output = tmp_path / "advisories.md"
 
     generate_security_advisory_md_report(report, output, build_fleet_security_advisory_run_context(report), DEFAULT_ADVISORY_REPORT_CONFIG)
 
     content = output.read_text(encoding="utf-8")
-    assert "| Device | Test | Result | Messages |" in content
-    assert "| Vulnerability | Description | Severity |" in content
-    assert "| CVE-2026-12001 | CVE-2026-12001 Authentication bypass in an enabled management API." in content
+    assert "| Device | Result | Findings | Remediations |" in content
+    assert "> | Vulnerability | Severity | Description |" in content
+    assert "#### Vulnerabilities" not in content
+    assert (
+        "> **Severity:** 🔴 Critical\\\n> **URL:** <https://www.arista.com/en/support/advisories-notices/security-advisory/example-0120>\n>\n"
+        "> An example vulnerability in an enabled management API could allow an unauthenticated remote actor to bypass authentication under specific "
+        "configurations. This fictional advisory is used only to exercise realistic report rendering."
+    ) in content
+    assert "> | CVE-2026-12001 | 🔴&nbsp;Critical | CVE-2026-12001 Authentication bypass in an enabled management API. |" in content
+    assert (
+        "> | GHSA-2345-6789-cfgh | 🟠&nbsp;High | GHSA-2345-6789-cfgh Authorization flaw affecting management API access controls. |\n"
+        ">\n\n#### 🔎 Device Findings" in content
+    )
     assert "CVE-2026-12001 vulnerable management API - The device is affected because the vulnerable management API is enabled." in content
     assert "GHSA-2345-6789-cfgh authorization controls - The device is not affected by this issue because" in content
+    assert "Upgrade to a fixed EOS release when one is published, then rerun the test." in content
+    assert "Collect valid EOS version evidence and rerun the test." in content
+    assert "Restore device reachability and rerun the test." in content
     assert "├──" not in content
     assert "└──" not in content
+
+
+def test_security_advisory_markdown_report_flattened_remediation(tmp_path: Path) -> None:
+    """Render aggregated test-level remediation when atomic rows are hidden."""
+    result = build_security_advisory_result(
+        "leaf1",
+        AntaTestStatus.FAILURE,
+        "The device is affected.",
+        ADVISORY,
+        remediations=["First remediation.", "Second remediation."],
+    )
+    result.add(
+        "Affected issue.",
+        AntaTestStatus.FAILURE,
+        ["Affected finding."],
+        vulnerability_ids=("CVE-2026-0001",),
+        remediations=["First remediation.", "Atomic remediation."],
+    )
+    manager = ResultManager()
+    manager.add(result)
+    report = SecurityAdvisoryReport.from_result_manager(manager)
+    output = tmp_path / "advisories.md"
+
+    generate_security_advisory_md_report(report, output, build_security_advisory_run_context(report), DEFAULT_ADVISORY_REPORT_CONFIG)
+
+    content = output.read_text(encoding="utf-8")
+    assert (
+        "| leaf1 | ❌&nbsp;Affected | The device is affected.<br>Affected issue. - Affected finding. "
+        "| •&nbsp;First remediation.<br>•&nbsp;Second remediation.<br>•&nbsp;Atomic remediation. |"
+    ) in content
 
 
 def test_security_advisory_markdown_report_expanded_without_atomic_results(tmp_path: Path) -> None:
     """Verify expanded mode keeps a normal parent row when no detailed issue assessment exists."""
     manager = ResultManager()
-    manager.add(build_security_advisory_result("leaf1", AntaTestStatus.SUCCESS, "The device is not affected because EOS 4.40.1F contains the fix.", ADVISORY))
+    result = build_security_advisory_result(
+        "leaf1",
+        AntaTestStatus.SUCCESS,
+        "The device is not affected because EOS 4.40.1F contains the fix.",
+        ADVISORY,
+        remediations=["Maintain EOS 4.40.1F or later."],
+    )
+    manager.add(result)
     report = SecurityAdvisoryReport.from_result_manager(manager)
     output = tmp_path / "advisories.md"
 
     generate_security_advisory_md_report(report, output, build_security_advisory_run_context(report), SecurityAdvisoryReportConfig(expand_results=True))
 
     content = output.read_text(encoding="utf-8")
-    assert "| Device | Test | Description | Vulnerability ID(s) | Result | Messages |" in content
+    assert "| Device | Description | Vulnerability ID(s) | Result | Findings | Remediations |" in content
     assert (
-        "| leaf1 | VerifySA1 | Verify that the device is not exposed to Arista Security Advisory 0001. | - | ✅&nbsp;Not Affected "
-        "| The device is not affected because EOS 4.40.1F contains the fix. |"
+        "| leaf1 | Verify that the device is not exposed to Arista Security Advisory 0001. | - | ✅&nbsp;Not Affected "
+        "| The device is not affected because EOS 4.40.1F contains the fix. | Maintain EOS 4.40.1F or later. |"
     ) in content
     assert "├──" not in content
     assert "└──" not in content
@@ -174,6 +238,7 @@ def test_security_advisory_markdown_report_expanded_preserves_parent_messages(tm
         AntaTestStatus.SUCCESS,
         ["The device is not affected because this individual platform check passed."],
         vulnerability_ids=("CVE-2026-0001",),
+        remediations=["Maintain the current platform configuration."],
     )
     manager = ResultManager()
     manager.add(result)
@@ -185,8 +250,9 @@ def test_security_advisory_markdown_report_expanded_preserves_parent_messages(tm
     content = output.read_text(encoding="utf-8")
     assert "**Detailed findings:** All&nbsp;1&nbsp;checks&nbsp;not&nbsp;affected" in content
     assert "**Overall evidence:** The device is affected because parent-specific evidence proves exposure." in content
-    assert "CVE-2026-0001 platform applicability - The device is not affected because this individual platform check passed." in content
+    assert "CVE-2026-0001 Test vulnerability affecting the management API." in content
     assert "The device is not affected because this individual platform check passed." in content
+    assert "Maintain the current platform configuration." in content
 
 
 def test_security_advisory_markdown_report_os_error(tmp_path: Path) -> None:
@@ -239,7 +305,7 @@ def test_security_advisory_markdown_summary_distinguishes_mitigated_results(tmp_
 
     content = output.read_text(encoding="utf-8")
     assert "| [SA0001: Test advisory](#sa-0001) | 🟠&nbsp;High | 2 | 0 | 0 | 1 | 1 | 0 | 0 |" in content
-    assert "| leaf1 | VerifySA1 | ✅&nbsp;Mitigated |" in content
+    assert "| leaf1 | ✅&nbsp;Mitigated |" in content
 
 
 @pytest.mark.parametrize(
@@ -314,8 +380,8 @@ def test_security_advisory_markdown_without_vulnerabilities(tmp_path: Path) -> N
 
     content = output.read_text(encoding="utf-8")
     assert "[SA0002: Test advisory](#sa-0002) | ⚪&nbsp;Unknown" in content
-    assert "⚪ **Severity:** Unknown" in content
-    assert "| Vulnerability | Description | Severity |" in content
+    assert "**Severity:** ⚪ Unknown" in content
+    assert "> | Vulnerability | Severity | Description |" in content
     assert "CVSS" not in content
     assert "Mitigations" not in content
     assert "Resolutions" not in content
@@ -333,5 +399,55 @@ def test_security_advisory_markdown_vulnerability_defaults(tmp_path: Path) -> No
     generate_security_advisory_md_report(report, output, build_security_advisory_run_context(report), DEFAULT_ADVISORY_REPORT_CONFIG)
 
     content = output.read_text(encoding="utf-8")
-    assert "| PROVIDER-0001 | Provider vulnerability. | Unknown |" in content
+    assert "| PROVIDER-0001 | ⚪&nbsp;Unknown | Provider vulnerability. |" in content
     assert "[PROVIDER-0001]" not in content
+
+
+def test_security_advisory_markdown_sorts_vulnerabilities_by_severity(tmp_path: Path) -> None:
+    """Order vulnerability metadata from highest to lowest severity."""
+    manager = ResultManager()
+    manager.add(build_security_advisory_result("leaf1", AntaTestStatus.SUCCESS, "No exposure detected.", ADVISORY))
+    report = SecurityAdvisoryReport.from_result_manager(manager)
+    output = tmp_path / "advisories.md"
+
+    generate_security_advisory_md_report(report, output, build_security_advisory_run_context(report), DEFAULT_ADVISORY_REPORT_CONFIG)
+
+    content = output.read_text(encoding="utf-8")
+    high_vulnerability = "| CVE-2026-0002 | 🟠&nbsp;High | CVE-2026-0002 Test vulnerability affecting access controls. |"
+    medium_vulnerability = "| CVE-2026-0001 | 🟡&nbsp;Medium | CVE-2026-0001 Test vulnerability affecting the management API. |"
+    assert content.index(high_vulnerability) < content.index(medium_vulnerability)
+
+
+def test_security_advisory_markdown_atomic_metadata_and_remediation(tmp_path: Path) -> None:
+    """Use vulnerability metadata and atomic remediation in expanded findings."""
+    result = _AdvisoryTestResult(
+        name="leaf1",
+        test="VerifySA1",
+        categories=["advisories"],
+        description="Test advisory metadata.",
+        result=AntaTestStatus.FAILURE,
+        messages=["The device is affected."],
+        advisory=ADVISORY,
+        remediations=["Parent aggregate remediation."],
+    )
+    result.add(
+        "Shared atomic description.",
+        AntaTestStatus.FAILURE,
+        ["Shared finding."],
+        vulnerability_ids=("CVE-2026-0001", "CVE-2026-0002"),
+        remediations=["Shared vulnerability remediation."],
+    )
+    result.add("Unassociated atomic description.", AntaTestStatus.INCONCLUSIVE, ["Unassociated finding."], remediations=["Unassociated remediation."])
+    manager = ResultManager()
+    manager.add(result)
+    report = SecurityAdvisoryReport.from_result_manager(manager)
+    output = tmp_path / "advisories.md"
+
+    generate_security_advisory_md_report(report, output, build_security_advisory_run_context(report), SecurityAdvisoryReportConfig(expand_results=True))
+
+    content = output.read_text(encoding="utf-8")
+    assert "CVE-2026-0001 Test vulnerability affecting the management API.<br>CVE-2026-0002 Test vulnerability affecting access controls." in content
+    assert "Unassociated atomic description." in content
+    assert "Shared vulnerability remediation." in content
+    assert "Unassociated remediation." in content
+    assert "•&nbsp;Parent aggregate remediation.<br>•&nbsp;Shared vulnerability remediation.<br>•&nbsp;Unassociated remediation." in content

--- a/tests/units/cli/test_psirt.py
+++ b/tests/units/cli/test_psirt.py
@@ -201,11 +201,12 @@ def test_anta_psirt_advisory_markdown_report_all_results_hidden(click_runner: Cl
 
     assert result.exit_code == ExitCode.OK
     content = output.read_text(encoding="utf-8")
-    assert "Security Advisory Run Overview" in content
+    assert "Run Overview" in content
+    assert "| **Security Advisories Tested** | 1 |" in content
     assert "Advisory Exposure Summary" not in content
     assert "Security Advisory Details" not in content
-    assert "**Security Advisories Assessed** | 1" in content
-    assert "**Devices Assessed** | 1" in content
+    assert "| **Total Devices In Inventory** | 1 |" in content
+    assert "| **Devices Assessed** | 1 |" in content
 
 
 def test_anta_psirt_advisory_markdown_report_error(click_runner: CliRunner, tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Improve the ANTA PSIRT Markdown report readability and security-advisory presentation:

- Rename “Exposure Summary” to “Assessment Summary”.
- Sort advisories and vulnerabilities by descending severity.
- Display advisory severity as the maximum vulnerability severity.
- Add severity icons to vulnerability metadata and expanded atomic rows.
- Replace Messages with Findings and remove the Test column.
- Add deduplicated, aggregated Remediations with bullet formatting.
- Use published vulnerability descriptions for associated atomic results.
- Render advisory metadata and vulnerability tables as blockquoted cards.
- Improve the title, table of contents, advisory anchors, and Run Overview.
- Add representative SA0117 and SA0121 fixture data covering remediations and all relevant severity levels.
- Preserve the generic Markdown and CSV report behavior.

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have run pre-commit for code linting and typing (pre-commit run)
  - [x] I have made corresponding changes to the documentation
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes (tox -e testenv)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Markdown security advisory reports with clearer headings, navigation, metadata, and consolidated run overviews.
  * Added severity indicators, severity-based vulnerability sorting, expanded findings, and linked advisory details.
  * Added remediation details to device findings, including deduplicated remediation guidance.
  * Added advisory assessment summaries with severity and device-result counts.
* **Documentation**
  * Updated security advisory report documentation to describe the revised layout, findings, severity ordering, and remediation information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->