### PR TITLE
fix(anta): Classify 720XPM in 722XPM family

### DIFF
--- a/anta/_eos/platform.py
+++ b/anta/_eos/platform.py
@@ -65,7 +65,6 @@ class PlatformFamily(str, Enum):
 
     SERIES_720_D = "720D Series"
     SERIES_720_XP = "720XP Series"
-    SERIES_720_XPM = "720XPM Series"
     SERIES_720_XDM = "720XDM Series"
     SERIES_722_XPM = "722XPM Series"
     SERIES_755_758 = "755/758 Series"
@@ -216,9 +215,8 @@ def _module_rule(role: PlatformComponentRole, *patterns: str) -> _ModuleFamilyRu
 SYSTEM_PLATFORM_RULES: tuple[_SystemPlatformRule, ...] = (
     _system_rule(PlatformType.FIXED, r"^CCS-720D[FTP]-.*$", families=(PlatformFamily.SERIES_720_D,)),
     _system_rule(PlatformType.FIXED, r"^CCS-720XP-.*$", families=(PlatformFamily.SERIES_720_XP,)),
-    _system_rule(PlatformType.FIXED, r"^CCS-720XPM-.*$", families=(PlatformFamily.SERIES_720_XPM,)),
     _system_rule(PlatformType.FIXED, r"^CCS-720XDM-.*$", families=(PlatformFamily.SERIES_720_XDM,)),
-    _system_rule(PlatformType.FIXED, r"^CCS-722XPM-.*$", families=(PlatformFamily.SERIES_722_XPM,)),
+    _system_rule(PlatformType.FIXED, r"^CCS-72[02]XPM-.*$", families=(PlatformFamily.SERIES_722_XPM,)),
     _system_rule(PlatformType.CHASSIS, r"^CCS-75[58]-CH.*$", families=(PlatformFamily.SERIES_755_758,)),
     _system_rule(PlatformType.FIXED, r"^CCS-710[A-Z0-9]*-.*$", families=(PlatformFamily.SERIES_710,)),
     _system_rule(PlatformType.FIXED, r"^DCS-7010T-.*$", families=(PlatformFamily.SERIES_7010,)),

--- a/tests/units/_eos/test_platform.py
+++ b/tests/units/_eos/test_platform.py
@@ -55,7 +55,7 @@ def test_every_platform_family_has_resolution_rules() -> None:
     ("family", "role", "positive", "negative"),
     [
         pytest.param(PlatformFamily.SERIES_720_D, None, "ccs-720df-48y6", "CCS-720XP-48ZC2", id="720d"),
-        pytest.param(PlatformFamily.SERIES_720_XPM, None, "CCS-720XPM-48TH-6SY-F", "CCS-722XPM-48TH-6SY-F", id="720xpm"),
+        pytest.param(PlatformFamily.SERIES_722_XPM, None, "CCS-720XPM-48TH-6SY-F", "CCS-720XDM-48ZC2-F", id="722xpm"),
         pytest.param(PlatformFamily.SERIES_720_XDM, None, "CCS-720XDM-48ZC2-F", "CCS-720XP-48ZC2-F", id="720xdm"),
         pytest.param(PlatformFamily.SERIES_710, None, "CCS-710P-16P", "DCS-7010T-48", id="710"),
         pytest.param(PlatformFamily.SERIES_7020_R4, None, "DCS-7020HR4M-48", "DCS-7020SR-32C2", id="7020r4"),
@@ -134,7 +134,7 @@ def test_parse_fixed_platform_from_show_version() -> None:
 @pytest.mark.parametrize(
     ("model", "platform_type", "family"),
     [
-        pytest.param("CCS-720XPM-48TH-6SY-F", PlatformType.FIXED, PlatformFamily.SERIES_720_XPM, id="720xpm"),
+        pytest.param("CCS-720XPM-48TH-6SY-F", PlatformType.FIXED, PlatformFamily.SERIES_722_XPM, id="720xpm"),
         pytest.param("CCS-722XPM-48TH-6SY-F", PlatformType.FIXED, PlatformFamily.SERIES_722_XPM, id="722xpm"),
         pytest.param("CCS-720XDM-48ZC2-F", PlatformType.FIXED, PlatformFamily.SERIES_720_XDM, id="720xdm"),
         pytest.param("DCS-7020R4-10QC-4DF", PlatformType.FIXED, PlatformFamily.SERIES_7020_R4, id="7020r4"),

--- a/tests/units/anta_tests/advisories/test_sa_142.py
+++ b/tests/units/anta_tests/advisories/test_sa_142.py
@@ -542,10 +542,6 @@ class TestSA142PlatformScope(unittest.TestCase):
         """Verify platform scopes do not inherit unrelated generations from a shared chassis."""
         assert PlatformFamily.SERIES_720_XP in PBR_PATH.platform_families
         assert PlatformFamily.SERIES_722_XPM in PBR_PATH.platform_families
-        assert PlatformFamily.SERIES_720_XPM not in PBR_PATH.platform_families
-        assert PlatformFamily.SERIES_720_XPM not in TRAFFIC_POLICY_PATH.platform_families
-        assert PlatformFamily.SERIES_720_XPM not in SEGMENT_SECURITY_PATH.platform_families
-        assert PlatformFamily.SERIES_720_XPM not in DIRECTFLOW_PATH.platform_families
         assert PlatformFamily.SERIES_7368_X4 not in TRAFFIC_POLICY_PATH.platform_families
         assert PlatformFamily.SERIES_7358_X4 not in DIRECTFLOW_PATH.platform_families
         assert PlatformFamily.SERIES_7300_X not in SEGMENT_SECURITY_PATH.platform_families
@@ -554,12 +550,12 @@ class TestSA142PlatformScope(unittest.TestCase):
         assert PlatformFamily.SERIES_7500_R2 not in SEGMENT_SECURITY_PATH.platform_families
         assert PlatformFamily.SERIES_7800_R4 not in SEGMENT_SECURITY_PATH.platform_families
 
-    def test_720xp_and_722xpm_scope_does_not_include_720xpm(self) -> None:
-        """Verify similarly named 720 platform families retain their documented scope."""
+    def test_720xp_and_722xpm_scope_includes_720xpm(self) -> None:
+        """Verify the 722XPM family scope includes 720XPM models."""
         for path in (PBR_PATH, TRAFFIC_POLICY_PATH, SEGMENT_SECURITY_PATH):
             for model, expected in (
                 ("CCS-720XP-48ZC2-F", AffectedStatus.AFFECTED),
-                ("CCS-720XPM-48TH-6SY-F", AffectedStatus.NOT_AFFECTED),
+                ("CCS-720XPM-48TH-6SY-F", AffectedStatus.AFFECTED),
                 ("CCS-722XPM-48TH-6SY-F", AffectedStatus.AFFECTED),
             ):
                 with self.subTest(path=path.name, model=model):


### PR DESCRIPTION
## Description

Classify CCS-720XPM models as part of the 722XPM Series platform family. This also ensures SA-142 exposure paths scoped to the 722XPM family apply to 720XPM models.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated platform-family detection so 720XPM models are classified with the 722XPM series.
  * Preserved separate classification for 720XDM models.
  * Corrected advisory applicability for 720XPM platforms, which are now identified as affected where appropriate.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->