### PR TITLE
feat(anta): Add possibility to choose SSL ciphers for AsyncEOSDevice

### DIFF
--- a/anta/device.py
+++ b/anta/device.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import ssl
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
 from collections.abc import Mapping
@@ -17,7 +18,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol
 import asyncssh
 import httpcore
 from asyncssh import SSHClientConnection, SSHClientConnectionOptions
-from httpx import ConnectError, HTTPError, TimeoutException
+from httpx import ConnectError, HTTPError, TimeoutException, create_ssl_context
 
 import asynceapi
 from anta import __DEBUG__
@@ -26,7 +27,7 @@ from anta._eos.platform import PlatformIdentity, PlatformType, parse_eos_platfor
 from anta._eos.version import parse_eos_version
 from anta.logger import anta_log_exception, exc_to_str
 from anta.models import AntaCommand
-from anta.settings import get_httpx_settings
+from anta.settings import get_httpx_settings, get_ssl_settings
 from asynceapi._models import EAPIClientConnectionOptions
 from asynceapi._types import EapiComplexCommand
 from asynceapi.errors import EapiAuthenticationError
@@ -95,9 +96,70 @@ class AntaDeviceCapabilities:
 
     Subclasses of AntaDevice set this as a ClassVar to advertise which
     ANTA capabilities they implement. The base default is all-False.
+
+    Attributes
+    ----------
+    supports_session_auth : bool
+        Whether the device supports eAPI cookie-session authentication.
+    supports_ssl : bool
+        Whether the device accepts SSL parameters from an ANTA inventory.
     """
 
     supports_session_auth: bool = False
+    supports_ssl: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SSLParameters:
+    """Parameters used to build an SSL context for an HTTPS eAPI connection.
+
+    Attributes
+    ----------
+    ciphers : str | None
+        OpenSSL cipher list. None uses the Python defaults.
+    verify : bool
+        Whether to verify the peer certificate. Defaults to False.
+    check_hostname : bool
+        Whether to verify that the certificate matches the device hostname. Defaults to False and requires ``verify=True``.
+    """
+
+    ciphers: str | None = None
+    verify: bool = False
+    check_hostname: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate the SSL parameter combination."""
+        if self.check_hostname and not self.verify:
+            msg = "SSL hostname checking requires certificate verification"
+            raise ValueError(msg)
+
+    def create_ssl_context(self, *, trust_env: bool = True) -> ssl.SSLContext:
+        """Build an HTTPX-compatible SSL context from these parameters.
+
+        Parameters
+        ----------
+        trust_env
+            Use the SSL certificate environment variables supported by HTTPX.
+
+        Returns
+        -------
+        ssl.SSLContext
+            Configured SSL context.
+
+        Raises
+        ------
+        ValueError
+            If the cipher list is invalid or selects no supported cipher.
+        """
+        context = create_ssl_context(verify=self.verify, trust_env=trust_env)
+        context.check_hostname = self.check_hostname
+        if self.ciphers is not None:
+            try:
+                context.set_ciphers(self.ciphers)
+            except ssl.SSLError as exc:
+                msg = f"Invalid SSL cipher list: {self.ciphers!r}"
+                raise ValueError(msg) from exc
+        return context
 
 
 class AntaCache:
@@ -432,9 +494,11 @@ class AsyncEOSDevice(AntaDevice):
         Tags for this device.
     enable : bool
         When True, commands are collected in privileged (enable) mode.
+    ssl_params : SSLParameters | None
+        Per-device SSL parameters. None inherits the global SSL cipher setting.
     """
 
-    capabilities = AntaDeviceCapabilities(supports_session_auth=True)
+    capabilities = AntaDeviceCapabilities(supports_session_auth=True, supports_ssl=True)
     """Features supported by this device type."""
 
     _client: asynceapi.Device
@@ -450,6 +514,8 @@ class AsyncEOSDevice(AntaDevice):
     """
     SSH client connection options used to establish transient SSH connections in `copy()`.
     """
+    _ssl_params: SSLParameters | None
+    """Explicit per-device SSL parameters, or None to inherit global SSL settings."""
 
     def __init__(  # noqa: PLR0913 # noqa: S107
         self,
@@ -468,6 +534,7 @@ class AsyncEOSDevice(AntaDevice):
         insecure: bool = False,
         disable_cache: bool = False,
         use_session_auth: bool = False,
+        ssl_params: SSLParameters | None = None,
     ) -> None:
         """Instantiate an AsyncEOSDevice.
 
@@ -501,6 +568,8 @@ class AsyncEOSDevice(AntaDevice):
             Disable caching for all commands for this device.
         use_session_auth
             Use eAPI cookie-session authentication for this device.
