### PR TITLE
ci: Manage documentation version lifecycle

### DIFF
--- a/.github/workflows/main-doc.yml
+++ b/.github/workflows/main-doc.yml
@@ -25,6 +25,7 @@ jobs:
     concurrency:
       group: documentation-gh-pages
       cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/main-doc.yml
+++ b/.github/workflows/main-doc.yml
@@ -8,7 +8,6 @@ on:
     paths:
       # Run only if any of the following paths are changed when pushing to main
       - ".github/workflows/main-doc.yml"
-      - ".github/workflows/release.yml"
       - "tools/zensical_extensions/**"
       - "docs/**"
       - "mkdocs.yml"
@@ -46,25 +45,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          SOURCE_ROOT="$PWD"
-          # Mike writes directly to the gh-pages ref without checking it out.
-          # Use a temporary worktree so the generated deployment can be
-          # normalized and amended before it is pushed once.
-          DEPLOY_TEMP_ROOT="$(mktemp -d)"
-          DEPLOY_WORKTREE="${DEPLOY_TEMP_ROOT}/gh-pages"
-          cleanup() {
-            git worktree remove --force "$DEPLOY_WORKTREE" 2>/dev/null || true
-            rmdir "$DEPLOY_TEMP_ROOT" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           pip install --group doc -e tools/zensical_extensions
-          mike deploy main
-          git worktree add "$DEPLOY_WORKTREE" gh-pages
-          python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE"
-          git -C "$DEPLOY_WORKTREE" add --all
-          if ! git -C "$DEPLOY_WORKTREE" diff --cached --quiet; then
-            git -C "$DEPLOY_WORKTREE" commit --amend --no-edit
-          fi
-          git -C "$DEPLOY_WORKTREE" push origin HEAD:gh-pages
+          docs/scripts/deploy_doc_version.sh main

--- a/.github/workflows/main-doc.yml
+++ b/.github/workflows/main-doc.yml
@@ -7,6 +7,8 @@ on:
       - main
     paths:
       # Run only if any of the following paths are changed when pushing to main
+      - ".github/workflows/main-doc.yml"
+      - ".github/workflows/release.yml"
       - "tools/zensical_extensions/**"
       - "docs/**"
       - "mkdocs.yml"
@@ -21,6 +23,9 @@ jobs:
   'build_latest_doc':
     name: 'Update Public main documentation'
     runs-on: ubuntu-latest
+    concurrency:
+      group: documentation-gh-pages
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -41,6 +46,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-            pip install --group doc -e tools/zensical_extensions
-            mike deploy --push main
+          SOURCE_ROOT="$PWD"
+          # Mike writes directly to the gh-pages ref without checking it out.
+          # Use a temporary worktree so the generated deployment can be
+          # normalized and amended before it is pushed once.
+          DEPLOY_TEMP_ROOT="$(mktemp -d)"
+          DEPLOY_WORKTREE="${DEPLOY_TEMP_ROOT}/gh-pages"
+          cleanup() {
+            git worktree remove --force "$DEPLOY_WORKTREE" 2>/dev/null || true
+            rmdir "$DEPLOY_TEMP_ROOT" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          pip install --group doc -e tools/zensical_extensions
+          mike deploy main
+          git worktree add "$DEPLOY_WORKTREE" gh-pages
+          python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE"
+          git -C "$DEPLOY_WORKTREE" add --all
+          if ! git -C "$DEPLOY_WORKTREE" diff --cached --quiet; then
+            git -C "$DEPLOY_WORKTREE" commit --amend --no-edit
+          fi
+          git -C "$DEPLOY_WORKTREE" push origin HEAD:gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,7 @@ jobs:
     concurrency:
       group: documentation-gh-pages
       cancel-in-progress: false
+      queue: max
     # Release doc only if successfully deployed to Pypi
     needs: [publish-anta-pypi]
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,9 @@ jobs:
   release-doc:
     name: "Publish documentation for release ${{github.ref_name}}"
     runs-on: ubuntu-latest
+    concurrency:
+      group: documentation-gh-pages
+      cancel-in-progress: false
     # Release doc only if successfully deployed to Pypi
     needs: [publish-anta-pypi]
     permissions:
@@ -191,13 +194,36 @@ jobs:
           PRERELEASE: ${{ github.event.release.prerelease }}
           REF_NAME: ${{ github.ref_name }}
         run: |
+          SOURCE_ROOT="$PWD"
+          # Mike writes directly to the gh-pages ref without checking it out.
+          # Use a temporary worktree so the generated deployment can be
+          # normalized and amended before it is pushed once.
+          DEPLOY_TEMP_ROOT="$(mktemp -d)"
+          DEPLOY_WORKTREE="${DEPLOY_TEMP_ROOT}/gh-pages"
+          cleanup() {
+            git worktree remove --force "$DEPLOY_WORKTREE" 2>/dev/null || true
+            rmdir "$DEPLOY_TEMP_ROOT" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           pip install --group doc -e tools/zensical_extensions
           if [[ "$PRERELEASE" == "true" ]]; then
-            mike deploy --push "$REF_NAME"
+            mike deploy "$REF_NAME"
           else
-            mike deploy --update-alias --push "$REF_NAME" stable
+            mike deploy --update-alias "$REF_NAME" stable
           fi
+          git worktree add "$DEPLOY_WORKTREE" gh-pages
+          if [[ "$PRERELEASE" == "true" ]]; then
+            python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE"
+          else
+            python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE" --final-version "$REF_NAME"
+          fi
+          git -C "$DEPLOY_WORKTREE" add --all
+          if ! git -C "$DEPLOY_WORKTREE" diff --cached --quiet; then
+            git -C "$DEPLOY_WORKTREE" commit --amend --no-edit
+          fi
+          git -C "$DEPLOY_WORKTREE" push origin HEAD:gh-pages
 
   docker:
     name: Docker Image Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,36 +194,13 @@ jobs:
           PRERELEASE: ${{ github.event.release.prerelease }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          SOURCE_ROOT="$PWD"
-          # Mike writes directly to the gh-pages ref without checking it out.
-          # Use a temporary worktree so the generated deployment can be
-          # normalized and amended before it is pushed once.
-          DEPLOY_TEMP_ROOT="$(mktemp -d)"
-          DEPLOY_WORKTREE="${DEPLOY_TEMP_ROOT}/gh-pages"
-          cleanup() {
-            git worktree remove --force "$DEPLOY_WORKTREE" 2>/dev/null || true
-            rmdir "$DEPLOY_TEMP_ROOT" 2>/dev/null || true
-          }
-          trap cleanup EXIT
-
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           pip install --group doc -e tools/zensical_extensions
           if [[ "$PRERELEASE" == "true" ]]; then
-            mike deploy "$REF_NAME"
+            docs/scripts/deploy_doc_version.sh "$REF_NAME"
           else
-            mike deploy --update-alias "$REF_NAME" stable
+            docs/scripts/deploy_doc_version.sh "$REF_NAME" --final
           fi
-          git worktree add "$DEPLOY_WORKTREE" gh-pages
-          if [[ "$PRERELEASE" == "true" ]]; then
-            python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE"
-          else
-            python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE" --final-version "$REF_NAME"
-          fi
-          git -C "$DEPLOY_WORKTREE" add --all
-          if ! git -C "$DEPLOY_WORKTREE" diff --cached --quiet; then
-            git -C "$DEPLOY_WORKTREE" commit --amend --no-edit
-          fi
-          git -C "$DEPLOY_WORKTREE" push origin HEAD:gh-pages
 
   docker:
     name: Docker Image Build

--- a/docs/scripts/deploy_doc_version.sh
+++ b/docs/scripts/deploy_doc_version.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 VERSION [--final]" >&2
+}
+
+if (( $# < 1 || $# > 2 )); then
+  usage
+  exit 2
+fi
+
+VERSION="$1"
+FINAL_RELEASE=false
+if (( $# == 2 )); then
+  if [[ "$2" != "--final" ]]; then
+    usage
+    exit 2
+  fi
+  FINAL_RELEASE=true
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+DEPLOY_TEMP_ROOT="$(mktemp -d)"
+DEPLOY_WORKTREE="${DEPLOY_TEMP_ROOT}/gh-pages"
+
+cleanup() {
+  git -C "$SOURCE_ROOT" worktree remove --force "$DEPLOY_WORKTREE" 2>/dev/null || true
+  rmdir "$DEPLOY_TEMP_ROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cd "$SOURCE_ROOT"
+
+if [[ "$FINAL_RELEASE" == "true" ]]; then
+  mike deploy --update-alias "$VERSION" stable
+else
+  mike deploy "$VERSION"
+fi
+
+# Mike writes directly to the local gh-pages ref using git fast-import, without
+# checking out the branch. A temporary worktree exposes that generated tree to
+# the version normalizer while leaving the source checkout untouched. Nothing
+# is pushed until normalization has completed, so the remote sees only the
+# final deployment state.
+git worktree add "$DEPLOY_WORKTREE" gh-pages
+if [[ "$FINAL_RELEASE" == "true" ]]; then
+  python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE" --final-version "$VERSION"
+else
+  python "$SOURCE_ROOT/docs/scripts/manage_doc_versions.py" "$DEPLOY_WORKTREE"
+fi
+
+git -C "$DEPLOY_WORKTREE" add --all
+if ! git -C "$DEPLOY_WORKTREE" diff --cached --quiet; then
+  # Mike treats an identical deployment as an empty commit and restores the
+  # previous gh-pages tip. Never amend here: in that case amend would rewrite
+  # an already-published commit instead of recording normalization separately.
+  git -C "$DEPLOY_WORKTREE" -c commit.gpgsign=false commit -m "Normalize documentation versions after deployment"
+fi
+
+git -C "$DEPLOY_WORKTREE" push origin HEAD:gh-pages

--- a/docs/scripts/manage_doc_versions.py
+++ b/docs/scripts/manage_doc_versions.py
@@ -25,6 +25,23 @@ class VersionMetadataError(ValueError):
     """Raised when deployed documentation metadata is unsafe or malformed."""
 
 
+def _entry_identifiers(entry: VersionEntry) -> list[str]:
+    """Return the version and alias identifiers for a metadata entry."""
+    return [entry["version"], *entry["aliases"]]
+
+
+def _unique_identifiers(entries: list[VersionEntry]) -> list[str]:
+    """Return deployment identifiers, preserving order and dropping duplicates."""
+    identifiers: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        for identifier in _entry_identifiers(entry):
+            if identifier not in seen:
+                seen.add(identifier)
+                identifiers.append(identifier)
+    return identifiers
+
+
 def _parse_version(identifier: str) -> Version | None:
     """Parse a deployed version, treating ``main`` as a special version."""
     if identifier == MAIN_VERSION:
@@ -44,7 +61,7 @@ def _validate_entries(entries: object) -> list[tuple[VersionEntry, Version | Non
         raise VersionMetadataError(msg)
 
     validated: list[tuple[VersionEntry, Version | None]] = []
-    seen_versions: set[str] = set()
+    identifier_owners: dict[str, str] = {}
 
     for entry in entries:
         if not isinstance(entry, dict):
@@ -57,11 +74,14 @@ def _validate_entries(entries: object) -> list[tuple[VersionEntry, Version | Non
         if not isinstance(version, str) or not isinstance(title, str) or not isinstance(aliases, list) or not all(isinstance(alias, str) for alias in aliases):
             msg = "Each versions.json entry must contain string version/title fields and a list of string aliases"
             raise VersionMetadataError(msg)
-        if version in seen_versions:
-            msg = f"Duplicate deployed documentation version: {version!r}"
-            raise VersionMetadataError(msg)
 
-        seen_versions.add(version)
+        for identifier in _entry_identifiers(entry):
+            owner = identifier_owners.get(identifier)
+            if owner is not None:
+                msg = f"Duplicate deployed documentation identifier {identifier!r} owned by {owner!r} and {version!r}"
+                raise VersionMetadataError(msg)
+            identifier_owners[identifier] = version
+
         validated.append((entry, _parse_version(version)))
 
     return validated
@@ -131,7 +151,7 @@ def manage_doc_versions(deployment_root: Path, final_version: str | None = None)
         raise VersionMetadataError(msg) from error
 
     ordered_entries, removed_entries = order_and_filter_versions(entries, final_version)
-    paths_to_remove = [_safe_deployment_path(deployment_root, identifier) for entry in removed_entries for identifier in [entry["version"], *entry["aliases"]]]
+    paths_to_remove = [_safe_deployment_path(deployment_root, identifier) for identifier in _unique_identifiers(removed_entries)]
 
     for path in paths_to_remove:
         if path.is_symlink() or path.is_file():

--- a/docs/scripts/manage_doc_versions.py
+++ b/docs/scripts/manage_doc_versions.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Order deployed documentation versions and remove superseded prereleases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+from packaging.version import InvalidVersion, Version
+
+LOGGER = logging.getLogger(__name__)
+MAIN_VERSION = "main"
+
+VersionEntry = dict[str, Any]
+
+
+class VersionMetadataError(ValueError):
+    """Raised when deployed documentation metadata is unsafe or malformed."""
+
+
+def _parse_version(identifier: str) -> Version | None:
+    """Parse a deployed version, treating ``main`` as a special version."""
+    if identifier == MAIN_VERSION:
+        return None
+
+    try:
+        return Version(identifier.removeprefix("v"))
+    except InvalidVersion as error:
+        msg = f"Invalid deployed documentation version: {identifier!r}"
+        raise VersionMetadataError(msg) from error
+
+
+def _validate_entries(entries: object) -> list[tuple[VersionEntry, Version | None]]:
+    """Validate and parse entries from ``versions.json``."""
+    if not isinstance(entries, list):
+        msg = "versions.json must contain a list"
+        raise VersionMetadataError(msg)
+
+    validated: list[tuple[VersionEntry, Version | None]] = []
+    seen_versions: set[str] = set()
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            msg = "Each versions.json entry must be an object"
+            raise VersionMetadataError(msg)
+
+        version = entry.get("version")
+        title = entry.get("title")
+        aliases = entry.get("aliases")
+        if not isinstance(version, str) or not isinstance(title, str) or not isinstance(aliases, list) or not all(isinstance(alias, str) for alias in aliases):
+            msg = "Each versions.json entry must contain string version/title fields and a list of string aliases"
+            raise VersionMetadataError(msg)
+        if version in seen_versions:
+            msg = f"Duplicate deployed documentation version: {version!r}"
+            raise VersionMetadataError(msg)
+
+        seen_versions.add(version)
+        validated.append((entry, _parse_version(version)))
+
+    return validated
+
+
+# The pinned Zensical-compatible Mike fork always rewrites versions.json using
+# a hard-coded reverse LooseVersion sort in mike.versions.Versions.__iter__.
+# It provides no CLI or configuration hook to append, position, or otherwise
+# order versions. Keep this post-processing workaround until Mike exposes a
+# supported ordering mechanism.
+def order_and_filter_versions(entries: object, final_version: str | None = None) -> tuple[list[VersionEntry], list[VersionEntry]]:
+    """Order version entries and select same-base prereleases for removal."""
+    validated = _validate_entries(entries)
+    removed: list[VersionEntry] = []
+
+    if final_version is not None:
+        parsed_final = _parse_version(final_version)
+        if parsed_final is None or parsed_final.is_prerelease:
+            msg = f"Cleanup requires a final PEP 440 release version, got {final_version!r}"
+            raise VersionMetadataError(msg)
+        if final_version not in {entry["version"] for entry, _ in validated}:
+            msg = f"Final documentation version {final_version!r} is not deployed"
+            raise VersionMetadataError(msg)
+
+        retained: list[tuple[VersionEntry, Version | None]] = []
+        for entry, parsed_version in validated:
+            if parsed_version is not None and parsed_version.is_prerelease and parsed_version.base_version == parsed_final.base_version:
+                removed.append(entry)
+            else:
+                retained.append((entry, parsed_version))
+        validated = retained
+
+    main_entries = [entry for entry, parsed_version in validated if parsed_version is None]
+    finals = sorted(
+        ((entry, parsed_version) for entry, parsed_version in validated if parsed_version is not None and not parsed_version.is_prerelease),
+        key=lambda item: item[1],
+        reverse=True,
+    )
+    prereleases = sorted(
+        ((entry, parsed_version) for entry, parsed_version in validated if parsed_version is not None and parsed_version.is_prerelease),
+        key=lambda item: item[1],
+        reverse=True,
+    )
+    return [*main_entries, *(entry for entry, _ in finals), *(entry for entry, _ in prereleases)], removed
+
+
+def _safe_deployment_path(deployment_root: Path, identifier: str) -> Path:
+    """Resolve a safe, top-level version or alias path."""
+    if not identifier or identifier in {".", ".."} or Path(identifier).name != identifier or "/" in identifier or "\\" in identifier:
+        msg = f"Unsafe deployed documentation path: {identifier!r}"
+        raise VersionMetadataError(msg)
+
+    path = deployment_root / identifier
+    if not path.exists() and not path.is_symlink():
+        msg = f"Deployed documentation path does not exist: {path}"
+        raise VersionMetadataError(msg)
+    return path
+
+
+def manage_doc_versions(deployment_root: Path, final_version: str | None = None) -> list[str]:
+    """Normalize ``versions.json`` and remove superseded prerelease content."""
+    versions_path = deployment_root / "versions.json"
+    try:
+        entries = json.loads(versions_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        msg = f"Unable to read deployed documentation metadata from {versions_path}"
+        raise VersionMetadataError(msg) from error
+
+    ordered_entries, removed_entries = order_and_filter_versions(entries, final_version)
+    paths_to_remove = [_safe_deployment_path(deployment_root, identifier) for entry in removed_entries for identifier in [entry["version"], *entry["aliases"]]]
+
+    for path in paths_to_remove:
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+
+    versions_path.write_text(f"{json.dumps(ordered_entries, indent=2)}\n", encoding="utf-8")
+    removed_versions = [entry["version"] for entry in removed_entries]
+    if removed_versions:
+        LOGGER.info("Removed superseded documentation versions: %s", ", ".join(removed_versions))
+    LOGGER.info("Documentation version order: %s", ", ".join(entry["version"] for entry in ordered_entries))
+    return removed_versions
+
+
+def main() -> None:
+    """Run documentation version management from the command line."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("deployment_root", type=Path, help="Checked-out documentation deployment root")
+    parser.add_argument("--final-version", help="Final release whose same-base prerelease documentation should be removed")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    manage_doc_versions(args.deployment_root, args.final_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ doc = [
   "griffe >=2.2.0,<2.3",
   "griffe-warnings-deprecated~=1.1.1",
   "mike @ git+https://github.com/squidfunk/mike.git@2d4ad799442f4592db8ad53b179bfb33db8c69ac",
+  "packaging>=24",
   "zensical==0.0.57",
   "mkdocs~=1.6",
   "mkdocs-autorefs~=1.4",

--- a/tests/units/test_manage_doc_versions.py
+++ b/tests/units/test_manage_doc_versions.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from docs.scripts.manage_doc_versions import VersionMetadataError, manage_doc_versions, order_and_filter_versions
+from docs.scripts.manage_doc_versions import VersionMetadataError, _unique_identifiers, manage_doc_versions, order_and_filter_versions
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -27,6 +27,12 @@ def entry(version: str, *, aliases: list[str] | None = None, properties: dict[st
 def version_names(entries: list[dict[str, Any]]) -> list[str]:
     """Return version names from metadata entries."""
     return [version_entry["version"] for version_entry in entries]
+
+
+def test_unique_identifiers_preserves_order_and_drops_duplicates() -> None:
+    """Cleanup should delete each deployment identifier at most once."""
+    entries = [entry("v1.10.0.dev1", aliases=["candidate", "v1.10.0.dev1"]), entry("v1.10.0.dev2", aliases=["candidate"])]
+    assert _unique_identifiers(entries) == ["v1.10.0.dev1", "candidate", "v1.10.0.dev2"]
 
 
 def test_order_versions_keeps_main_and_finals_before_prereleases() -> None:
@@ -89,6 +95,12 @@ def test_cleanup_requires_a_deployed_final_version(final_version: str) -> None:
         order_and_filter_versions([entry("main"), entry("v1.10.0")], final_version)
 
 
+def test_cleanup_rejects_undeployed_final_version() -> None:
+    """Cleanup should reject a valid final version that is not deployed."""
+    with pytest.raises(VersionMetadataError, match="is not deployed"):
+        order_and_filter_versions([entry("main"), entry("v1.10.0")], "v9.9.9")
+
+
 def test_cleanup_rejects_unsafe_alias_before_removing_content(tmp_path: Path) -> None:
     """Unsafe aliases should fail without deleting already validated content."""
     prerelease_path = tmp_path / "v1.10.0.dev1"
@@ -102,11 +114,29 @@ def test_cleanup_rejects_unsafe_alias_before_removing_content(tmp_path: Path) ->
     assert prerelease_path.exists()
 
 
+def test_cleanup_rejects_identifier_collision_before_removing_content(tmp_path: Path) -> None:
+    """A prerelease alias must not collide with a retained version path."""
+    prerelease_path = tmp_path / "v1.10.0.dev1"
+    retained_path = tmp_path / "v1.9.0"
+    prerelease_path.mkdir()
+    retained_path.mkdir()
+    versions = [entry("main"), entry("v1.10.0"), entry("v1.9.0"), entry("v1.10.0.dev1", aliases=["v1.9.0"])]
+    (tmp_path / "versions.json").write_text(json.dumps(versions), encoding="utf-8")
+
+    with pytest.raises(VersionMetadataError, match="Duplicate deployed documentation identifier"):
+        manage_doc_versions(tmp_path, "v1.10.0")
+
+    assert prerelease_path.exists()
+    assert retained_path.exists()
+
+
 def test_invalid_metadata_is_rejected() -> None:
     """Malformed or duplicate version metadata should fail clearly."""
     with pytest.raises(VersionMetadataError, match="must contain a list"):
         order_and_filter_versions({})
     with pytest.raises(VersionMetadataError, match="Duplicate"):
         order_and_filter_versions([entry("main"), entry("main")])
+    with pytest.raises(VersionMetadataError, match="Duplicate deployed documentation identifier"):
+        order_and_filter_versions([entry("v1.9.0", aliases=["stable"]), entry("v1.10.0.dev1", aliases=["stable"])])
     with pytest.raises(VersionMetadataError, match="Invalid deployed"):
         order_and_filter_versions([entry("invalid")])

--- a/tests/units/test_manage_doc_versions.py
+++ b/tests/units/test_manage_doc_versions.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Tests for documentation version management."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from docs.scripts.manage_doc_versions import VersionMetadataError, manage_doc_versions, order_and_filter_versions
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def entry(version: str, *, aliases: list[str] | None = None, properties: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Create a versions.json entry."""
+    version_entry: dict[str, Any] = {"version": version, "title": version, "aliases": aliases or []}
+    if properties is not None:
+        version_entry["properties"] = properties
+    return version_entry
+
+
+def version_names(entries: list[dict[str, Any]]) -> list[str]:
+    """Return version names from metadata entries."""
+    return [version_entry["version"] for version_entry in entries]
+
+
+def test_order_versions_keeps_main_and_finals_before_prereleases() -> None:
+    """Versions should be sorted within the main, final, and prerelease groups."""
+    stable_properties = {"channel": "stable"}
+    entries = [
+        entry("v1.10.0.dev1"),
+        entry("v1.8.0"),
+        entry("main"),
+        entry("v1.10.0rc1"),
+        entry("v1.9.0", aliases=["stable"], properties=stable_properties),
+        entry("v1.10.0.dev3"),
+        entry("v1.10.0.dev2"),
+    ]
+
+    ordered, removed = order_and_filter_versions(entries)
+
+    assert version_names(ordered) == ["main", "v1.9.0", "v1.8.0", "v1.10.0rc1", "v1.10.0.dev3", "v1.10.0.dev2", "v1.10.0.dev1"]
+    assert ordered[1]["aliases"] == ["stable"]
+    assert ordered[1]["properties"] == stable_properties
+    assert not removed
+
+
+def test_manage_versions_removes_same_base_prereleases_and_paths(tmp_path: Path) -> None:
+    """A final release should remove all same-base PEP 440 prerelease documentation."""
+    versions = [
+        entry("main"),
+        entry("v1.10.0", aliases=["stable"]),
+        entry("v1.10.0rc1", aliases=["candidate"]),
+        entry("v1.10.0b1"),
+        entry("v1.10.0a1"),
+        entry("v1.10.0.dev1"),
+        entry("v1.9.0"),
+        entry("v1.11.0.dev1"),
+    ]
+    (tmp_path / "versions.json").write_text(json.dumps(versions), encoding="utf-8")
+    removed_paths = ["v1.10.0rc1", "candidate", "v1.10.0b1", "v1.10.0a1", "v1.10.0.dev1"]
+    for path_name in removed_paths:
+        path = tmp_path / path_name
+        if path_name == "candidate":
+            path.write_text("alias", encoding="utf-8")
+        else:
+            path.mkdir()
+            (path / "index.html").write_text(path_name, encoding="utf-8")
+
+    removed = manage_doc_versions(tmp_path, "v1.10.0")
+
+    assert removed == ["v1.10.0rc1", "v1.10.0b1", "v1.10.0a1", "v1.10.0.dev1"]
+    assert all(not (tmp_path / path_name).exists() for path_name in removed_paths)
+    managed = json.loads((tmp_path / "versions.json").read_text(encoding="utf-8"))
+    assert version_names(managed) == ["main", "v1.10.0", "v1.9.0", "v1.11.0.dev1"]
+
+    assert manage_doc_versions(tmp_path, "v1.10.0") == []
+
+
+@pytest.mark.parametrize("final_version", ["main", "v1.10.0.dev1", "not-a-version"])
+def test_cleanup_requires_a_deployed_final_version(final_version: str) -> None:
+    """Cleanup should reject non-final and invalid release identifiers."""
+    with pytest.raises(VersionMetadataError):
+        order_and_filter_versions([entry("main"), entry("v1.10.0")], final_version)
+
+
+def test_cleanup_rejects_unsafe_alias_before_removing_content(tmp_path: Path) -> None:
+    """Unsafe aliases should fail without deleting already validated content."""
+    prerelease_path = tmp_path / "v1.10.0.dev1"
+    prerelease_path.mkdir()
+    versions = [entry("main"), entry("v1.10.0"), entry("v1.10.0.dev1", aliases=["../outside"])]
+    (tmp_path / "versions.json").write_text(json.dumps(versions), encoding="utf-8")
+
+    with pytest.raises(VersionMetadataError, match="Unsafe deployed documentation path"):
+        manage_doc_versions(tmp_path, "v1.10.0")
+
+    assert prerelease_path.exists()
+
+
+def test_invalid_metadata_is_rejected() -> None:
+    """Malformed or duplicate version metadata should fail clearly."""
+    with pytest.raises(VersionMetadataError, match="must contain a list"):
+        order_and_filter_versions({})
+    with pytest.raises(VersionMetadataError, match="Duplicate"):
+        order_and_filter_versions([entry("main"), entry("main")])
+    with pytest.raises(VersionMetadataError, match="Invalid deployed"):
+        order_and_filter_versions([entry("invalid")])


### PR DESCRIPTION
## Description

Keep development documentation versions below final releases in the version selector, and remove superseded prerelease deployments when publishing a final release. Documentation deployments are serialized, normalized before one explicit push, and shared between the main and release workflows.

Issue: N/A — this is CI and documentation deployment maintenance with no linked issue.

## Review follow-up

- Validate unique ownership of every deployed version and alias before cleanup.
- Use a shared deployment helper for the main and release workflows.
- Record normalization in a new commit instead of amending, because an identical Mike deployment creates no commit.
- Remove the release workflow from the main documentation path trigger.

## Validation

- `uv run --group test pytest tests/units/test_manage_doc_versions.py -q` — 10 passed
- `uv run --group doc --with-editable tools/zensical_extensions zensical build --clean --strict` — no issues found
- `pre-commit run --all-files` — passed, including zizmor
- Disposable local-remote deployment tests covered a complete no-op and the no-Mike-commit normalization case without rewriting the published tip

## Documentation

No user-facing documentation content changes are required; this PR changes documentation deployment and version lifecycle tooling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing
- [x] I have added and retained tests that prove the version-management behavior
- [x] Targeted unit tests and the strict documentation build pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation release handling, including consistent version ordering and cleanup of matching prereleases.
  * Added validation to prevent invalid, duplicate, or unsafe documentation version metadata.
  * Documentation deployments are now serialized to avoid conflicting releases.
  * Added support for distinguishing final and prerelease deployments.

* **Bug Fixes**
  * Prevented documentation cleanup when release metadata or deployment paths are invalid.

* **Tests**
  * Added coverage for version ordering, validation, cleanup, aliases, and deployment safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->