### PR TITLE
refactor(anta): rename psirt to sat

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Commands:
   exec   Commands to execute various scripts on EOS devices.
   get    Commands to get information from or generate inventories.
   nrfu   Run ANTA tests on selected inventory devices.
-  psirt  Run ANTA tests for Arista security advisories.
+  sat  Run ANTA security advisory tests.
 ```
 
 You can also still choose to install it directly with `pip`:

--- a/anta/cli/_main.py
+++ b/anta/cli/_main.py
@@ -17,7 +17,7 @@ from anta.cli.debug import debug as debug_command
 from anta.cli.exec import _exec as exec_command
 from anta.cli.get import get as get_command
 from anta.cli.nrfu import nrfu as nrfu_command
-from anta.cli.psirt import psirt as psirt_command
+from anta.cli.sat import sat as sat_command
 from anta.cli.utils import AliasedGroup, ExitCode
 from anta.logger import Log, LogLevel, anta_log_exception, setup_logging
 
@@ -53,7 +53,7 @@ def anta(ctx: click.Context, log_level: LogLevel, log_file: pathlib.Path) -> Non
 
 
 anta.add_command(nrfu_command)
-anta.add_command(psirt_command)
+anta.add_command(sat_command)
 anta.add_command(check_command)
 anta.add_command(exec_command)
 anta.add_command(get_command)

--- a/anta/cli/sat.py
+++ b/anta/cli/sat.py
@@ -91,18 +91,18 @@ def _md_report(ctx: click.Context, md_output: pathlib.Path, *, expand: bool) -> 
     exit_with_code(ctx)
 
 
-psirt = _build_nrfu_command(
-    name="psirt",
+sat = _build_nrfu_command(
+    name="sat",
     help_text=(
-        "[PREVIEW] Run ANTA tests for Arista security advisories. This command is a preview feature; its interface and behavior may change at any time without a "
+        "[PREVIEW] Run ANTA security advisory tests. This command is a preview feature; its interface and behavior may change at any time without a "
         "deprecation notice."
     ),
     default_catalog_factory=_load_default_catalog,
 )
 # Override the generic NRFU commands registered by the factory with the
 # security-advisory-specific reporters under the same Click command names.
-psirt.add_command(_csv)
-psirt.add_command(_md_report)
+sat.add_command(_csv)
+sat.add_command(_md_report)
 
 
-__all__ = ["psirt"]
+__all__ = ["sat"]

--- a/anta/tests/advisories/__init__.py
+++ b/anta/tests/advisories/__init__.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from anta._advisory.base import _AntaAdvisoryTest
 
 # Keep this registry explicit: adding an advisory module also requires adding its
-# test class here. The default ``anta psirt`` catalog is built from every entry.
+# test class here. The default ``anta sat`` catalog is built from every entry.
 _ADVISORY_TESTS: tuple[type[_AntaAdvisoryTest], ...] = tuple(
     cast("type[_AntaAdvisoryTest]", test) for test in (VerifySA117, VerifySA140, VerifySA142, VerifySA146, VerifySA147)
 )

--- a/docs/cli/overview.md
+++ b/docs/cli/overview.md
@@ -77,12 +77,12 @@ Below are the environment variables usable with the `anta nrfu` command:
 | ANTA_NRFU_DRY_RUN | Run `anta nrfu` command but stop before running the tests. | No | False |
 | ANTA_DISCONNECT_INVENTORY | Disconnect inventory devices once the test run is complete. | No | True |
 
-The `anta psirt` command accepts the shared environment variables above.
-`ANTA_CATALOG` is optional for `anta psirt`: when unset, the command uses the
+The `anta sat` command accepts the shared environment variables above.
+`ANTA_CATALOG` is optional for `anta sat`: when unset, the command uses the
 complete catalog of advisory tests installed with ANTA. When set, it replaces
 that default catalog. Its command-specific flags use
-`ANTA_PSIRT_IGNORE_STATUS`, `ANTA_PSIRT_IGNORE_ERROR`, and
-`ANTA_PSIRT_DRY_RUN`.
+`ANTA_SAT_IGNORE_STATUS`, `ANTA_SAT_IGNORE_ERROR`, and
+`ANTA_SAT_DRY_RUN`.
 
 !!! note
     Caching can be disabled with the global parameter `--disable-cache`. For more details about how caching is implemented in ANTA, please refer to [Caching in ANTA](../advanced_usages/caching.md).

--- a/docs/cli/sat.md
+++ b/docs/cli/sat.md
@@ -1,10 +1,10 @@
 ---
-title: Run ANTA PSIRT Tests
+title: Run ANTA Security Advisory Tests (SAT)
 hide:
   - tags
 tags:
   - CLI
-  - PSIRT
+  - SAT
   - Preview
   - Security
 ---
@@ -16,31 +16,31 @@ tags:
   -->
 
 !!! warning "Preview"
-    The `anta psirt` command is a preview feature. Its interface and behavior may change at any time without a deprecation notice.
+    The `anta sat` command is a preview feature. Its interface and behavior may change at any time without a deprecation notice.
 
-The `anta psirt` command runs the complete catalog of security advisory tests
+The `anta sat` command runs the complete catalog of security advisory tests
 installed with ANTA. It shares inventory options, filters, execution behavior,
 and exit handling with [`anta nrfu`](nrfu.md).
 
 ## Command overview
 
 ```bash
