### PR TITLE
bump: Version 1.10.0.dev3 -> 1.10.0.dev4

### DIFF
--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -38,7 +38,7 @@ $ pip install -e ".[cli]" --group dev
     $ pip list -e
     Package Version Editable project location
     ------- ------- -------------------------
-    anta    1.10.0.dev3   /mnt/lab/projects/anta
+    anta    1.10.0.dev4   /mnt/lab/projects/anta
     ```
 
 Then, [`tox`](https://tox.wiki/) is configured with a few environments to run CI locally:

--- a/docs/requirements-and-installation.md
+++ b/docs/requirements-and-installation.md
@@ -92,7 +92,7 @@ which anta
 ```bash
 # Check ANTA version
 anta --version
-anta, version v1.10.0.dev3
+anta, version v1.10.0.dev4
 ```
 
 ## EOS Requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anta"
-version = "v1.10.0.dev3"
+version = "v1.10.0.dev4"
 readme = "README.md"
 authors = [{ name = "Arista Networks ANTA maintainers", email = "anta-dev@arista.com" }]
 maintainers = [
@@ -122,7 +122,7 @@ namespaces = false
 # Version
 ################################
 [tool.bumpver]
-current_version = "1.10.0.dev3"
+current_version = "1.10.0.dev4"
 version_pattern = "MAJOR.MINOR.PATCH[.PYTAGNUM]"
 commit_message  = "bump: Version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documented ANTA installation and CLI versions to `1.10.0.dev4`.

- **Chores**
  - Updated the project version to `1.10.0.dev4`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->