### PR TITLE
fix(anta): Advisory SA146 missing trustedCertificates means mitigation is not in place

### DIFF
--- a/anta/_advisory/facts/management.py
+++ b/anta/_advisory/facts/management.py
@@ -200,7 +200,9 @@ def _ssl_profile_is_valid(profile: Mapping[str, object]) -> bool:
 
 def _ssl_profile_trust_is_valid(profile: Mapping[str, object]) -> bool | None:
     """Return whether an SSL profile has valid trusted client certificates."""
-    trusted = profile.get("trustedCertificates")
+    if "trustedCertificates" not in profile:
+        return False
+    trusted = profile["trustedCertificates"]
     if not isinstance(trusted, Sequence) or isinstance(trusted, str | bytes):
         return None
     if not trusted:

--- a/tests/units/anta_tests/advisories/test_sa_146.py
+++ b/tests/units/anta_tests/advisories/test_sa_146.py
@@ -138,17 +138,19 @@ def gribi_output(*, enabled: bool, profile: str = "", mtls: bool = False) -> dic
     return {"enabled": enabled, "sslProfile": profile, "mTls": mtls}
 
 
-def ssl_profiles(*, valid: bool = True, trusted: bool = True) -> dict[str, Any]:
+def ssl_profiles(*, valid: bool = True, trusted: bool | None = True) -> dict[str, Any]:
     """Return compact SSL profile status using observed EOS field names."""
+    profile = {
+        "profileState": "valid" if valid else "invalid",
+        "profileError": [] if valid else [{"errorType": "invalid"}],
+        "certName": "target.crt",
+        "keyName": "target.key",
+    }
+    if trusted is not None:
+        profile["trustedCertificates"] = ["ca.crt"] if trusted else []
     return {
         "profileStatus": {
-            "mtls": {
-                "profileState": "valid" if valid else "invalid",
-                "profileError": [] if valid else [{"errorType": "invalid"}],
-                "certName": "target.crt",
-                "keyName": "target.key",
-                "trustedCertificates": ["ca.crt"] if trusted else [],
-            }
+            "mtls": profile,
         }
     }
 
@@ -197,6 +199,18 @@ _DATA: AntaUnitTestData = {
     (VerifySA146, "failure-gnmi-without-mtls"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": sa146_eos_data(gnmi=gnmi_output(enabled=True)),
+        "expected": expected_result(
+            AntaTestStatus.FAILURE,
+            "The device is affected because EOS version '4.35.5M' is affected and the gNMI feature is enabled.",
+            remediation_plan((EXPECTED_EOS_VERSION_CHANGE,)),
+        ),
+    },
+    (VerifySA146, "failure-gnmi-profile-without-trusted-certificates"): {
+        "version": build_eos_version("4.35.5M"),
+        "eos_data": sa146_eos_data(
+            gnmi=gnmi_output(enabled=True, profile="mtls"),
+            profiles=ssl_profiles(trusted=None),
+        ),
         "expected": expected_result(
             AntaTestStatus.FAILURE,
             "The device is affected because EOS version '4.35.5M' is affected and the gNMI feature is enabled.",
@@ -482,6 +496,7 @@ class TestSA146Evidence(unittest.TestCase):
         assert not _ssl_profile_has_mtls("", ssl_profiles())
         assert not _ssl_profile_has_mtls("mtls", ssl_profiles(valid=False))
         assert not _ssl_profile_has_mtls("mtls", ssl_profiles(trusted=False))
+        assert not _ssl_profile_has_mtls("mtls", ssl_profiles(trusted=None))
         assert _ssl_profile_has_mtls("missing", ssl_profiles()) is None
         assert _ssl_profile_has_mtls("mtls", {}) is None
 
@@ -496,6 +511,7 @@ class TestSA146Evidence(unittest.TestCase):
         assert not _mitigation_bool(GnmiMtlsFact.parse((_command(GnmiMtlsFact.commands[0], gnmi), _command(GnmiMtlsFact.commands[1], ssl_profiles()))))
         gnmi["transports"]["other"]["sslProfile"] = "mtls"
         assert _mitigation_bool(GnmiMtlsFact.parse((_command(GnmiMtlsFact.commands[0], gnmi), _command(GnmiMtlsFact.commands[1], ssl_profiles()))))
+        assert not _mitigation_bool(GnmiMtlsFact.parse((_command(GnmiMtlsFact.commands[0], gnmi), _command(GnmiMtlsFact.commands[1], ssl_profiles(trusted=None)))))
 
         assert _mitigation_bool(
             GribiMtlsFact.parse(
@@ -510,6 +526,14 @@ class TestSA146Evidence(unittest.TestCase):
                 (
                     _command(GribiMtlsFact.commands[0], gribi_output(enabled=True, profile="mtls", mtls=False)),
                     _command(GribiMtlsFact.commands[1], ssl_profiles()),
+                )
+            )
+        )
+        assert not _mitigation_bool(
+            GribiMtlsFact.parse(
+                (
+                    _command(GribiMtlsFact.commands[0], gribi_output(enabled=True, profile="mtls", mtls=True)),
+                    _command(GribiMtlsFact.commands[1], ssl_profiles(trusted=None)),
                 )
             )
         )

--- a/tests/units/anta_tests/advisories/test_sa_146.py
+++ b/tests/units/anta_tests/advisories/test_sa_146.py
@@ -492,11 +492,11 @@ class TestSA146Evidence(unittest.TestCase):
         assert isinstance(TerminAttrVersionFact.parse((_command(TerminAttrVersionFact.commands[0], version_output(terminattr=None)),)), UnavailableFact)
 
     def test_ssl_profile_requires_valid_server_and_trust_material(self) -> None:
-        assert _ssl_profile_has_mtls("mtls", ssl_profiles())
-        assert not _ssl_profile_has_mtls("", ssl_profiles())
-        assert not _ssl_profile_has_mtls("mtls", ssl_profiles(valid=False))
-        assert not _ssl_profile_has_mtls("mtls", ssl_profiles(trusted=False))
-        assert not _ssl_profile_has_mtls("mtls", ssl_profiles(trusted=None))
+        assert _ssl_profile_has_mtls("mtls", ssl_profiles()) is True
+        assert _ssl_profile_has_mtls("", ssl_profiles()) is False
+        assert _ssl_profile_has_mtls("mtls", ssl_profiles(valid=False)) is False
+        assert _ssl_profile_has_mtls("mtls", ssl_profiles(trusted=False)) is False
+        assert _ssl_profile_has_mtls("mtls", ssl_profiles(trusted=None)) is False
         assert _ssl_profile_has_mtls("missing", ssl_profiles()) is None
         assert _ssl_profile_has_mtls("mtls", {}) is None
 


### PR DESCRIPTION
## Description

<!-- PR description !-->
Advisory SA146 missing trustedCertificates means mitigation is not in place

Fixes #1693

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SSL profiles without trusted certificates are now correctly treated as invalid.
  - mTLS mitigation checks now correctly report ineffective configurations when trust material is missing.
  - Validation consistently covers enabled gNMI and gRIBI transports requiring mTLS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->