+        ssl_params
+            SSL parameters for HTTPS eAPI connections. None inherits ``ANTA_SSL_CIPHERS``.
         """
         if host is None:
             message = "'host' is required to create an AsyncEOSDevice"
@@ -522,6 +591,7 @@ class AsyncEOSDevice(AntaDevice):
         self._eapi_opts = EAPIClientConnectionOptions(
             host=host, username=username, password=password, port=port, proto=proto, timeout=timeout, use_session_auth=use_session_auth
         )
+        self._ssl_params = ssl_params
         self._client = self._create_client()
         ssh_params: dict[str, Any] = {}
         if insecure:
@@ -533,6 +603,15 @@ class AsyncEOSDevice(AntaDevice):
     def _create_client(self) -> asynceapi.Device:
         """Create and return a new asynceapi.Device client using stored connection options."""
         eapi_opts = self._eapi_opts
+        httpx_settings = get_httpx_settings()
+        ssl_params = self._ssl_params
+        if ssl_params is None and (global_ciphers := get_ssl_settings().ciphers) is not None:
+            ssl_params = SSLParameters(ciphers=global_ciphers)
+
+        verify: ssl.SSLContext | bool = False
+        if eapi_opts.proto == "https" and ssl_params is not None:
+            verify = ssl_params.create_ssl_context(trust_env=httpx_settings.trust_env)
+
         return asynceapi.Device(
             host=eapi_opts.host,
             port=eapi_opts.port,
@@ -540,7 +619,8 @@ class AsyncEOSDevice(AntaDevice):
             password=eapi_opts.password,
             proto=eapi_opts.proto,
             timeout=eapi_opts.timeout,
-            trust_env=get_httpx_settings().trust_env,
+            trust_env=httpx_settings.trust_env,
+            verify=verify,
             use_session_auth=eapi_opts.use_session_auth,
         )
 
@@ -556,6 +636,8 @@ class AsyncEOSDevice(AntaDevice):
         yield ("username", self._ssh_opts.username)
         yield ("enable", self.enable)
         yield ("insecure", self._ssh_opts.known_hosts is None)
+        if self.ssl_params is not None:
+            yield ("ssl_params", self.ssl_params)
         if __DEBUG__:
             _ssh_opts = vars(self._ssh_opts).copy()
             removed_pw = "<removed>"
@@ -576,6 +658,7 @@ class AsyncEOSDevice(AntaDevice):
     def __repr__(self) -> str:
         """Return a printable representation of an AsyncEOSDevice."""
         version = repr(str(self.version)) if self.version is not None else "None"
+        ssl_params = f", ssl_params={self.ssl_params!r}" if self.ssl_params is not None else ""
         return (
             f"AsyncEOSDevice({self.name!r}, "
             f"tags={self.tags!r}, "
@@ -589,7 +672,8 @@ class AsyncEOSDevice(AntaDevice):
             f"eapi_port={self._client.port!r}, "
             f"username={self._ssh_opts.username!r}, "
             f"enable={self.enable!r}, "
-            f"insecure={self._ssh_opts.known_hosts is None!r})"
+            f"insecure={self._ssh_opts.known_hosts is None!r}"
+            f"{ssl_params})"
         )
 
     @property
@@ -612,6 +696,11 @@ class AsyncEOSDevice(AntaDevice):
     def use_session_auth(self) -> bool:
         """Whether eAPI cookie-session authentication is enabled for this device."""
         return self._eapi_opts.use_session_auth
+
+    @property
+    def ssl_params(self) -> SSLParameters | None:
+        """Explicit per-device SSL parameters, or None when global defaults are inherited."""
+        return self._ssl_params
 
     async def _collect(self, command: AntaCommand, *, collection_id: str | None = None) -> None:
         """Collect device command output from EOS using asynceapi.

--- a/anta/inventory/__init__.py
+++ b/anta/inventory/__init__.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal
 from pydantic import ValidationError
 from yaml import YAMLError, safe_load
 
-from anta.device import AntaDevice, AntaDeviceCapabilities, AsyncEOSDevice
+from anta.device import AntaDevice, AntaDeviceCapabilities, AsyncEOSDevice, SSLParameters
 from anta.inventory.exceptions import InventoryIncorrectSchemaError, InventoryRootKeyError
 from anta.inventory.models import AntaInventoryHost, AntaInventoryInput
 from anta.logger import anta_log_exception, exc_to_str
@@ -108,6 +108,24 @@ class AntaInventory(dict[str, AntaDevice]):
         return False
 
     @staticmethod
+    def _resolve_ssl_params(
+        device_name: str,
+        device_capabilities: AntaDeviceCapabilities,
+        ssl_params: SSLParameters | None,
+    ) -> SSLParameters | None:
+        """Return SSL parameters only when they are supported by the device implementation.
+
+        Inventory validation remains independent of the concrete device type. If a future
+        device implementation does not support SSL, its inventory still parses and the
+        unsupported parameters are ignored with a warning during device instantiation.
+        """
+        if ssl_params is None or device_capabilities.supports_ssl:
+            return ssl_params
+
+        logger.warning("Device '%s' does not support SSL; SSL parameters ignored for this device.", device_name)
+        return None
+
+    @staticmethod
     def _parse_hosts(
         inventory_input: AntaInventoryInput,
         inventory: AntaInventory,
@@ -146,6 +164,7 @@ class AntaInventory(dict[str, AntaDevice]):
                 host=str(host.host),
                 port=host.port,
                 tags=host.tags,
+                ssl_params=AntaInventory._resolve_ssl_params(device_name, AsyncEOSDevice.capabilities, host.ssl_params),
                 **updated_kwargs,
             )
             inventory.add_device(device)
@@ -190,7 +209,12 @@ class AntaInventory(dict[str, AntaDevice]):
                         use_session_auth_override=use_session_auth_override,
                         inventory_use_session_auth=network.use_session_auth,
                     )
-                    device = AsyncEOSDevice(host=str(host_ip), tags=network.tags, **updated_kwargs)
+                    device = AsyncEOSDevice(
+                        host=str(host_ip),
+                        tags=network.tags,
+                        ssl_params=AntaInventory._resolve_ssl_params(str(host_ip), AsyncEOSDevice.capabilities, network.ssl_params),
+                        **updated_kwargs,
+                    )
                     inventory.add_device(device)
         except ValueError as e:
             message = "Could not parse the network section in the inventory"
@@ -241,7 +265,12 @@ class AntaInventory(dict[str, AntaDevice]):
                         use_session_auth_override=use_session_auth_override,
                         inventory_use_session_auth=range_def.use_session_auth,
                     )
