### PR TITLE
fix: Test VerifyOSPFMaxLSA - TypeError

### DIFF
--- a/anta/tests/routing/ospf.py
+++ b/anta/tests/routing/ospf.py
@@ -160,7 +160,7 @@ class VerifyOSPFMaxLSA(AntaTest):
                 max_lsa_threshold = instance_data["maxLsaInformation"]["maxLsaThreshold"]
                 num_lsa = get_value(instance_data, "lsaInformation.numLsa")
                 if num_lsa is None:
-                    self.result.is_failure(f"Instance: {instance} - LSA information not found")
+                    self.result.is_failure(f"Instance: {instance} - Current number of LSAs not found")
                     continue
                 if num_lsa > (max_lsa_threshold := round(max_lsa * (max_lsa_threshold / 100))):
                     self.result.is_failure(f"Instance: {instance} - Crossed the maximum LSA threshold - Expected: < {max_lsa_threshold} Actual: {num_lsa}")

--- a/anta/tests/routing/ospf.py
+++ b/anta/tests/routing/ospf.py
@@ -159,6 +159,9 @@ class VerifyOSPFMaxLSA(AntaTest):
                 max_lsa = instance_data["maxLsaInformation"]["maxLsa"]
                 max_lsa_threshold = instance_data["maxLsaInformation"]["maxLsaThreshold"]
                 num_lsa = get_value(instance_data, "lsaInformation.numLsa")
+                if num_lsa is None:
+                    self.result.is_failure(f"Instance: {instance} - LSA information not found")
+                    continue
                 if num_lsa > (max_lsa_threshold := round(max_lsa * (max_lsa_threshold / 100))):
                     self.result.is_failure(f"Instance: {instance} - Crossed the maximum LSA threshold - Expected: < {max_lsa_threshold} Actual: {num_lsa}")
 

--- a/tests/units/anta_tests/routing/test_ospf.py
+++ b/tests/units/anta_tests/routing/test_ospf.py
@@ -355,7 +355,7 @@ DATA: AntaUnitTestData = {
         ],
         "expected": {
             "result": AntaTestStatus.FAILURE,
-            "messages": ["Instance: 1 - LSA information not found"],
+            "messages": ["Instance: 1 - Current number of LSAs not found"],
         },
     },
     (VerifyOSPFMaxLSA, "skipped"): {"eos_data": [{"vrfs": {}}], "expected": {"result": AntaTestStatus.SKIPPED, "messages": ["OSPF not configured"]}},

--- a/tests/units/anta_tests/routing/test_ospf.py
+++ b/tests/units/anta_tests/routing/test_ospf.py
@@ -337,6 +337,27 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
+    (VerifyOSPFMaxLSA, "failure-lsa-information-missing"): {
+        "eos_data": [
+            {
+                "vrfs": {
+                    "default": {
+                        "instList": {
+                            "1": {
+                                "instanceId": 1,
+                                "maxLsaInformation": {"maxLsa": 12000, "maxLsaThreshold": 75},
+                                "routerId": "1.1.1.1",
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Instance: 1 - LSA information not found"],
+        },
+    },
     (VerifyOSPFMaxLSA, "skipped"): {"eos_data": [{"vrfs": {}}], "expected": {"result": AntaTestStatus.SKIPPED, "messages": ["OSPF not configured"]}},
     (VerifyOSPFSpecificNeighbors, "success"): {
         "eos_data": [


### PR DESCRIPTION
## Description
Fix: VerifyOSPFMaxLSA.test() — TypeError

Fixes #1622 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OSPF validation when LSA information is unavailable.
  * Reports a clear failure message instead of attempting an invalid threshold comparison.
* **Tests**
  * Added coverage for OSPF instances missing LSA information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->