### PR TITLE
refactor(anta.cli): Add better spinner for anta psirt

### DIFF
--- a/anta/cli/nrfu/__init__.py
+++ b/anta/cli/nrfu/__init__.py
@@ -125,6 +125,7 @@ def nrfu(
     ctx.obj["test"] = test
     ctx.obj["dry_run"] = dry_run
     ctx.obj["disconnect"] = disconnect
+    ctx.obj["progress_spinner"] = "anta"
 
     if not ctx.invoked_subcommand:
         ctx.invoke(commands.table)

--- a/anta/cli/nrfu/utils.py
+++ b/anta/cli/nrfu/utils.py
@@ -50,7 +50,7 @@ def run_tests(ctx: click.Context) -> AntaRunContext:
     inventory: AntaInventory = ctx.obj["inventory"]
 
     print_settings(inventory, catalog)
-    with anta_progress_bar() as AntaTest.progress:
+    with anta_progress_bar(ctx.obj["progress_spinner"]) as AntaTest.progress:
         runner = AntaRunner()
         filters = AntaRunFilters(
             devices=set(device) if device else None,
@@ -233,11 +233,29 @@ SPINNERS["anta"] = {
     ],
 }
 
+# Adding our own security spinner
+SPINNERS["security"] = {
+    "interval": 150,
+    "frames": [
+        "(🔍   🥷)",
+        "( 🔍  🥷)",
+        "(  🔍 🥷)",
+        "(   🔍🥷)",
+        "(     💥)",
+        "(     🚨)",
+        "(    🛡️ )",
+        "(   🛡️  )",
+        "(  🛡️   )",
+        "( 🛡️    )",
+        "(🛡️     )",
+    ],
+}
 
-def anta_progress_bar() -> Progress:
+
+def anta_progress_bar(spinner_name: str = "anta") -> Progress:
     """Return a customized Progress for progress bar."""
     return Progress(
-        SpinnerColumn("anta"),
+        SpinnerColumn(spinner_name),
         TextColumn("•"),
         TextColumn("{task.description}[progress.percentage]{task.percentage:>3.0f}%"),
         BarColumn(bar_width=None),

--- a/anta/cli/psirt.py
+++ b/anta/cli/psirt.py
@@ -160,6 +160,7 @@ def psirt(
     ctx.obj["test"] = test
     ctx.obj["dry_run"] = dry_run
     ctx.obj["disconnect"] = True
+    ctx.obj["progress_spinner"] = "security"
 
 
 psirt.add_command(nrfu_commands.tpl_report)

--- a/tests/units/cli/nrfu/test_commands.py
+++ b/tests/units/cli/nrfu/test_commands.py
@@ -11,13 +11,45 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import PropertyMock, patch
 
+from rich.cells import cell_len
+
 from anta.cli import anta
+from anta.cli.nrfu.utils import SPINNERS
 from anta.cli.utils import ExitCode
 
 if TYPE_CHECKING:
     from click.testing import CliRunner
 
 DATA_DIR: Path = Path(__file__).parents[3].resolve() / "data"
+
+
+def test_security_spinner() -> None:
+    """Test the security spinner frames and their display width."""
+    expected_frames = [
+        "(🔍   🥷)",
+        "( 🔍  🥷)",
+        "(  🔍 🥷)",
+        "(   🔍🥷)",
+        "(     💥)",
+        "(     🚨)",
+        "(    🛡️ )",
+        "(   🛡️  )",
+        "(  🛡️   )",
+        "( 🛡️    )",
+        "(🛡️     )",
+    ]
+
+    assert SPINNERS["security"] == {"interval": 150, "frames": expected_frames}
+    assert {cell_len(frame) for frame in expected_frames} == {9}
+
+
+def test_anta_nrfu_uses_anta_progress_spinner(click_runner: CliRunner) -> None:
+    """Use the standard ANTA spinner for NRFU test runs."""
+    with patch("anta.cli.nrfu.utils.anta_progress_bar") as progress_bar_mock:
+        result = click_runner.invoke(anta, ["nrfu", "--dry-run"])
+
+    assert result.exit_code == ExitCode.OK
+    progress_bar_mock.assert_called_once_with("anta")
 
 
 def test_anta_nrfu_table_help(click_runner: CliRunner) -> None:

--- a/tests/units/cli/test_psirt.py
+++ b/tests/units/cli/test_psirt.py
@@ -158,6 +158,24 @@ def test_anta_psirt_report_help(click_runner: CliRunner, report: str) -> None:
 
 
 @pytest.mark.parametrize(
+    "report_args",
+    [
+        pytest.param(["csv", "--csv-output", "report.csv"], id="csv"),
+        pytest.param(["tpl-report", "--template", str(DATA_DIR / "template.j2")], id="template"),
+        pytest.param(["md-report", "--md-output", "report.md"], id="markdown"),
+    ],
+)
+def test_anta_psirt_uses_security_progress_spinner(click_runner: CliRunner, report_args: list[str]) -> None:
+    """Use the security spinner for every PSIRT report command."""
+    catalog = AntaCatalog.parse(DATA_DIR / "test_catalog.yml")
+    with patch("anta.cli.psirt.get_catalog", return_value=catalog), patch("anta.cli.nrfu.utils.anta_progress_bar") as progress_bar_mock:
+        result = click_runner.invoke(anta, ["psirt", "--dry-run", *report_args], env={"ANTA_CATALOG": None})
+
+    assert result.exit_code == ExitCode.OK
+    progress_bar_mock.assert_called_once_with("security")
+
+
+@pytest.mark.parametrize(
     ("command", "output_option", "filename", "generator", "label"),
     [
         pytest.param("csv", "--csv-output", "report.csv", "generate_security_advisory_csv_report", "CSV", id="csv"),


### PR DESCRIPTION
## Description

because sometimes you need some fun. Update the spinner for `anta psirt` command

```
    expected_frames = [
        "(🔍   🥷)",
        "( 🔍  🥷)",
        "(  🔍 🥷)",
        "(   🔍🥷)",
        "(     💥)",
        "(     🚨)",
        "(    🛡️ )",
        "(   🛡️  )", 
        "(  🛡️   )",
        "( 🛡️    )",
        "(🛡️     )",
    ]
```

Fixes # (issue id)

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a security-focused progress spinner for PSIRT report generation.
  * Standard NRFU operations continue using the default ANTA progress spinner.
  * PSIRT commands now use the built-in advisory catalog and supported report options.
* **Bug Fixes**
  * Progress indicators are selected consistently across supported PSIRT report formats.
* **Tests**
  * Added coverage for spinner animations, display sizing, command validation, and progress behavior across NRFU and PSIRT commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->