### PR TITLE
test(anta.cli): make Ansible output assertion wrapping-safe

### DIFF
--- a/tests/units/cli/get/test_commands.py
+++ b/tests/units/cli/get/test_commands.py
@@ -194,7 +194,7 @@ def test_from_ansible(
 
     if expected_exit != ExitCode.OK:
         assert expected_log
-        assert expected_log in result.output
+        assert expected_log in " ".join(result.output.split())
     else:
         assert output.exists()
         # TODO: check size of generated inventory to validate the group functionality!


### PR DESCRIPTION
## Description

Prevent the `anta get from-ansible` CLI test from failing when Rich wraps the expected error message in long worktree paths.

The assertion now normalizes rendered whitespace before checking the semantic error text. Production logging and user-facing output are unchanged.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run --all-files`)
- [x] The existing Ansible CLI test covers the fix and passes from a long-path worktree
- [x] New and existing unit tests pass locally (`2921 passed, 1 skipped`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the `from-ansible` command test to normalize whitespace when validating error output, improving assertion reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->