---8<-- "anta_psirt_help.txt"
+--8<-- "anta_sat_help.txt"
 ```
 
 Provide an inventory and credentials as for NRFU. When no report subcommand is
 specified, ANTA renders the table report:
 
 ```bash
-anta psirt --inventory inventory.yml --username admin --prompt
+anta sat --inventory inventory.yml --username admin --prompt
 ```
 
 By default, the command runs every test registered in the built-in
 `anta.tests.advisories` catalog.
 
-PSIRT-specific execution settings can be configured with
-`ANTA_PSIRT_IGNORE_STATUS`, `ANTA_PSIRT_IGNORE_ERROR`,
-and `ANTA_PSIRT_DRY_RUN`. Disconnect behavior remains global through
+SAT-specific execution settings can be configured with
+`ANTA_SAT_IGNORE_STATUS`, `ANTA_SAT_IGNORE_ERROR`,
+and `ANTA_SAT_DRY_RUN`. Disconnect behavior remains global through
 `ANTA_DISCONNECT_INVENTORY`.
 
 ## Override the catalog
@@ -48,7 +48,7 @@ and `ANTA_PSIRT_DRY_RUN`. Disconnect behavior remains global through
 Use `--catalog` to replace the package catalog with a YAML or JSON catalog:
 
 ```bash
-anta psirt --inventory inventory.yml --catalog selected-advisories.yml table
+anta sat --inventory inventory.yml --catalog selected-advisories.yml table
 ```
 
 The `ANTA_CATALOG` environment variable provides the same override. Overrides
@@ -67,9 +67,9 @@ and assessment counts. CSV also includes result remediation when provided by
 the advisory test:
 
 ```bash
