### PR TITLE
fix: Test VerifyBFDPeersIntervals -TypeError

### DIFF
--- a/anta/tests/bfd.py
+++ b/anta/tests/bfd.py
@@ -194,11 +194,15 @@ class VerifyBFDPeersIntervals(AntaTest):
                 self.result.is_failure(f"{bfd_peer} - Not found")
                 continue
 
+            if (peer_stats_detail := peer_stats.get("peerStatsDetail")) is None:
+                self.result.is_failure(f"{bfd_peer} - Peer stats detail not found")
+                continue
+
             # Convert interval timers into milliseconds to be consistent with the inputs
-            act_tx_interval = get_value(peer_stats, "peerStatsDetail.operTxInterval") // 1000
-            act_rx_interval = get_value(peer_stats, "peerStatsDetail.operRxInterval") // 1000
-            act_detect_time = get_value(peer_stats, "peerStatsDetail.detectTime") // 1000
-            act_detect_mult = get_value(peer_stats, "peerStatsDetail.detectMult")
+            act_tx_interval = peer_stats_detail["operTxInterval"] // 1000
+            act_rx_interval = peer_stats_detail["operRxInterval"] // 1000
+            act_detect_time = peer_stats_detail["detectTime"] // 1000
+            act_detect_mult = peer_stats_detail["detectMult"]
 
             if act_tx_interval != bfd_peer.tx_interval:
                 self.result.is_failure(f"{bfd_peer} - Incorrect Transmit interval - Expected: {bfd_peer.tx_interval} Actual: {act_tx_interval}")

--- a/tests/units/anta_tests/test_bfd.py
+++ b/tests/units/anta_tests/test_bfd.py
@@ -317,6 +317,14 @@ DATA: AntaUnitTestData = {
             ],
         },
     },
+    (VerifyBFDPeersIntervals, "failure-peer-stats-detail-missing"): {
+        "eos_data": [{"vrfs": {"default": {"ipv4Neighbors": {"192.0.255.7": {"peerStats": {"": {}}}}}}}],
+        "inputs": {"bfd_peers": [{"peer_address": "192.0.255.7", "vrf": "default", "tx_interval": 1200, "rx_interval": 1200, "multiplier": 3}]},
+        "expected": {
+            "result": AntaTestStatus.FAILURE,
+            "messages": ["Peer: 192.0.255.7 VRF: default - Peer stats detail not found"],
+        },
+    },
     (VerifyBFDSpecificPeers, "success"): {
         "eos_data": [
             {


### PR DESCRIPTION
## Description
fix: Test VerifyBFDPeersIntervals -TypeError
Fixes #1620 

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BFD peer interval validation when peer statistics details are missing.
  * Reports a clear failure message identifying the affected peer and VRF instead of attempting to read unavailable timer values.

* **Tests**
  * Added coverage for BFD data where peer statistics details are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->