### PR TITLE
bump: Version 1.10.0.dev1 -> 1.10.0.dev2

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -38,7 +38,7 @@ $ pip install -e ".[cli]" --group dev
     $ pip list -e
     Package Version Editable project location
     ------- ------- -------------------------
-    anta    1.10.0.dev1   /mnt/lab/projects/anta
+    anta    1.10.0.dev2   /mnt/lab/projects/anta
     ```
 
 Then, [`tox`](https://tox.wiki/) is configured with a few environments to run CI locally:

--- a/docs/requirements-and-installation.md
+++ b/docs/requirements-and-installation.md
@@ -92,7 +92,7 @@ which anta
 ```bash
 # Check ANTA version
 anta --version
-anta, version v1.10.0.dev1
+anta, version v1.10.0.dev2
 ```
 
 ## EOS Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anta"
-version = "v1.10.0.dev1"
+version = "v1.10.0.dev2"
 readme = "README.md"
 authors = [{ name = "Arista Networks ANTA maintainers", email = "anta-dev@arista.com" }]
 maintainers = [
@@ -121,7 +121,7 @@ namespaces = false
 # Version
 ################################
 [tool.bumpver]
-current_version = "1.10.0.dev1"
+current_version = "1.10.0.dev2"
 version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
 commit_message  = "bump: Version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
what the title says

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and contribution documentation to reference version `1.10.0.dev2`.
  * Updated documented CLI version output to `v1.10.0.dev2`.

* **Chores**
  * Bumped the project version to `1.10.0.dev2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->