-                    device = AsyncEOSDevice(host=str(range_increment), tags=range_def.tags, **updated_kwargs)
+                    device = AsyncEOSDevice(
+                        host=str(range_increment),
+                        tags=range_def.tags,
+                        ssl_params=AntaInventory._resolve_ssl_params(str(range_increment), AsyncEOSDevice.capabilities, range_def.ssl_params),
+                        **updated_kwargs,
+                    )
                     inventory.add_device(device)
                     range_increment += 1
         except ValueError as e:
@@ -484,6 +513,7 @@ class AntaInventory(dict[str, AntaDevice]):
                 tags=device.tags,
                 disable_cache=device.cache is None,
                 use_session_auth=device.use_session_auth if isinstance(device, AsyncEOSDevice) else False,
+                **({"ssl_params": device.ssl_params} if isinstance(device, AsyncEOSDevice) and device.ssl_params is not None else {}),
             )
             for device in self.devices
         ]

--- a/anta/inventory/models.py
+++ b/anta/inventory/models.py
@@ -12,6 +12,7 @@ import yaml
 from pydantic import BaseModel, ConfigDict, FieldSerializationInfo, IPvAnyAddress, IPvAnyNetwork, field_serializer
 
 from anta.custom_types import Hostname, Port
+from anta.device import SSLParameters
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +46,8 @@ class AntaInventoryHost(AntaInventoryBaseModel):
         Disable cache for this device.
     use_session_auth : bool
         Use session based authentication for this device if supported.
+    ssl_params : SSLParameters | None
+        SSL parameters for this device.
 
     """
 
@@ -54,6 +57,7 @@ class AntaInventoryHost(AntaInventoryBaseModel):
     tags: set[str] | None = None
     disable_cache: bool = False
     use_session_auth: bool = False
+    ssl_params: SSLParameters | None = None
 
 
 class AntaInventoryNetwork(AntaInventoryBaseModel):
@@ -69,6 +73,8 @@ class AntaInventoryNetwork(AntaInventoryBaseModel):
         Disable cache for all devices in this network.
     use_session_auth : bool
         Use session based authentication for all devices if supported in this network.
+    ssl_params : SSLParameters | None
+        SSL parameters for all devices in this network.
 
     """
 
@@ -76,6 +82,7 @@ class AntaInventoryNetwork(AntaInventoryBaseModel):
     tags: set[str] | None = None
     disable_cache: bool = False
     use_session_auth: bool = False
+    ssl_params: SSLParameters | None = None
 
 
 class AntaInventoryRange(AntaInventoryBaseModel):
@@ -93,6 +100,8 @@ class AntaInventoryRange(AntaInventoryBaseModel):
         Disable cache for all devices in this IP range.
     use_session_auth : bool
         Use session based authentication for all devices if supported in this IP range.
+    ssl_params : SSLParameters | None
+        SSL parameters for all devices in this IP range.
 
     """
 
@@ -101,6 +110,7 @@ class AntaInventoryRange(AntaInventoryBaseModel):
     tags: set[str] | None = None
     disable_cache: bool = False
     use_session_auth: bool = False
+    ssl_params: SSLParameters | None = None
 
 
 class AntaInventoryInput(BaseModel):

--- a/anta/settings.py
+++ b/anta/settings.py
@@ -26,6 +26,9 @@ DEFAULT_NOFILE = 16384
 DEFAULT_HTTPX_TRUST_ENV = True
 """Default value for the trust_env parameter of the HTTPX client."""
 
+DEFAULT_SSL_CIPHERS: str | None = None
+"""Default value for the SSL cipher list."""
+
 
 class AntaRunnerSettings(BaseSettings):
     """Environment variables for configuring the ANTA runner.
@@ -129,4 +132,41 @@ def get_httpx_settings() -> AntaHttpxSettings:
         return AntaHttpxSettings()
     except ValidationError as exc:
         msg = f"Failed to load ANTA HTTPX settings. Check ANTA_HTTPX_* environment variables: {exc_to_str(exc)}"
