### PR TITLE
refactor: Do not emit preview warnings for advisories test, keep it in doc only

### DIFF
--- a/anta/_advisory/base.py
+++ b/anta/_advisory/base.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+_PREVIEW_WARNING = "Security Advisory tests are in preview"
+
 
 class _AntaAdvisoryTest(AntaTest):
     """Base class for ANTA security advisory tests."""

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from functools import cache, wraps
-from typing import Any, ParamSpec
+from typing import Any, ParamSpec, overload
 
 from anta.models import AntaTest, logger
 from anta.result_manager.models import TestResult
@@ -124,25 +124,50 @@ def deprecated_test_class(new_tests: list[str] | None = None, removal_in_version
     return decorator
 
 
-def preview_test_class(cls: type[AntaTest]) -> type[AntaTest]:
+@overload
+def preview_test_class(cls: type[AntaTest], *, emit_warning: bool = True) -> type[AntaTest]: ...
+
+
+@overload
+def preview_test_class(cls: None = None, *, emit_warning: bool = True) -> Callable[[type[AntaTest]], type[AntaTest]]: ...
+
+
+def preview_test_class(cls: type[AntaTest] | None = None, *, emit_warning: bool = True) -> type[AntaTest] | Callable[[type[AntaTest]], type[AntaTest]]:
     """Mark a test class as preview.
 
     Preview tests may have their input models and behavior changed between minor releases without a deprecation notice.
+
+    Parameters
+    ----------
+    cls
+        The test class to mark as preview.
+    emit_warning
+        Whether to log a warning when the test class is instantiated.
     """
-    orig_init = cls.__init__
 
-    @cache
-    def emit_warning() -> None:
-        """Emit the preview warning once per test class."""
-        logger.warning("%s test is in preview. Input models and behavior may change between minor releases.", cls.name)
+    def decorator(test_cls: type[AntaTest]) -> type[AntaTest]:
+        """Mark the test class as preview and optionally wrap its initializer."""
+        if not emit_warning:
+            return test_cls
 
-    def new_init(*args: Any, **kwargs: Any) -> None:
-        """Overload __init__ to generate a warning message for preview tests."""
-        emit_warning()
-        orig_init(*args, **kwargs)
+        orig_init = test_cls.__init__
 
-    cls.__init__ = new_init
-    return cls
+        @cache
+        def warn_once() -> None:
+            """Emit the preview warning once per test class."""
+            logger.warning("%s test is in preview. Input models and behavior may change between minor releases.", test_cls.name)
+
+        def new_init(*args: Any, **kwargs: Any) -> None:
+            """Overload __init__ to generate a warning message for preview tests."""
+            warn_once()
+            orig_init(*args, **kwargs)
+
+        test_cls.__init__ = new_init
+        return test_cls
+
+    if cls is None:
+        return decorator
+    return decorator(cls)
 
 
 def skip_on_platforms(platforms: list[str]) -> T_TestAsyncDecorator:

--- a/anta/decorators.py
+++ b/anta/decorators.py
@@ -18,6 +18,12 @@ T_TestAsyncFunc = Callable[P, Coroutine[Any, Any, TestResult]]
 T_TestAsyncDecorator = Callable[[T_TestAsyncFunc], T_TestAsyncFunc]
 
 
+@cache
+def _emit_preview_warning(message: str) -> None:
+    """Emit a preview warning once per unique message."""
+    logger.warning(message)
+
+
 # TODO: Remove this decorator in ANTA v2.0.0 in favor of deprecated_test_class
 def deprecated_test(new_tests: list[str] | None = None) -> T_TestAsyncDecorator:
     """Return a decorator to log a message of WARNING severity when a test is deprecated.
@@ -125,14 +131,14 @@ def deprecated_test_class(new_tests: list[str] | None = None, removal_in_version
 
 
 @overload
-def preview_test_class(cls: type[AntaTest], *, emit_warning: bool = True) -> type[AntaTest]: ...
+def preview_test_class(cls: type[AntaTest], *, warning_message: str | None = None) -> type[AntaTest]: ...
 
 
 @overload
-def preview_test_class(cls: None = None, *, emit_warning: bool = True) -> Callable[[type[AntaTest]], type[AntaTest]]: ...
+def preview_test_class(cls: None = None, *, warning_message: str | None = None) -> Callable[[type[AntaTest]], type[AntaTest]]: ...
 
 
-def preview_test_class(cls: type[AntaTest] | None = None, *, emit_warning: bool = True) -> type[AntaTest] | Callable[[type[AntaTest]], type[AntaTest]]:
+def preview_test_class(cls: type[AntaTest] | None = None, *, warning_message: str | None = None) -> type[AntaTest] | Callable[[type[AntaTest]], type[AntaTest]]:
     """Mark a test class as preview.
 
     Preview tests may have their input models and behavior changed between minor releases without a deprecation notice.
@@ -141,25 +147,19 @@ def preview_test_class(cls: type[AntaTest] | None = None, *, emit_warning: bool 
     ----------
     cls
         The test class to mark as preview.
-    emit_warning
-        Whether to log a warning when the test class is instantiated.
+    warning_message
+        Custom warning message. Classes using the same message share one deduplicated warning.
     """
 
     def decorator(test_cls: type[AntaTest]) -> type[AntaTest]:
-        """Mark the test class as preview and optionally wrap its initializer."""
-        if not emit_warning:
-            return test_cls
-
+        """Mark the test class as preview and wrap its initializer."""
         orig_init = test_cls.__init__
-
-        @cache
-        def warn_once() -> None:
-            """Emit the preview warning once per test class."""
-            logger.warning("%s test is in preview. Input models and behavior may change between minor releases.", test_cls.name)
+        default_message = f"{test_cls.name} test is in preview. " + "Input models and behavior may change between minor releases."
+        message = warning_message if warning_message is not None else default_message
 
         def new_init(*args: Any, **kwargs: Any) -> None:
             """Overload __init__ to generate a warning message for preview tests."""
-            warn_once()
+            _emit_preview_warning(message)
             orig_init(*args, **kwargs)
 
         test_cls.__init__ = new_init

--- a/anta/tests/advisories/sa_117.py
+++ b/anta/tests/advisories/sa_117.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnmiAccountingFact, GnmiTransportFact, RiskyOpenConfigTraceFact
@@ -123,7 +123,7 @@ def _assess_sa117(  # noqa: PLR0911
     return NotAffectedResult(vulnerability_id=vulnerability_id, decisive=(accounting, trace))
 
 
-@preview_test_class(emit_warning=False)
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA117(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Assess SA117 credential exposure through OpenConfig accounting or tracing.
 

--- a/anta/tests/advisories/sa_117.py
+++ b/anta/tests/advisories/sa_117.py
@@ -123,7 +123,7 @@ def _assess_sa117(  # noqa: PLR0911
     return NotAffectedResult(vulnerability_id=vulnerability_id, decisive=(accounting, trace))
 
 
-@preview_test_class
+@preview_test_class(emit_warning=False)
 class SA117(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Assess SA117 credential exposure through OpenConfig accounting or tracing.
 

--- a/anta/tests/advisories/sa_140.py
+++ b/anta/tests/advisories/sa_140.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact, SecureBootFact
 from anta._advisory.facts.models import (
@@ -104,7 +104,7 @@ def _assess_sa140(
     )
 
 
-@preview_test_class(emit_warning=False)
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA140(_AntaAdvisoryTest):
     """Verify that the advisory 140 Secure Boot exposure is absent.
 

--- a/anta/tests/advisories/sa_140.py
+++ b/anta/tests/advisories/sa_140.py
@@ -104,7 +104,7 @@ def _assess_sa140(
     )
 
 
-@preview_test_class
+@preview_test_class(emit_warning=False)
 class SA140(_AntaAdvisoryTest):
     """Verify that the advisory 140 Secure Boot exposure is absent.
 

--- a/anta/tests/advisories/sa_142.py
+++ b/anta/tests/advisories/sa_142.py
@@ -426,7 +426,7 @@ def _assess_sa142(  # noqa: C901, PLR0911, PLR0912, PLR0915
     return NotAffectedResult(vulnerability_id=vulnerability_id, decisive=tuple(decisive))
 
 
-@preview_test_class
+@preview_test_class(emit_warning=False)
 class SA142(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify that Security Advisory 142 next-hop redirects are fully remediated.
 

--- a/anta/tests/advisories/sa_142.py
+++ b/anta/tests/advisories/sa_142.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import (
     AffectedStatus,
     VersionRule,
@@ -426,7 +426,7 @@ def _assess_sa142(  # noqa: C901, PLR0911, PLR0912, PLR0915
     return NotAffectedResult(vulnerability_id=vulnerability_id, decisive=tuple(decisive))
 
 
-@preview_test_class(emit_warning=False)
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA142(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify that Security Advisory 142 next-hop redirects are fully remediated.
 

--- a/anta/tests/advisories/sa_146.py
+++ b/anta/tests/advisories/sa_146.py
@@ -242,7 +242,7 @@ def _assess_sa146(paths: tuple[_GrpcPath, ...]) -> VulnerabilityResult:  # noqa:
     return NotAffectedResult(vulnerability_id=vulnerability_id, decisive=tuple(decisive))
 
 
-@preview_test_class
+@preview_test_class(emit_warning=False)
 class SA146(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Assess the SA146 HTTP/2 Rapid Reset exposure and documented mTLS control.
 

--- a/anta/tests/advisories/sa_146.py
+++ b/anta/tests/advisories/sa_146.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnmiMtlsFact, GnmiTransportFact, GribiMtlsFact, GribiTransportFact
@@ -242,7 +242,7 @@ def _assess_sa146(paths: tuple[_GrpcPath, ...]) -> VulnerabilityResult:  # noqa:
     return NotAffectedResult(vulnerability_id=vulnerability_id, decisive=tuple(decisive))
 
 
-@preview_test_class(emit_warning=False)
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA146(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Assess the SA146 HTTP/2 Rapid Reset exposure and documented mTLS control.
 

--- a/anta/tests/advisories/sa_147.py
+++ b/anta/tests/advisories/sa_147.py
@@ -198,7 +198,7 @@ def _assess_server_issue(  # noqa: PLR0911
     )
 
 
-@preview_test_class
+@preview_test_class(emit_warning=False)
 class SA147(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify the four independent OpenSSH issues in Security Advisory 147.
 

--- a/anta/tests/advisories/sa_147.py
+++ b/anta/tests/advisories/sa_147.py
@@ -9,7 +9,7 @@ import re
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import (
@@ -198,7 +198,7 @@ def _assess_server_issue(  # noqa: PLR0911
     )
 
 
-@preview_test_class(emit_warning=False)
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA147(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify the four independent OpenSSH issues in Security Advisory 147.
 

--- a/docs/templates/python/material/class.html.jinja
+++ b/docs/templates/python/material/class.html.jinja
@@ -74,7 +74,7 @@
 <img alt="Atomic support badge" src="https://img.shields.io/badge/Atomic%20result%20support-brightgreen?style=flat&logoSize=auto">
 {% endif %}
 {% for dec in class.decorators %}
-{% if dec.value.name is defined and dec.value.name == "preview_test_class" %}
+{% if (dec.value.name is defined and dec.value.name == "preview_test_class") or (dec.value.function is defined and dec.value.function.name == "preview_test_class") %}
 <img alt="Preview badge" src="https://img.shields.io/badge/PREVIEW-blue?style=flat&logoSize=auto">
 <div class="admonition warning">
 <p class="admonition-title">Preview</p>

--- a/tests/units/anta_tests/advisories/test_metadata.py
+++ b/tests/units/anta_tests/advisories/test_metadata.py
@@ -9,8 +9,6 @@ import logging
 from datetime import date
 from typing import TYPE_CHECKING
 
-import pytest
-
 from anta._advisory.base import _AntaAdvisoryTest
 from anta._advisory.models import _AdvisoryVulnerabilitySeverity
 from anta.tests.advisories.sa_117 import SA117
@@ -20,6 +18,8 @@ from anta.tests.advisories.sa_146 import SA146
 from anta.tests.advisories.sa_147 import SA147
 
 if TYPE_CHECKING:
+    import pytest
+
     from anta.device import AntaDevice
 
 
@@ -122,11 +122,11 @@ def test_published_advisory_metadata() -> None:
         assert tuple((item.id, item.severity, item.description) for item in test_class.advisory.vulnerabilities) == expected_vulnerabilities
 
 
-@pytest.mark.parametrize("test_class", ADVISORY_TEST_CLASSES)
-def test_published_advisory_does_not_emit_preview_warning(caplog: pytest.LogCaptureFixture, device: AntaDevice, test_class: type[_AntaAdvisoryTest]) -> None:
-    """Verify advisory tests retain preview status without emitting runtime preview warnings."""
+def test_published_advisories_emit_one_shared_preview_warning(caplog: pytest.LogCaptureFixture, device: AntaDevice) -> None:
+    """Verify advisory tests emit one shared preview warning."""
     caplog.set_level(logging.WARNING)
 
-    test_class(device)
+    for test_class in ADVISORY_TEST_CLASSES:
+        test_class(device)
 
-    assert not any("test is in preview" in message for message in caplog.messages)
+    assert caplog.messages.count("Security Advisory tests are in preview") == 1

--- a/tests/units/anta_tests/advisories/test_metadata.py
+++ b/tests/units/anta_tests/advisories/test_metadata.py
@@ -3,7 +3,13 @@
 # that can be found in the LICENSE file.
 """Validate metadata shared by the published security-advisory tests."""
 
+from __future__ import annotations
+
+import logging
 from datetime import date
+from typing import TYPE_CHECKING
+
+import pytest
 
 from anta._advisory.base import _AntaAdvisoryTest
 from anta._advisory.models import _AdvisoryVulnerabilitySeverity
@@ -12,6 +18,12 @@ from anta.tests.advisories.sa_140 import SA140
 from anta.tests.advisories.sa_142 import SA142
 from anta.tests.advisories.sa_146 import SA146
 from anta.tests.advisories.sa_147 import SA147
+
+if TYPE_CHECKING:
+    from anta.device import AntaDevice
+
+
+ADVISORY_TEST_CLASSES = (SA117, SA140, SA142, SA146, SA147)
 
 
 def test_published_advisory_metadata() -> None:
@@ -108,3 +120,13 @@ def test_published_advisory_metadata() -> None:
         assert test_class.advisory.last_updated == last_updated
         assert test_class.advisory.description
         assert tuple((item.id, item.severity, item.description) for item in test_class.advisory.vulnerabilities) == expected_vulnerabilities
+
+
+@pytest.mark.parametrize("test_class", ADVISORY_TEST_CLASSES)
+def test_published_advisory_does_not_emit_preview_warning(caplog: pytest.LogCaptureFixture, device: AntaDevice, test_class: type[_AntaAdvisoryTest]) -> None:
+    """Verify advisory tests retain preview status without emitting runtime preview warnings."""
+    caplog.set_level(logging.WARNING)
+
+    test_class(device)
+
+    assert not any("test is in preview" in message for message in caplog.messages)

--- a/tests/units/test_decorators.py
+++ b/tests/units/test_decorators.py
@@ -77,9 +77,8 @@ async def test_deprecated_test(caplog: pytest.LogCaptureFixture, device: AntaDev
     assert caplog.messages.count(warning) == 1
 
 
-@pytest.mark.parametrize("emit_warning", [True, False])
-def test_preview_test_class(caplog: pytest.LogCaptureFixture, device: AntaDevice, *, emit_warning: bool) -> None:
-    """Test preview_test_class decorator optionally logs the warning once per test class."""
+def test_preview_test_class(caplog: pytest.LogCaptureFixture, device: AntaDevice) -> None:
+    """Test preview_test_class decorator logs the default warning once per test class."""
     caplog.set_level(logging.WARNING)
 
     class PreviewExampleTest(AntaTest):
@@ -93,13 +92,33 @@ def test_preview_test_class(caplog: pytest.LogCaptureFixture, device: AntaDevice
             """Test function."""
             self.result.is_success()
 
-    decorated_test_class = preview_test_class(PreviewExampleTest) if emit_warning else preview_test_class(emit_warning=False)(PreviewExampleTest)
+    decorated_test_class = preview_test_class(PreviewExampleTest)
 
     decorated_test_class(device)
     decorated_test_class(device)
 
     warning = "PreviewExampleTest test is in preview. Input models and behavior may change between minor releases."
-    assert caplog.messages.count(warning) == int(emit_warning)
+    assert caplog.messages.count(warning) == 1
+
+
+def test_preview_test_class_deduplicates_custom_warning(caplog: pytest.LogCaptureFixture, device: AntaDevice) -> None:
+    """Test preview_test_class deduplicates a custom warning shared by multiple test classes."""
+    caplog.set_level(logging.WARNING)
+    warning = "A group of tests is in preview"
+
+    class FirstExampleTest(ExampleTest):
+        """First ANTA preview test that always succeeds."""
+
+    class AnotherExampleTest(ExampleTest):
+        """Another ANTA preview test that always succeeds."""
+
+    first_test_class = preview_test_class(warning_message=warning)(FirstExampleTest)
+    second_test_class = preview_test_class(warning_message=warning)(AnotherExampleTest)
+
+    first_test_class(device)
+    second_test_class(device)
+
+    assert caplog.messages.count(warning) == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/units/test_decorators.py
+++ b/tests/units/test_decorators.py
@@ -77,16 +77,29 @@ async def test_deprecated_test(caplog: pytest.LogCaptureFixture, device: AntaDev
     assert caplog.messages.count(warning) == 1
 
 
-def test_preview_test_class_warns_once(caplog: pytest.LogCaptureFixture, device: AntaDevice) -> None:
-    """Test preview_test_class decorator only logs the warning once per test class."""
+@pytest.mark.parametrize("emit_warning", [True, False])
+def test_preview_test_class(caplog: pytest.LogCaptureFixture, device: AntaDevice, *, emit_warning: bool) -> None:
+    """Test preview_test_class decorator optionally logs the warning once per test class."""
     caplog.set_level(logging.WARNING)
-    decorated_test_class = preview_test_class(ExampleTest)
+
+    class PreviewExampleTest(AntaTest):
+        """ANTA preview test that always succeeds."""
+
+        categories: ClassVar[list[str]] = []
+        commands: ClassVar[list[AntaCommand | AntaTemplate]] = []
+
+        @AntaTest.anta_test
+        def test(self) -> None:
+            """Test function."""
+            self.result.is_success()
+
+    decorated_test_class = preview_test_class(PreviewExampleTest) if emit_warning else preview_test_class(emit_warning=False)(PreviewExampleTest)
 
     decorated_test_class(device)
     decorated_test_class(device)
 
-    warning = "ExampleTest test is in preview. Input models and behavior may change between minor releases."
-    assert caplog.messages.count(warning) == 1
+    warning = "PreviewExampleTest test is in preview. Input models and behavior may change between minor releases."
+    assert caplog.messages.count(warning) == int(emit_warning)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Given that users can do nothing when running `anta psirt` removing the warning but keeping it in doc

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preview test decorators now support direct and factory-style usage with optional custom warning messages.
  - Preview warnings are consolidated so identical messages are logged only once.
  - Preview badges are recognized consistently across supported decorator styles.

- **Bug Fixes**
  - Published advisory tests now emit a single shared preview warning instead of repeated warnings.

- **Tests**
  - Added coverage for default and custom warning behavior, including deduplication across multiple advisory tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->