### PR TITLE
feat(anta.tests): Add advisory support matrix

### DIFF
--- a/anta/_advisory/models.py
+++ b/anta/_advisory/models.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from enum import Enum
 from typing import Annotated
 
@@ -53,6 +54,7 @@ class _AdvisoryMetadata(_AdvisoryModel):
 
     sa_number: str
     title: str
+    last_updated: date
     vulnerabilities: tuple[_AdvisoryVulnerability, ...]
     url: str
     description: str

--- a/anta/tests/advisories/sa_117.py
+++ b/anta/tests/advisories/sa_117.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from anta._advisory.base import _AntaAdvisoryTest
@@ -56,6 +57,7 @@ FIXED_RELEASES = (
 ADVISORY = _AdvisoryMetadata(
     sa_number="0117",
     title="Security Advisory 0117",
+    last_updated=date(2025, 5, 20),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="CVE-2025-0936",

--- a/anta/tests/advisories/sa_140.py
+++ b/anta/tests/advisories/sa_140.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from typing import TYPE_CHECKING
 
 from anta._advisory.base import _AntaAdvisoryTest
@@ -59,6 +60,7 @@ FIXED_RELEASES = (
 ADVISORY = _AdvisoryMetadata(
     sa_number="0140",
     title="Security Advisory 0140",
+    last_updated=date(2026, 6, 3),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="CVE-2026-10040",

--- a/anta/tests/advisories/sa_142.py
+++ b/anta/tests/advisories/sa_142.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from anta._advisory.base import _AntaAdvisoryTest
@@ -242,6 +243,7 @@ EXPOSURE_PATHS = (
 ADVISORY = _AdvisoryMetadata(
     sa_number="0142",
     title="Security Advisory 0142",
+    last_updated=date(2026, 8, 10),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="CVE-2026-12546",

--- a/anta/tests/advisories/sa_146.py
+++ b/anta/tests/advisories/sa_146.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from anta._advisory.base import _AntaAdvisoryTest
@@ -90,6 +91,7 @@ TERMINATTR_EXEC_PREFIX = ("exec", "/usr/bin/TerminAttr")
 ADVISORY = _AdvisoryMetadata(
     sa_number="0146",
     title="Security Advisory 0146",
+    last_updated=date(2026, 8, 19),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="GHSA-hrxh-6v49-42gf",

--- a/anta/tests/advisories/sa_147.py
+++ b/anta/tests/advisories/sa_147.py
@@ -70,7 +70,7 @@ EOS_AFFECTED_VERSION_MATRIX: tuple[VersionRule, ...] = (
 ADVISORY = _AdvisoryMetadata(
     sa_number="0147",
     title="Security Advisory 0147",
-    last_updated=date(2026, 9, 3),
+    last_updated=date(2026, 8, 31),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="CVE-2026-59995",

--- a/anta/tests/advisories/sa_147.py
+++ b/anta/tests/advisories/sa_147.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import re
+from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from anta._advisory.base import _AntaAdvisoryTest
@@ -69,6 +70,7 @@ EOS_AFFECTED_VERSION_MATRIX: tuple[VersionRule, ...] = (
 ADVISORY = _AdvisoryMetadata(
     sa_number="0147",
     title="Security Advisory 0147",
+    last_updated=date(2026, 9, 3),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="CVE-2026-59995",

--- a/docs/api/tests/advisories.md
+++ b/docs/api/tests/advisories.md
@@ -92,19 +92,19 @@ tags:
 ## Security advisory support matrix
 
 !!! note
-    `TBC` means support in ANTA has not yet been confirmed.
+    `TBD` means **To Be Determined**.
 
 | Security advisory | Last updated | Supported in ANTA version | Comment |
 | --- | --- | --- | --- |
 | Security Advisory 0148 | | N/A | Advance Notice |
 | [Security Advisory 0147](https://www.arista.com/en/support/advisories-notices/security-advisory/24515-security-advisory-0147) | 2026-09-03 | v1.10 | |
 | [Security Advisory 0146](https://www.arista.com/en/support/advisories-notices/security-advisory/24500-security-advisory-0146) | 2026-08-19 | v1.10 | |
-| Security Advisories 0145–0143 | | TBC | |
+| Security Advisories 0145–0143 | | TBD | |
 | [Security Advisory 0142](https://www.arista.com/en/support/advisories-notices/security-advisory/24111-security-advisory-0142) | 2026-08-10 | v1.10 | |
-| Security Advisory 0141 | | TBC | |
+| Security Advisory 0141 | | TBD | |
 | [Security Advisory 0140](https://www.arista.com/en/support/advisories-notices/security-advisory/24074-security-advisory-0140) | 2026-06-03 | v1.10 | |
-| Security Advisories 0139–0118 | | TBC | |
+| Security Advisories 0139–0118 | | TBD | |
 | [Security Advisory 0117](https://www.arista.com/en/support/advisories-notices/security-advisory/21394-security-advisory-0117) | 2025-05-20 | v1.10 | |
-| Security Advisories 0116–0061 | | TBC | |
+| Security Advisories 0116–0061 | | TBD | |
 | Security Advisory 0060 | | N/A | Not Published |
-| Security Advisories 0059–0001 | | TBC | |
+| Security Advisories 0059–0001 | | TBD | |

--- a/docs/api/tests/advisories.md
+++ b/docs/api/tests/advisories.md
@@ -20,9 +20,7 @@ tags:
       extra:
           anta_hide_test_module_description: true
       filters:
-        - "!test"
-        - "!render"
-        - "!^_[^_]"
+        - "^VerifySA"
       merge_init_into_class: false
       show_bases: false
       show_labels: true
@@ -37,9 +35,7 @@ tags:
       extra:
           anta_hide_test_module_description: true
       filters:
-        - "!test"
-        - "!render"
-        - "!^_[^_]"
+        - "^VerifySA"
       merge_init_into_class: false
       show_bases: false
       show_labels: true
@@ -54,9 +50,7 @@ tags:
       extra:
           anta_hide_test_module_description: true
       filters:
-        - "!test"
-        - "!render"
-        - "!^_[^_]"
+        - "^VerifySA"
       merge_init_into_class: false
       show_bases: false
       show_labels: true
@@ -71,9 +65,7 @@ tags:
       extra:
           anta_hide_test_module_description: true
       filters:
-        - "!test"
-        - "!render"
-        - "!^_[^_]"
+        - "^VerifySA"
       merge_init_into_class: false
       show_bases: false
       show_labels: true
@@ -88,9 +80,7 @@ tags:
       extra:
           anta_hide_test_module_description: true
       filters:
-        - "!test"
-        - "!render"
-        - "!^_[^_]"
+        - "^VerifySA"
       merge_init_into_class: false
       show_bases: false
       show_labels: true
@@ -98,3 +88,23 @@ tags:
       show_root_toc_entry: false
       show_symbol_type_heading: false
       show_symbol_type_toc: false
+
+## Security advisory support matrix
+
+!!! note
+    `TBC` means support in ANTA has not yet been confirmed.
+
+| Security advisory | Last updated | Supported in ANTA version | Comment |
+| --- | --- | --- | --- |
+| Security Advisory 0148 | | N/A | Advance Notice |
+| [Security Advisory 0147](https://www.arista.com/en/support/advisories-notices/security-advisory/24515-security-advisory-0147) | 2026-09-03 | v1.10 | |
+| [Security Advisory 0146](https://www.arista.com/en/support/advisories-notices/security-advisory/24500-security-advisory-0146) | 2026-08-19 | v1.10 | |
+| Security Advisories 0145–0143 | | TBC | |
+| [Security Advisory 0142](https://www.arista.com/en/support/advisories-notices/security-advisory/24111-security-advisory-0142) | 2026-08-10 | v1.10 | |
+| Security Advisory 0141 | | TBC | |
+| [Security Advisory 0140](https://www.arista.com/en/support/advisories-notices/security-advisory/24074-security-advisory-0140) | 2026-06-03 | v1.10 | |
+| Security Advisories 0139–0118 | | TBC | |
+| [Security Advisory 0117](https://www.arista.com/en/support/advisories-notices/security-advisory/21394-security-advisory-0117) | 2025-05-20 | v1.10 | |
+| Security Advisories 0116–0061 | | TBC | |
+| Security Advisory 0060 | | N/A | Not Published |
+| Security Advisories 0059–0001 | | TBC | |

--- a/docs/api/tests/advisories.md
+++ b/docs/api/tests/advisories.md
@@ -97,7 +97,7 @@ tags:
 | Security advisory | Last updated | Supported in ANTA version | Comment |
 | --- | --- | --- | --- |
 | Security Advisory 0148 | | N/A | Advance Notice |
-| [Security Advisory 0147](https://www.arista.com/en/support/advisories-notices/security-advisory/24515-security-advisory-0147) | 2026-09-03 | v1.10 | |
+| [Security Advisory 0147](https://www.arista.com/en/support/advisories-notices/security-advisory/24515-security-advisory-0147) | 2026-08-31 | v1.10 | |
 | [Security Advisory 0146](https://www.arista.com/en/support/advisories-notices/security-advisory/24500-security-advisory-0146) | 2026-08-19 | v1.10 | |
 | Security Advisories 0145–0143 | | TBD | |
 | [Security Advisory 0142](https://www.arista.com/en/support/advisories-notices/security-advisory/24111-security-advisory-0142) | 2026-08-10 | v1.10 | |

--- a/docs/templates/python/material/module.html.jinja
+++ b/docs/templates/python/material/module.html.jinja
@@ -1,0 +1,7 @@
+{% extends "_base/module.html.jinja" %}
+
+{% block docstring scoped %}
+{% if not config.extra.anta_hide_test_module_description %}
+{{ super() }}
+{% endif %}
+{% endblock docstring %}

--- a/tests/units/_advisory/conftest.py
+++ b/tests/units/_advisory/conftest.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,6 +21,7 @@ from anta._runner import AntaRunContext, AntaRunFilters
 ADVISORY = _AdvisoryMetadata(
     sa_number="0001",
     title="Test advisory",
+    last_updated=date(2026, 1, 1),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="CVE-2026-0001",

--- a/tests/units/_advisory/findings/test_projection.py
+++ b/tests/units/_advisory/findings/test_projection.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -84,6 +85,7 @@ VULNERABILITY_ID = "CVE-2026-0001"
 ADVISORY = _AdvisoryMetadata(
     sa_number="TBD",
     title="Projection test",
+    last_updated=date(2026, 1, 1),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id=VULNERABILITY_ID,

--- a/tests/units/_advisory/reporting_data.py
+++ b/tests/units/_advisory/reporting_data.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from typing import TYPE_CHECKING, cast
 
 from anta._advisory.models import (
@@ -25,6 +26,7 @@ SA117_ADVISORY = cast("_AdvisoryMetadata", vars(VerifySA117)["advisory"])
 EXAMPLE_CRITICAL_ADVISORY = _AdvisoryMetadata(
     sa_number="0120",
     title="Example Management API Authentication Bypass",
+    last_updated=date(2026, 1, 1),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="CVE-2026-12001",
@@ -47,6 +49,7 @@ EXAMPLE_CRITICAL_ADVISORY = _AdvisoryMetadata(
 EXAMPLE_HIGH_ADVISORY = _AdvisoryMetadata(
     sa_number="0121",
     title="Example EOS Process Denial of Service",
+    last_updated=date(2026, 1, 1),
     vulnerabilities=(
         _AdvisoryVulnerability(
             id="GTI-EXAMPLE-12101",

--- a/tests/units/_advisory/test_models.py
+++ b/tests/units/_advisory/test_models.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 from pydantic import ValidationError
 
@@ -17,6 +19,7 @@ from anta._advisory.models import (
 _BASE_ADVISORY_FIELDS = {
     "sa_number": "0001",
     "title": "Test advisory",
+    "last_updated": date(2026, 1, 1),
     "url": "https://example.com/advisory",
     "description": "Test advisory description.",
 }

--- a/tests/units/_advisory/test_status.py
+++ b/tests/units/_advisory/test_status.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
 from anta._advisory.models import _AdvisoryMetadata
@@ -12,7 +14,14 @@ from anta._advisory.results import _AdvisoryTestResult
 from anta._advisory.status import AdvisoryStatus, project_advisory_status
 from anta.result_manager.models import AntaTestStatus
 
-ADVISORY = _AdvisoryMetadata(sa_number="TBD", title="Projection test", vulnerabilities=(), url="TBD", description="Projection test advisory.")
+ADVISORY = _AdvisoryMetadata(
+    sa_number="TBD",
+    title="Projection test",
+    last_updated=date(2026, 1, 1),
+    vulnerabilities=(),
+    url="TBD",
+    description="Projection test advisory.",
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/units/anta_tests/advisories/test_metadata.py
+++ b/tests/units/anta_tests/advisories/test_metadata.py
@@ -73,7 +73,7 @@ def test_published_advisory_metadata() -> None:
             VerifySA147,
             "0147",
             "24515-security-advisory-0147",
-            date(2026, 9, 3),
+            date(2026, 8, 31),
             (
                 (
                     "CVE-2026-59995",

--- a/tests/units/anta_tests/advisories/test_metadata.py
+++ b/tests/units/anta_tests/advisories/test_metadata.py
@@ -3,6 +3,8 @@
 # that can be found in the LICENSE file.
 """Validate metadata shared by the published security-advisory tests."""
 
+from datetime import date
+
 from anta._advisory.base import _AntaAdvisoryTest
 from anta._advisory.models import _AdvisoryVulnerabilitySeverity
 from anta.tests.advisories.sa_117 import VerifySA117
@@ -19,6 +21,7 @@ def test_published_advisory_metadata() -> None:
             VerifySA117,
             "0117",
             "21394-security-advisory-0117",
+            date(2025, 5, 20),
             (
                 (
                     "CVE-2025-0936",
@@ -31,6 +34,7 @@ def test_published_advisory_metadata() -> None:
             VerifySA140,
             "0140",
             "24074-security-advisory-0140",
+            date(2026, 6, 3),
             (
                 (
                     "CVE-2026-10040",
@@ -43,6 +47,7 @@ def test_published_advisory_metadata() -> None:
             VerifySA142,
             "0142",
             "24111-security-advisory-0142",
+            date(2026, 8, 10),
             (
                 (
                     "CVE-2026-12546",
@@ -55,6 +60,7 @@ def test_published_advisory_metadata() -> None:
             VerifySA146,
             "0146",
             "24500-security-advisory-0146",
+            date(2026, 8, 19),
             (
                 (
                     "GHSA-hrxh-6v49-42gf",
@@ -67,6 +73,7 @@ def test_published_advisory_metadata() -> None:
             VerifySA147,
             "0147",
             "24515-security-advisory-0147",
+            date(2026, 9, 3),
             (
                 (
                     "CVE-2026-59995",
@@ -92,11 +99,12 @@ def test_published_advisory_metadata() -> None:
         ),
     )
 
-    for test_class, sa_number, url_suffix, expected_vulnerabilities in cases:
+    for test_class, sa_number, url_suffix, last_updated, expected_vulnerabilities in cases:
         assert issubclass(test_class, _AntaAdvisoryTest)
         assert test_class.description == f"Verify whether the device is impacted by SA {sa_number}."
         assert test_class.advisory.sa_number == sa_number
         assert test_class.advisory.title == f"Security Advisory {sa_number}"
         assert test_class.advisory.url.endswith(url_suffix)
+        assert test_class.advisory.last_updated == last_updated
         assert test_class.advisory.description
         assert tuple((item.id, item.severity, item.description) for item in test_class.advisory.vulnerabilities) == expected_vulnerabilities


### PR DESCRIPTION
## Description

Adding a security matrix in the doc

Fixes # (issue id)

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security advisories now include a “last updated” date in their metadata.
  * Advisory documentation includes a support matrix with links, update dates, supported ANTA versions, support statuses, and advance-notice or unpublished entries.

* **Documentation**
  * Advisory documentation filters now show only verification entries.
  * Python module documentation can conditionally display inherited module descriptions based on configuration.
  * Support-status terminology now includes “TBD” (“To Be Determined”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->