+        raise ValueError(msg) from exc
+
+
+class AntaSslSettings(BaseSettings):
+    """Environment variables for configuring SSL connections.
+
+    Attributes
+    ----------
+    ciphers : str | None
+        Environment variable: ANTA_SSL_CIPHERS
+
+        OpenSSL cipher list applied to HTTPS connections. None uses the Python defaults.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="ANTA_SSL_")
+
+    ciphers: str | None = Field(default=DEFAULT_SSL_CIPHERS)
+
+
+@cache
+def get_ssl_settings() -> AntaSslSettings:
+    """Return the cached ANTA SSL settings loaded from environment variables.
+
+    Returns
+    -------
+    AntaSslSettings
+        The SSL settings instance populated from ``ANTA_SSL_*`` environment variables.
+
+    Raises
+    ------
+    ValueError
+        If any ``ANTA_SSL_*`` environment variable has an invalid value.
+    """
+    try:
+        return AntaSslSettings()
+    except ValidationError as exc:
+        msg = f"Failed to load ANTA SSL settings. Check ANTA_SSL_* environment variables: {exc_to_str(exc)}"
         raise ValueError(msg) from exc

--- a/docs/advanced_usages/env-vars.md
+++ b/docs/advanced_usages/env-vars.md
@@ -20,6 +20,7 @@ ANTA exposes several environment variables that allow you to configure its behav
 | Variable | Default | Consumed By | Description |
 | -------- | ------- | ----------- | ----------- |
 | `ANTA_HTTPX_TRUST_ENV` | `true` | AsyncEOSDevice | Configures the `trust_env` parameter for the underlying HTTPX client. When false, HTTPX ignores environment variables for proxy and SSL settings. See the [HTTPX documentation](https://www.python-httpx.org/environment_variables/) for details. |
+| `ANTA_SSL_CIPHERS` | unset | AsyncEOSDevice | OpenSSL cipher list used by HTTPS eAPI connections without explicit per-device `ssl_params`. Custom ciphers may reduce TLS security. |
 
 ---
 
@@ -33,5 +34,14 @@ The examples below show common scenarios where environment variables can be used
 export ANTA_HTTPX_TRUST_ENV=false
 anta nrfu table
 ```
+
+### Configuring SSL ciphers globally
+
+```bash
+export ANTA_SSL_CIPHERS="AES256-SHA:DHE-RSA-AES256-SHA:AES128-SHA:DHE-RSA-AES128-SHA"
+anta nrfu table
+```
+
+`ANTA_SSL_CIPHERS` applies to every HTTPS inventory entry that does not define `ssl_params`. Prefer upgrading EOS or configuring an EOS server-side SSL profile instead of enabling legacy ciphers when possible.
 
 ---

--- a/docs/api/class-diagram.mmd
+++ b/docs/api/class-diagram.mmd
@@ -21,6 +21,7 @@ classDiagram
       tags : set[str] | None
       disable_cache : bool
       use_session_auth : bool
+      ssl_params : SSLParameters | None
     }
     class AntaInventoryInput:::pydantic {
       hosts : list[AntaInventoryHost] | None
@@ -34,6 +35,7 @@ classDiagram
       tags : set[str] | None
       disable_cache : bool
       use_session_auth : bool
+      ssl_params : SSLParameters | None
     }
     class AntaInventoryRange:::pydantic {
       start : IPvAnyAddress
@@ -41,6 +43,7 @@ classDiagram
       tags : set[str] | None
       disable_cache : bool
       use_session_auth : bool
+      ssl_params : SSLParameters | None
     }
   }
 
@@ -71,9 +74,11 @@ classDiagram
       enable : bool
       max_connections : int | None
       use_session_auth : bool
+      ssl_params : SSLParameters | None
       _client : asynceapi.Device
       _eapi_opts : EAPIClientConnectionOptions
       _ssh_opts : SSHClientConnectionOptions
+      _ssl_params : SSLParameters | None
       _command_semaphore : asyncio.Semaphore
       copy(sources: list[Path], destination: Path, direction: Literal['to', 'from']) None
       disconnect() None
@@ -83,6 +88,14 @@ classDiagram
     class AntaDeviceCapabilities:::dataclass {
       <<Frozen Dataclass>>
       supports_session_auth : bool
+      supports_ssl : bool
+    }
+    class SSLParameters:::dataclass {
+      <<Frozen Dataclass>>
+      ciphers : str | None
+      verify : bool
+      check_hostname : bool
+      create_ssl_context(trust_env: bool) SSLContext
     }
     class DeviceVersion {
       <<Protocol>>
@@ -302,6 +315,10 @@ classDiagram
   AntaDevice o-- DeviceVersion : version
   AsyncEOSDevice *-- AntaDeviceCapabilities : capabilities
   AsyncEOSDevice *-- EAPIClientConnectionOptions : _eapi_opts
+  AsyncEOSDevice o-- SSLParameters : ssl_params
+  AntaInventoryHost o-- SSLParameters : ssl_params
+  AntaInventoryNetwork o-- SSLParameters : ssl_params
+  AntaInventoryRange o-- SSLParameters : ssl_params
   AntaDevice --o AntaTest : device
   AntaTest *-- Input : inputs
   Input *-- Filters : filters

--- a/docs/api/device.md
+++ b/docs/api/device.md
@@ -18,6 +18,10 @@ tags:
     options:
       filters: ["!^_", "^\\x5f\\x5fstr\\x5f\\x5f$"]
 
+::: anta.device.AntaDeviceCapabilities
+
+::: anta.device.SSLParameters
+
 ::: anta.device.AntaDevice
     options:
       filters: ["!^_", "_collect"]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,6 +76,35 @@ tags:
 
     In this command, ANTA NRFU is configured with several options. Notably, the `--timeout` parameter is set to 50 seconds (instead of the default 30 seconds) to allow extra time for API calls to complete.
 
+## `SSLV3_ALERT_HANDSHAKE_FAILURE` when connecting to EOS { .anta-toc-heading }
+
+??? question "`SSLV3_ALERT_HANDSHAKE_FAILURE` when connecting to EOS"
+
+    Python 3.10 changed its default TLS cipher suites. These defaults have no cipher in common with the default eAPI HTTPS ciphers on some older EOS releases, so EOS rejects the TLS Client Hello with an `SSLV3_ALERT_HANDSHAKE_FAILURE` alert.
+
+    The preferred solution is to upgrade to EOS 4.30.2 or later, or configure eAPI with a server-side SSL profile and stronger cipher suites. See the [Arista Community article](https://arista.my.site.com/AristaCommunity/s/article/Python-3-10-and-SSLV3-ALERT-HANDSHAKE-FAILURE-error) for the EOS certificate and SSL profile configuration.
+
+    If the server-side configuration cannot be changed, configure ANTA with the legacy EOS cipher list:
+
+    ```bash
+    export ANTA_SSL_CIPHERS="AES256-SHA:DHE-RSA-AES256-SHA:AES128-SHA:DHE-RSA-AES128-SHA"
+    ```
+
+    This environment variable applies to all HTTPS devices that do not define explicit `ssl_params`. For mixed inventories, scope the workaround to an older device, network or range:
+
+    ```yaml
+    anta_inventory:
+      hosts:
+        - host: 192.0.2.10
+          ssl_params:
+            ciphers: "AES256-SHA:DHE-RSA-AES256-SHA:AES128-SHA:DHE-RSA-AES128-SHA"
+    ```
+
+    !!! warning
+        Legacy cipher suites provide weaker security than the server-side solution. Python's `SSLContext.set_ciphers()` does not configure TLS 1.3 cipher suites, and local OpenSSL security policies can still reject legacy algorithms.
+
+    By default, ANTA does not verify eAPI HTTPS certificates or hostnames. Per-device verification can be enabled with `verify: true` and `check_hostname: true` under `ssl_params`. HTTP authentication (`use_session_auth`) and the SSH-only `insecure` option are independent from TLS configuration.
+
 ## `Session cookie expired` errors when using session-based authentication { .anta-toc-heading }
 
 ??? question "`Session cookie expired` errors when using session-based authentication"

--- a/docs/usage-inventory-catalog.md
+++ b/docs/usage-inventory-catalog.md
@@ -39,17 +39,23 @@ anta_inventory:
       tags: < list of tags to use to filter inventory during tests >
       disable_cache: < Disable cache per hosts. Default is False. >
       use_session_auth: < Enable session-based authentication for this host. Default is False. >
+      ssl_params:
+        ciphers: < OpenSSL cipher list. Default is inherited from ANTA_SSL_CIPHERS. >
+        verify: < Verify the HTTPS certificate. Default is False. >
+        check_hostname: < Verify the certificate hostname. Requires verify. Default is False. >
   networks:
     - network: < network using CIDR notation >
       tags: < list of tags to use to filter inventory during tests >
       disable_cache: < Disable cache per network. Default is False. >
       use_session_auth: < Enable session-based authentication for all hosts in this network. Default is False. >
+      ssl_params: < SSL parameters applied to all hosts in this network. >
   ranges:
     - start: < first ip address value of the range >
       end: < last ip address value of the range >
       tags: < list of tags to use to filter inventory during tests >
       disable_cache: < Disable cache per range. Default is False. >
       use_session_auth: < Enable session-based authentication for all hosts in this range. Default is False. >
+      ssl_params: < SSL parameters applied to all hosts in this range. >
 ```
 
 The inventory file must start with the `anta_inventory` key then define one or multiple methods:
@@ -65,6 +71,9 @@ A full description of the inventory model is available in [API documentation](ap
 
 !!! info
     Session-based authentication can be enabled per device, network or range by setting `use_session_auth: true`. The per-device value can be overridden globally via the `--use-session-auth` / `--no-session-auth` CLI flags or the `ANTA_USE_SESSION_AUTH` environment variable. Session-based authentication is only available on device types that advertise the `supports_session_auth` capability (e.g. `AsyncEOSDevice`). If `use_session_auth` is enabled in the inventory for a device type that does not support it, ANTA raises an exception during inventory loading; if it is requested globally from the CLI or environment variable, ANTA logs a warning for unsupported devices.
+
+!!! info
+    SSL parameters can be configured per device, network or range. When `ssl_params` is omitted, HTTPS connections inherit the cipher list from `ANTA_SSL_CIPHERS`. An explicit `ssl_params` mapping takes precedence; use `ssl_params: {}` to keep Python's default ciphers for one inventory entry when the global variable is set. Inventory parsing is independent of the device implementation: if a device type does not support SSL, parsing succeeds and ANTA warns that the SSL parameters are ignored for that device.
 
 ### Example
 

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -89,6 +89,12 @@ def yaml_file(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
 
 @pytest.fixture
 def setenvvar(monkeypatch: pytest.MonkeyPatch) -> Generator[pytest.MonkeyPatch, None, None]:
-    """Fixture to set environment variables for testing."""
-    with mock.patch.dict(os.environ, clear=True):
+    """Set environment variables in an isolated environment.
+
+    Preserve ``SystemRoot`` on Windows because socket service lookups use it to locate
+    the system services database.
+    """
+    system_root = os.environ.get("SYSTEMROOT")
+    preserved_environment = {"SYSTEMROOT": system_root} if system_root is not None else {}
+    with mock.patch.dict(os.environ, preserved_environment, clear=True):
         yield monkeypatch

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -91,10 +91,14 @@ def yaml_file(request: pytest.FixtureRequest, tmp_path: Path) -> Path:
 def setenvvar(monkeypatch: pytest.MonkeyPatch) -> Generator[pytest.MonkeyPatch, None, None]:
     """Set environment variables in an isolated environment.
 
