### PR TITLE
refactor(anta): Cleanup unused constants in advisories

### DIFF
--- a/anta/tests/advisories/sa_142.py
+++ b/anta/tests/advisories/sa_142.py
@@ -28,6 +28,7 @@ from anta._advisory.facts.models import (
 )
 from anta._advisory.facts.platform import PlatformIdentityFact
 from anta._advisory.facts.redirection import (
+    MTU_DROP_COMMAND,
     DirectFlowRedirectFact,
     FlowSpecRedirectFact,
     MtuDropMitigationFact,
@@ -65,9 +66,6 @@ from anta.decorators import preview_test_class
 
 if TYPE_CHECKING:
     from anta.device import DeviceVersion
-
-MTU_DROP_COMMAND = "ip software forwarding mtu exceed action drop"
-MTU_DROP_SHOW_COMMAND = f"show running-config | include ^{MTU_DROP_COMMAND}$"
 
 REDIRECT_AFFECTED_VERSION_MATRIX: tuple[VersionRule, ...] = (
     VersionRule(major=4, minor=36, patch_eq=0, hotfix_lte=1),

--- a/anta/tests/advisories/sa_146.py
+++ b/anta/tests/advisories/sa_146.py
@@ -85,7 +85,6 @@ TERMINATTR_FIXED_RELEASES = (
 TERMINATTR_VERSION_PATTERN = re.compile(r"^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
 TERMINATTR_LAST_AFFECTED_PATCH = {31: 16, 34: 13, 37: 12, 40: 12, 43: 7, 45: 0}
 TERMINATTR_FULLY_AFFECTED_MINOR_RANGES = ((0, 30), (32, 33), (35, 36), (38, 39), (41, 42))
-TERMINATTR_EXEC_PREFIX = ("exec", "/usr/bin/TerminAttr")
 
 ADVISORY = _AdvisoryMetadata(
     sa_number="0146",

--- a/tests/units/anta_tests/advisories/test_sa_142.py
+++ b/tests/units/anta_tests/advisories/test_sa_142.py
@@ -52,7 +52,6 @@ from anta.tests.advisories.sa_142 import (
     CONDITIONAL_FIXED_VERSION_MATRIX,
     DIRECTFLOW_PATH,
     EXPOSURE_PATHS,
-    MTU_DROP_COMMAND,
     PBR_PATH,
     REDIRECT_AFFECTED_VERSION_MATRIX,
     SEGMENT_SECURITY_AFFECTED_VERSION_MATRIX,
@@ -65,6 +64,8 @@ from anta.tests.advisories.sa_142 import (
 )
 from tests.units.anta_tests import build_eos_platform, build_eos_version, test
 from tests.units.anta_tests.advisories import OfflineAntaDevice
+
+MTU_DROP_COMMAND = "ip software forwarding mtu exceed action drop"
 
 if TYPE_CHECKING:
     from anta.device import DevicePlatform, DeviceVersion


### PR DESCRIPTION
## Description

<!-- PR description !-->
Cleanup unused constants


## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)
