### PR TITLE
bump: Version 1.10.0.dev2 -> 1.10.0.dev3

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -38,7 +38,7 @@ $ pip install -e ".[cli]" --group dev
     $ pip list -e
     Package Version Editable project location
     ------- ------- -------------------------
-    anta    1.10.0.dev2   /mnt/lab/projects/anta
+    anta    1.10.0.dev3   /mnt/lab/projects/anta
     ```
 
 Then, [`tox`](https://tox.wiki/) is configured with a few environments to run CI locally:

--- a/docs/requirements-and-installation.md
+++ b/docs/requirements-and-installation.md
@@ -92,7 +92,7 @@ which anta
 ```bash
 # Check ANTA version
 anta --version
-anta, version v1.10.0.dev2
+anta, version v1.10.0.dev3
 ```
 
 ## EOS Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anta"
-version = "v1.10.0.dev2"
+version = "v1.10.0.dev3"
 readme = "README.md"
 authors = [{ name = "Arista Networks ANTA maintainers", email = "anta-dev@arista.com" }]
 maintainers = [
@@ -121,7 +121,7 @@ namespaces = false
 # Version
 ################################
 [tool.bumpver]
-current_version = "1.10.0.dev2"
+current_version = "1.10.0.dev3"
 version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
 commit_message  = "bump: Version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
Another dev version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation and contribution documentation to reference ANTA version `1.10.0.dev3`.

- **Chores**
  - Bumped the project version to `1.10.0.dev3`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->