-    Preserve ``SystemRoot`` on Windows because socket service lookups use it to locate
-    the system services database.
+    On Windows, preserve ``SYSTEMROOT`` because socket service lookups use it to locate
+    the system services database. Also preserve ``USERNAME`` so user lookup does not
+    fall back to importing the unavailable POSIX-only ``pwd`` module.
     """
-    system_root = os.environ.get("SYSTEMROOT")
-    preserved_environment = {"SYSTEMROOT": system_root} if system_root is not None else {}
+    preserved_environment: dict[str, str] = {}
+    if os.name == "nt":
+        for variable in ("SYSTEMROOT", "USERNAME"):
+            if (value := os.environ.get(variable)) is not None:
+                preserved_environment[variable] = value
     with mock.patch.dict(os.environ, preserved_environment, clear=True):
         yield monkeypatch

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -93,11 +93,12 @@ def setenvvar(monkeypatch: pytest.MonkeyPatch) -> Generator[pytest.MonkeyPatch, 
 
     On Windows, preserve ``SYSTEMROOT`` because socket service lookups use it to locate
     the system services database. Also preserve ``USERNAME`` so user lookup does not
-    fall back to importing the unavailable POSIX-only ``pwd`` module.
+    fall back to importing the unavailable POSIX-only ``pwd`` module. Preserve
+    ``USERPROFILE``, ``HOMEDRIVE``, and ``HOMEPATH`` so home directories can be expanded.
     """
     preserved_environment: dict[str, str] = {}
     if os.name == "nt":