-anta psirt --inventory inventory.yml --catalog sa.yml csv --csv-output sa-report.csv
-anta psirt --inventory inventory.yml --catalog sa.yml md-report --md-output sa-report.md
-anta psirt --inventory inventory.yml --catalog sa.yml md-report --md-output sa-report-expanded.md --expand
+anta sat --inventory inventory.yml --catalog sa.yml csv --csv-output sa-report.csv
+anta sat --inventory inventory.yml --catalog sa.yml md-report --md-output sa-report.md
+anta sat --inventory inventory.yml --catalog sa.yml md-report --md-output sa-report-expanded.md --expand
 ```
 
 Use `--expand` on the Markdown report to include atomic advisory findings and

--- a/docs/scripts/generate_doc_snippets.py
+++ b/docs/scripts/generate_doc_snippets.py
@@ -21,7 +21,7 @@ COMMANDS = [
     "anta nrfu text --help",
     "anta nrfu tpl-report --help",
     "anta nrfu md-report --help",
-    "anta psirt --help",
+    "anta sat --help",
     "anta get tags --help",
     "anta get inventory --help",
     "anta get tests --help",

--- a/docs/security-advisory-reports.md
+++ b/docs/security-advisory-reports.md
@@ -19,7 +19,7 @@ tags:
 
 Security advisory reports combine device test results with published advisory metadata. The advisory result answers whether the complete advisory affects a device, while detailed results preserve the conclusions and evidence for individual issues.
 
-These reports are generated with the `anta psirt` command. See the [PSIRT CLI documentation](cli/psirt.md) for usage instructions and examples.
+These reports are generated with the `anta sat` command. See the [SAT CLI documentation](cli/sat.md) for usage instructions and examples.
 
 ## Vulnerability metadata
 

--- a/docs/snippets/anta_help.txt
+++ b/docs/snippets/anta_help.txt
@@ -19,4 +19,4 @@ Commands:
   exec   Commands to execute various scripts on EOS devices.
   get    Commands to get information from or generate inventories.
   nrfu   Run ANTA tests on selected inventory devices.
-  sat  [PREVIEW] Run ANTA security advisory tests.
+  sat    [PREVIEW] Run ANTA security advisory tests.

--- a/docs/snippets/anta_help.txt
+++ b/docs/snippets/anta_help.txt
@@ -19,4 +19,4 @@ Commands:
   exec   Commands to execute various scripts on EOS devices.
   get    Commands to get information from or generate inventories.
   nrfu   Run ANTA tests on selected inventory devices.
-  psirt  [PREVIEW] Run ANTA tests for Arista security advisories.
+  sat  [PREVIEW] Run ANTA security advisory tests.

--- a/docs/snippets/anta_sat_help.txt
+++ b/docs/snippets/anta_sat_help.txt
@@ -1,8 +1,8 @@
 $ anta sat --help
 Usage: anta sat [OPTIONS] [COMMAND] [ARGS]...
 
-  [PREVIEW] Run ANTA security advisory tests. This command is a
-  preview feature; its interface and behavior may change at any time without a
+  [PREVIEW] Run ANTA security advisory tests. This command is a preview
+  feature; its interface and behavior may change at any time without a
   deprecation notice.
 
 Options:

--- a/docs/snippets/anta_sat_help.txt
+++ b/docs/snippets/anta_sat_help.txt
@@ -1,7 +1,7 @@
-$ anta psirt --help
-Usage: anta psirt [OPTIONS] [COMMAND] [ARGS]...
+$ anta sat --help
+Usage: anta sat [OPTIONS] [COMMAND] [ARGS]...
 
-  [PREVIEW] Run ANTA tests for Arista security advisories. This command is a
+  [PREVIEW] Run ANTA security advisory tests. This command is a
   preview feature; its interface and behavior may change at any time without a
   deprecation notice.
 
@@ -48,16 +48,16 @@ Options:
   -t, --test TEXT                 Run a specific test. Can be provided
                                   multiple times.
   --ignore-status                 Exit code will always be 0.  [env var:
-                                  ANTA_PSIRT_IGNORE_STATUS]
+                                  ANTA_SAT_IGNORE_STATUS]
   --ignore-error                  Ignore test errors when determining the exit
-                                  code.  [env var: ANTA_PSIRT_IGNORE_ERROR]
+                                  code.  [env var: ANTA_SAT_IGNORE_ERROR]
   --hide [success|inconclusive|failure|error|skipped]
                                   Hide results by type: success / inconclusive
                                   / failure / error / skipped.
-  --dry-run                       Run anta psirt command but stop before
+  --dry-run                       Run anta sat command but stop before
                                   starting to execute the tests. Considers all
                                   devices as connected.  [env var:
-                                  ANTA_PSIRT_DRY_RUN]
+                                  ANTA_SAT_DRY_RUN]
   --disconnect / --no-disconnect  Disconnect inventory devices once the test
                                   run is complete.  [env var:
                                   ANTA_DISCONNECT_INVENTORY; default:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,7 +175,7 @@ nav:
   - ANTA CLI:
       - Overview: cli/overview.md
       - NRFU: cli/nrfu.md
-      - PSIRT: cli/psirt.md
+      - SAT: cli/sat.md
       - Execute commands: cli/exec.md
       - Inventory from CVP: cli/inv-from-cvp.md
       - Inventory from Ansible: cli/inv-from-ansible.md

--- a/tests/units/cli/test_main.py
+++ b/tests/units/cli/test_main.py
@@ -29,7 +29,7 @@ def test_anta_help(click_runner: CliRunner) -> None:
     result = click_runner.invoke(anta, ["--help"])
     assert result.exit_code == ExitCode.OK
     assert "Usage" in result.output
-    assert "psirt" in result.output
+    assert "sat" in result.output
 
 
 def test_anta_exec_help(click_runner: CliRunner) -> None:

--- a/tests/units/cli/test_sat.py
+++ b/tests/units/cli/test_sat.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
-"""Tests for the ``anta psirt`` command."""
+"""Tests for the ``anta sat`` command."""
 
 from __future__ import annotations
 
@@ -27,22 +27,22 @@ if TYPE_CHECKING:
 DATA_DIR: Path = Path(__file__).parents[2].resolve() / "data"
 
 
-def test_anta_psirt_help(click_runner: CliRunner) -> None:
-    """Expose the built-in PSIRT command and its report formats."""
-    with patch("anta.cli.psirt.get_catalog") as catalog_mock:
-        result = click_runner.invoke(anta, ["psirt", "--help"])
+def test_anta_sat_help(click_runner: CliRunner) -> None:
+    """Expose the built-in SAT command and its report formats."""
+    with patch("anta.cli.sat.get_catalog") as catalog_mock:
+        result = click_runner.invoke(anta, ["sat", "--help"])
 
     help_output = " ".join(result.output.split())
     assert result.exit_code == ExitCode.OK
-    assert "Usage: anta psirt" in help_output
-    assert "[PREVIEW] Run ANTA tests for Arista security advisories" in help_output
+    assert "Usage: anta sat" in help_output
+    assert "[PREVIEW] Run ANTA security advisory tests" in help_output
     assert "This command is a preview feature" in help_output
     assert "may change at any time without a deprecation notice" in help_output
     assert "--catalog" in help_output
     for envvar in (
-        "ANTA_PSIRT_IGNORE_STATUS",
-        "ANTA_PSIRT_IGNORE_ERROR",
-        "ANTA_PSIRT_DRY_RUN",
+        "ANTA_SAT_IGNORE_STATUS",
+        "ANTA_SAT_IGNORE_ERROR",
+        "ANTA_SAT_DRY_RUN",
         "ANTA_DISCONNECT_INVENTORY",
     ):
         assert envvar in help_output
@@ -51,11 +51,11 @@ def test_anta_psirt_help(click_runner: CliRunner) -> None:
     catalog_mock.assert_not_called()
 
 
-def test_anta_psirt_uses_builtin_catalog(click_runner: CliRunner) -> None:
+def test_anta_sat_uses_builtin_catalog(click_runner: CliRunner) -> None:
     """Use every registered built-in advisory test when no override is supplied."""
     catalog = AntaCatalog.parse(DATA_DIR / "test_catalog.yml")
-    with patch("anta.cli.psirt.get_catalog", return_value=catalog) as catalog_mock:
-        result = click_runner.invoke(anta, ["psirt", "--dry-run"], env={"ANTA_CATALOG": None})
+    with patch("anta.cli.sat.get_catalog", return_value=catalog) as catalog_mock:
+        result = click_runner.invoke(anta, ["sat", "--dry-run"], env={"ANTA_CATALOG": None})
 
     assert result.exit_code == ExitCode.OK
     assert "Tests catalog contains 1 tests" in result.output
@@ -63,26 +63,26 @@ def test_anta_psirt_uses_builtin_catalog(click_runner: CliRunner) -> None:
     catalog_mock.assert_called_once_with()
 
 
-def test_anta_psirt_missing_default_catalog(click_runner: CliRunner) -> None:
+def test_anta_sat_missing_default_catalog(click_runner: CliRunner) -> None:
     """Raise an explicit error when the default catalog factory returns no catalog."""
-    with patch("anta.cli.psirt.get_catalog", return_value=None):
-        result = click_runner.invoke(anta, ["psirt", "--dry-run"], env={"ANTA_CATALOG": None})
+    with patch("anta.cli.sat.get_catalog", return_value=None):
+        result = click_runner.invoke(anta, ["sat", "--dry-run"], env={"ANTA_CATALOG": None})
 
     assert result.exit_code == 1
     assert isinstance(result.exception, RuntimeError)
-    assert str(result.exception) == "Missing catalog for anta psirt"
+    assert str(result.exception) == "Missing catalog for anta sat"
 
 
 @pytest.mark.parametrize(
     ("args", "env"),
     [
-        pytest.param(["psirt", "--dry-run", "--catalog", str(DATA_DIR / "test_catalog.yml")], {}, id="option"),
-        pytest.param(["psirt", "--dry-run"], {"ANTA_CATALOG": str(DATA_DIR / "test_catalog.yml")}, id="environment"),
+        pytest.param(["sat", "--dry-run", "--catalog", str(DATA_DIR / "test_catalog.yml")], {}, id="option"),
+        pytest.param(["sat", "--dry-run"], {"ANTA_CATALOG": str(DATA_DIR / "test_catalog.yml")}, id="environment"),
     ],
 )
-def test_anta_psirt_catalog_override(click_runner: CliRunner, args: list[str], env: dict[str, str]) -> None:
+def test_anta_sat_catalog_override(click_runner: CliRunner, args: list[str], env: dict[str, str]) -> None:
     """A file catalog replaces the built-in catalog and may contain ordinary ANTA tests."""
-    with patch("anta.cli.psirt.get_catalog") as catalog_mock:
+    with patch("anta.cli.sat.get_catalog") as catalog_mock:
         result = click_runner.invoke(anta, args, env=env)
 
     assert result.exit_code == ExitCode.OK
@@ -90,23 +90,23 @@ def test_anta_psirt_catalog_override(click_runner: CliRunner, args: list[str], e
     catalog_mock.assert_not_called()
 
 
-def test_anta_psirt_dry_run_environment_variable(click_runner: CliRunner) -> None:
-    """Use the command-specific ANTA_PSIRT_DRY_RUN environment variable."""
+def test_anta_sat_dry_run_environment_variable(click_runner: CliRunner) -> None:
+    """Use the command-specific ANTA_SAT_DRY_RUN environment variable."""
     catalog = AntaCatalog.parse(DATA_DIR / "test_catalog.yml")
-    with patch("anta.cli.psirt.get_catalog", return_value=catalog):
-        result = click_runner.invoke(anta, ["psirt"], env={"ANTA_CATALOG": None, "ANTA_PSIRT_DRY_RUN": "true"})
+    with patch("anta.cli.sat.get_catalog", return_value=catalog):
+        result = click_runner.invoke(anta, ["sat"], env={"ANTA_CATALOG": None, "ANTA_SAT_DRY_RUN": "true"})
 
     assert result.exit_code == ExitCode.OK
     assert "Dry-run" in result.output
 
 
 @pytest.mark.parametrize("report", ["csv", "json", "md-report", "table", "text", "tpl-report"])
-def test_anta_psirt_report_help(click_runner: CliRunner, report: str) -> None:
-    """Expose report commands under the PSIRT profile."""
-    result = click_runner.invoke(anta, ["psirt", report, "--help"])
+def test_anta_sat_report_help(click_runner: CliRunner, report: str) -> None:
+    """Expose report commands under the SAT profile."""
+    result = click_runner.invoke(anta, ["sat", report, "--help"])
 
     assert result.exit_code == ExitCode.OK
-    assert f"Usage: anta psirt {report}" in result.output
+    assert f"Usage: anta sat {report}" in result.output
 
 
 @pytest.mark.parametrize(
@@ -135,7 +135,7 @@ def test_anta_psirt_report_help(click_runner: CliRunner, report: str) -> None:
         ),
     ],
 )
-def test_anta_psirt_advisory_report(
+def test_anta_sat_advisory_report(
     click_runner: CliRunner,
     tmp_path: Path,
     command: str,
@@ -151,11 +151,11 @@ def test_anta_psirt_advisory_report(
     report = MagicMock()
     run_context = MagicMock()
     with (
-        patch("anta.cli.psirt.run_tests", return_value=run_context) as run_tests_mock,
-        patch("anta.cli.psirt.SecurityAdvisoryReport.from_result_manager", return_value=report) as report_mock,
-        patch(f"anta.cli.psirt.{generator}") as generator_mock,
+        patch("anta.cli.sat.run_tests", return_value=run_context) as run_tests_mock,
+        patch("anta.cli.sat.SecurityAdvisoryReport.from_result_manager", return_value=report) as report_mock,
+        patch(f"anta.cli.sat.{generator}") as generator_mock,
     ):
-        result = click_runner.invoke(anta, ["psirt", command, output_option, str(output), *extra_args])
+        result = click_runner.invoke(anta, ["sat", command, output_option, str(output), *extra_args])
 
     assert result.exit_code == ExitCode.OK
     assert f"Security advisory {label} report saved to {output}" in " ".join(result.output.split())
@@ -173,19 +173,19 @@ def test_anta_psirt_advisory_report(
         generator_mock.assert_called_once_with(report, output)
 
 
-def test_anta_psirt_advisory_report_rejects_invalid_results(click_runner: CliRunner, tmp_path: Path) -> None:
+def test_anta_sat_advisory_report_rejects_invalid_results(click_runner: CliRunner, tmp_path: Path) -> None:
     """Report invalid advisory result sets as CLI usage errors."""
     output = tmp_path / "report.csv"
     error = "Security advisory reports only support advisory test results."
-    with patch("anta.cli.psirt.run_tests"), patch("anta.cli.psirt.SecurityAdvisoryReport.from_result_manager", side_effect=ValueError(error)):
-        result = click_runner.invoke(anta, ["psirt", "csv", "--csv-output", str(output)])
+    with patch("anta.cli.sat.run_tests"), patch("anta.cli.sat.SecurityAdvisoryReport.from_result_manager", side_effect=ValueError(error)):
+        result = click_runner.invoke(anta, ["sat", "csv", "--csv-output", str(output)])
 
     assert result.exit_code == ExitCode.USAGE_ERROR
     assert error in " ".join(result.output.split())
     assert not output.exists()
 
 
-def test_anta_psirt_advisory_markdown_report_all_results_hidden(click_runner: CliRunner, tmp_path: Path) -> None:
+def test_anta_sat_advisory_markdown_report_all_results_hidden(click_runner: CliRunner, tmp_path: Path) -> None:
     """Generate only the run overview when every advisory result is hidden."""
     output = tmp_path / "report.md"
 
@@ -196,8 +196,8 @@ def test_anta_psirt_advisory_markdown_report_all_results_hidden(click_runner: Cl
         inventory.__len__.return_value = 1
         return AntaRunContext(inventory=inventory, catalog=MagicMock(), manager=manager, filters=AntaRunFilters())
 
-    with patch("anta.cli.psirt.run_tests", side_effect=run_tests_with_success):
-        result = click_runner.invoke(anta, ["psirt", "--hide", "success", "md-report", "--md-output", str(output)])
+    with patch("anta.cli.sat.run_tests", side_effect=run_tests_with_success):
+        result = click_runner.invoke(anta, ["sat", "--hide", "success", "md-report", "--md-output", str(output)])
 
     assert result.exit_code == ExitCode.OK
     content = output.read_text(encoding="utf-8")
@@ -209,16 +209,16 @@ def test_anta_psirt_advisory_markdown_report_all_results_hidden(click_runner: Cl
     assert "| **Devices Assessed** | 1 |" in content
 
 
-def test_anta_psirt_advisory_markdown_report_error(click_runner: CliRunner, tmp_path: Path) -> None:
+def test_anta_sat_advisory_markdown_report_error(click_runner: CliRunner, tmp_path: Path) -> None:
     """Report Markdown generation errors as CLI usage errors."""
     output = tmp_path / "report.md"
     error = "Unable to write the Markdown report."
     with (
-        patch("anta.cli.psirt.run_tests", return_value=MagicMock()),
-        patch("anta.cli.psirt.SecurityAdvisoryReport.from_result_manager", return_value=MagicMock()),
-        patch("anta.cli.psirt.generate_security_advisory_md_report", side_effect=OSError(error)),
+        patch("anta.cli.sat.run_tests", return_value=MagicMock()),
+        patch("anta.cli.sat.SecurityAdvisoryReport.from_result_manager", return_value=MagicMock()),
+        patch("anta.cli.sat.generate_security_advisory_md_report", side_effect=OSError(error)),
     ):
-        result = click_runner.invoke(anta, ["psirt", "md-report", "--md-output", str(output)])
+        result = click_runner.invoke(anta, ["sat", "md-report", "--md-output", str(output)])
 
     assert result.exit_code == ExitCode.USAGE_ERROR
     assert error in " ".join(result.output.split())


### PR DESCRIPTION
## Description

Rename PSIRT to SAT (Security Advisory Tests)

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the security advisory CLI command from `anta psirt` to `anta sat`.
  * Updated command help, reporting, dry-run behavior, and environment variable names to use the `ANTA_SAT_` prefix.

* **Documentation**
  * Updated CLI guides, examples, navigation, help snippets, and security advisory reporting documentation to reference `anta sat`.

* **Tests**
  * Updated CLI tests and assertions for the renamed command and environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->