-        for variable in ("SYSTEMROOT", "USERNAME"):
+        for variable in ("SYSTEMROOT", "USERNAME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"):
             if (value := os.environ.get(variable)) is not None:
                 preserved_environment[variable] = value
     with mock.patch.dict(os.environ, preserved_environment, clear=True):

--- a/tests/units/inventory/test__init__.py
+++ b/tests/units/inventory/test__init__.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pydantic import ValidationError
 
-from anta.device import AntaDeviceCapabilities, AsyncEOSDevice
+from anta.device import AntaDeviceCapabilities, AsyncEOSDevice, SSLParameters
 from anta.inventory import AntaInventory
 from anta.inventory.exceptions import InventoryIncorrectSchemaError, InventoryRootKeyError
 
@@ -145,6 +145,43 @@ class TestAntaInventory:
         assert devices_by_host["192.168.0.2"]._client._use_session_auth is False
 
     @pytest.mark.parametrize(
+        "yaml_file",
+        [
+            {
+                "anta_inventory": {
+                    "hosts": [{"host": "192.168.0.1", "ssl_params": {"ciphers": "AES256-SHA"}}],
+                    "networks": [{"network": "192.168.1.0/31", "ssl_params": {"ciphers": "AES128-SHA"}}],
+                    "ranges": [{"start": "192.168.2.1", "end": "192.168.2.2", "ssl_params": {"verify": True}}],
+                }
+            }
+        ],
+        indirect=["yaml_file"],
+    )
+    def test_ssl_parameters_propagate_and_dump(self, yaml_file: Path) -> None:
+        """Verify SSL parameters propagate from all inventory entry types and are preserved by dump()."""
+        inventory = AntaInventory.parse(filename=yaml_file, username="arista", password="arista123")
+        devices_by_host = {device._client.host: device for device in inventory.values() if isinstance(device, AsyncEOSDevice)}
+
+        assert devices_by_host["192.168.0.1"].ssl_params is not None
+        assert devices_by_host["192.168.0.1"].ssl_params.ciphers == "AES256-SHA"
+        assert devices_by_host["192.168.1.0"].ssl_params is not None
+        assert devices_by_host["192.168.1.0"].ssl_params.ciphers == "AES128-SHA"
+        assert devices_by_host["192.168.2.1"].ssl_params is not None
+        assert devices_by_host["192.168.2.1"].ssl_params.verify is True
+
+        dumped_hosts = {str(host.host): host for host in inventory.dump().hosts or []}
+        assert dumped_hosts["192.168.0.1"].ssl_params == devices_by_host["192.168.0.1"].ssl_params
+        assert dumped_hosts["192.168.1.0"].ssl_params == devices_by_host["192.168.1.0"].ssl_params
+        assert dumped_hosts["192.168.2.1"].ssl_params == devices_by_host["192.168.2.1"].ssl_params
+
+    def test_dump_omits_unconfigured_ssl_parameters(self, async_device: AsyncEOSDevice) -> None:
+        """Verify unconfigured SSL parameters do not alter serialized inventories."""
+        inventory = AntaInventory()
+        inventory.add_device(async_device)
+
+        assert "ssl_params" not in inventory.dump().to_json()
+
+    @pytest.mark.parametrize(
         ("cli", "inventory", "expected"),
         [
             # CLI unset: inventory value wins, default is False
@@ -176,6 +213,24 @@ class TestAntaInventory:
         result = AntaInventory._resolve_session_auth("unsupported-device", caps, use_session_auth_override=True, inventory_use_session_auth=False)
         assert result is False
         assert "does not support session authentication" in caplog.text
+
+    def test_resolve_ssl_params_supported_device(self) -> None:
+        """Verify SSL parameters pass through unchanged for a supporting device."""
+        ssl_params = SSLParameters(ciphers="AES256-SHA")
+
+        result = AntaInventory._resolve_ssl_params("supported-device", AsyncEOSDevice.capabilities, ssl_params)
+
+        assert result is ssl_params
+
+    def test_resolve_ssl_params_unsupported_device_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Verify unsupported SSL parameters are ignored without preventing inventory parsing."""
+        ssl_params = SSLParameters(ciphers="AES256-SHA")
+        caplog.set_level(logging.WARNING)
+
+        result = AntaInventory._resolve_ssl_params("unsupported-device", AntaDeviceCapabilities(), ssl_params)
+
+        assert result is None
+        assert "does not support SSL" in caplog.text
 
     @pytest.mark.parametrize(
         "yaml_file",

--- a/tests/units/inventory/test_models.py
+++ b/tests/units/inventory/test_models.py
@@ -13,6 +13,7 @@ import pytest
 from pydantic import ValidationError
 from yaml import safe_load
 
+from anta.device import SSLParameters
 from anta.inventory.models import AntaInventoryHost, AntaInventoryInput, AntaInventoryNetwork, AntaInventoryRange
 
 if TYPE_CHECKING:
@@ -211,6 +212,28 @@ class TestAntaInventoryRange:
 
 class TestAntaInventoryInputs:
     """Test anta.inventory.models.AntaInventoryInputs."""
+
+    def test_ssl_parameters(self) -> None:
+        """Verify nested SSL parameters are parsed for every inventory entry type."""
+        inventory = AntaInventoryInput.model_validate(
+            {
+                "hosts": [{"host": "192.0.2.1", "ssl_params": {"ciphers": "AES256-SHA"}}],
+                "networks": [{"network": "192.0.2.0/31", "ssl_params": {"verify": True, "check_hostname": True}}],
+                "ranges": [{"start": "192.0.2.2", "end": "192.0.2.3", "ssl_params": {}}],
+            }
+        )
+
+        assert inventory.hosts is not None
+        assert inventory.networks is not None
+        assert inventory.ranges is not None
+        assert inventory.hosts[0].ssl_params == SSLParameters(ciphers="AES256-SHA")
+        assert inventory.networks[0].ssl_params == SSLParameters(verify=True, check_hostname=True)
+        assert inventory.ranges[0].ssl_params == SSLParameters()
+
+    def test_invalid_ssl_parameters(self) -> None:
+        """Verify invalid SSL parameter combinations fail inventory validation."""
+        with pytest.raises(ValidationError, match="SSL hostname checking requires certificate verification"):
+            AntaInventoryInput.model_validate({"hosts": [{"host": "192.0.2.1", "ssl_params": {"check_hostname": True}}]})
 
     def test_dump_to_json(self) -> None:
         """Load a YAML file, dump it to JSON and verify it works."""

--- a/tests/units/test_device.py
+++ b/tests/units/test_device.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import ssl
 from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
@@ -20,8 +21,9 @@ from rich import print as rprint
 
 from anta._eos.platform import PlatformComponentRole, PlatformFamily, PlatformIdentity, PlatformType, parse_eos_platform_or_none
 from anta._eos.version import EOSVersion
-from anta.device import AntaDevice, AntaDeviceCapabilities, AsyncEOSDevice
+from anta.device import AntaDevice, AntaDeviceCapabilities, AsyncEOSDevice, SSLParameters
 from anta.models import AntaCommand
+from anta.settings import get_ssl_settings
 from asynceapi import EapiCommandError
 from asynceapi._models import EAPIClientConnectionOptions
 from asynceapi.errors import EapiAuthenticationError
@@ -700,14 +702,47 @@ class TestAntaDevice:
         """Verify the base AntaDevice capabilities default to all-False."""
         assert device.capabilities == AntaDeviceCapabilities()
         assert device.capabilities.supports_session_auth is False
+        assert device.capabilities.supports_ssl is False
 
 
 class TestAsyncEOSDevice:
     """Test for anta.device.AsyncEOSDevice."""
 
     def test_capabilities(self) -> None:
-        """Verify AsyncEOSDevice advertises session auth support."""
+        """Verify AsyncEOSDevice advertises its supported optional features."""
         assert AsyncEOSDevice.capabilities.supports_session_auth is True
+        assert AsyncEOSDevice.capabilities.supports_ssl is True
+
+    def test_ssl_parameters_default_context(self) -> None:
+        """Verify SSL parameters preserve ANTA's existing certificate behavior by default."""
+        context = SSLParameters().create_ssl_context()
+
+        assert context.verify_mode is ssl.CERT_NONE
+        assert context.check_hostname is False
+
+    def test_ssl_parameters_verified_context(self) -> None:
+        """Verify certificate and hostname validation can be enabled together."""
+        context = SSLParameters(verify=True, check_hostname=True).create_ssl_context()
+
+        assert context.verify_mode is ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_ssl_parameters_hostname_requires_verification(self) -> None:
+        """Verify hostname validation cannot be enabled without certificate verification."""
+        with pytest.raises(ValueError, match="SSL hostname checking requires certificate verification"):
+            SSLParameters(check_hostname=True)
+
+    def test_ssl_parameters_invalid_ciphers(self) -> None:
+        """Verify invalid OpenSSL cipher expressions fail with a clear error."""
+        with pytest.raises(ValueError, match="Invalid SSL cipher list"):
+            SSLParameters(ciphers="NOT-A-CIPHER").create_ssl_context()
+
+    def test_ssl_parameters_custom_ciphers(self) -> None:
+        """Verify the configured OpenSSL ciphers are enabled on the context."""
+        context = SSLParameters(ciphers="AES256-SHA:AES128-SHA").create_ssl_context()
+        cipher_names = {cipher["name"] for cipher in context.get_ciphers()}
+
+        assert {"AES256-SHA", "AES128-SHA"} <= cipher_names
 
     @pytest.mark.parametrize(("device", "expected", "expected_raise"), INIT_PARAMS)
     def test__init__(self, device: dict[str, Any], expected: dict[str, Any] | None, expected_raise: AbstractContextManager[Exception]) -> None:
@@ -743,6 +778,42 @@ class TestAsyncEOSDevice:
             timeout=12.0,
         )
 
+    def test__init__uses_per_device_ssl_parameters(self) -> None:
+        """Verify per-device SSL parameters are applied to the HTTPX transport."""
+        ssl_params = SSLParameters(ciphers="AES256-SHA")
+        dev = AsyncEOSDevice(host="42.42.42.42", username="anta", password="anta", ssl_params=ssl_params)
+        context = dev._client._transport._pool._ssl_context  # pyright: ignore[reportAttributeAccessIssue]
+
+        assert dev.ssl_params is ssl_params
+        assert "AES256-SHA" in {cipher["name"] for cipher in context.get_ciphers()}
+
+    def test__init__uses_global_ssl_ciphers(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Verify ANTA_SSL_CIPHERS applies when no per-device parameters are provided."""
+        get_ssl_settings.cache_clear()
+        setenvvar.setenv("ANTA_SSL_CIPHERS", "AES128-SHA")
+        dev = AsyncEOSDevice(host="42.42.42.42", username="anta", password="anta")
+        context = dev._client._transport._pool._ssl_context  # pyright: ignore[reportAttributeAccessIssue]
+
+        assert dev.ssl_params is None
+        assert "AES128-SHA" in {cipher["name"] for cipher in context.get_ciphers()}
+        get_ssl_settings.cache_clear()
+
+    def test__init__explicit_ssl_parameters_override_global(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Verify an explicit empty SSLParameters object opts out of the global cipher override."""
+        get_ssl_settings.cache_clear()
+        setenvvar.setenv("ANTA_SSL_CIPHERS", "AES128-SHA")
+        dev = AsyncEOSDevice(host="42.42.42.42", username="anta", password="anta", ssl_params=SSLParameters())
+        context = dev._client._transport._pool._ssl_context  # pyright: ignore[reportAttributeAccessIssue]
+
+        assert "AES128-SHA" not in {cipher["name"] for cipher in context.get_ciphers()}
+        get_ssl_settings.cache_clear()
+
+    def test__init__ignores_ssl_parameters_for_http(self) -> None:
+        """Verify SSL parameters are not evaluated for clear-text HTTP connections."""
+        dev = AsyncEOSDevice(host="42.42.42.42", username="anta", password="anta", proto="http", ssl_params=SSLParameters(ciphers="NOT-A-CIPHER"))
+
+        assert dev._client.base_url.scheme == "http"
+
     def test__rich_repr_debug_sanitizes_client_details(self, async_device: AsyncEOSDevice) -> None:
         """Test the debug Rich repr does not expose internal client state."""
         async_device.version = EOSVersion(major=4, minor=34, patch=7, hotfix=1, suffix="M")
@@ -765,6 +836,11 @@ class TestAsyncEOSDevice:
         async_device.version = EOSVersion(major=4, minor=34, patch=7, hotfix=1, suffix="M")
 
         assert "version='4.34.7.1M'" in repr(async_device)
+
+    def test_default_representations_omit_ssl_parameters(self, async_device: AsyncEOSDevice) -> None:
+        """Verify default SSL parameters do not alter device representations."""
+        assert "ssl_params" not in dict(async_device.__rich_repr__())
+        assert "ssl_params" not in repr(async_device)
 
     def test__repr__renders_missing_version_as_none(self, async_device: AsyncEOSDevice) -> None:
         """Test the printable representation renders None when the version is unavailable."""

--- a/tests/units/test_settings.py
+++ b/tests/units/test_settings.py
@@ -14,7 +14,17 @@ import pytest
 from pydantic import ValidationError
 
 from anta.device import AsyncEOSDevice
-from anta.settings import DEFAULT_HTTPX_TRUST_ENV, DEFAULT_MAX_CONCURRENCY, DEFAULT_NOFILE, AntaHttpxSettings, AntaRunnerSettings, get_httpx_settings
+from anta.settings import (
+    DEFAULT_HTTPX_TRUST_ENV,
+    DEFAULT_MAX_CONCURRENCY,
+    DEFAULT_NOFILE,
+    DEFAULT_SSL_CIPHERS,
+    AntaHttpxSettings,
+    AntaRunnerSettings,
+    AntaSslSettings,
+    get_httpx_settings,
+    get_ssl_settings,
+)
 
 if os.name == "posix":
     # The function is not defined on non-POSIX system
@@ -158,3 +168,23 @@ class TestAntaHttpxSettings:
         with pytest.raises(ValueError, match=r"Failed to load ANTA HTTPX settings\. Check ANTA_HTTPX_\* environment variables:"):
             get_httpx_settings()
         get_httpx_settings.cache_clear()
+
+
+class TestAntaSslSettings:
+    """Tests for the AntaSslSettings class."""
+
+    def test_defaults(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Test that SSL settings use Python's default cipher list by default."""
+        assert AntaSslSettings().ciphers is DEFAULT_SSL_CIPHERS
+
+    def test_env_var(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Test that ANTA_SSL_CIPHERS overrides the default cipher list."""
+        setenvvar.setenv("ANTA_SSL_CIPHERS", "AES256-SHA:AES128-SHA")
+        assert AntaSslSettings().ciphers == "AES256-SHA:AES128-SHA"
+
+    def test_cached_settings(self, setenvvar: pytest.MonkeyPatch) -> None:
+        """Test that get_ssl_settings returns the configured cipher list."""
+        get_ssl_settings.cache_clear()
+        setenvvar.setenv("ANTA_SSL_CIPHERS", "AES256-SHA")
+        assert get_ssl_settings().ciphers == "AES256-SHA"
+        get_ssl_settings.cache_clear()


### PR DESCRIPTION
## Description

Add configurable SSL parameters for `AsyncEOSDevice`, including custom cipher suites for older EOS releases whose default eAPI ciphers are incompatible with Python 3.10 and later.

SSL parameters can be configured per host, network, or range using `ssl_params`. `ANTA_SSL_CIPHERS` provides a global cipher fallback.

The change also:

  - Adds certificate and hostname verification options.
  - Adds the `supports_ssl` device capability.
  - Preserves default connection, representation, and inventory serialization behavior.
  - Documents `SSLV3_ALERT_HANDSHAKE_FAILURE` and the preferred EOS server-side solution in the FAQ.

## Checklist

<!-- Delete not relevant items !-->

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have run pre-commit for code linting and typing (`pre-commit run`)
  - [x] I have made corresponding changes to the documentation
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable SSL/TLS settings for HTTPS eAPI connections, including certificate verification, hostname checking, and custom cipher lists.
  - Added per-device SSL configuration for inventory hosts, networks, and address ranges.
  - Added global cipher configuration through an environment variable when device-specific settings are not provided.
  - Unsupported SSL settings are ignored with a warning.

- **Documentation**
  - Documented SSL configuration, environment variables, inventory usage, troubleshooting, compatibility limitations, and security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->