### PR TITLE
feat(anta): add JUnit reporter

### DIFF
--- a/anta/cli/nrfu/__init__.py
+++ b/anta/cli/nrfu/__init__.py
@@ -133,6 +133,7 @@ def nrfu(
 nrfu.add_command(commands.table)
 nrfu.add_command(commands.csv)
 nrfu.add_command(commands.json)
+nrfu.add_command(commands.junit)
 nrfu.add_command(commands.text)
 nrfu.add_command(commands.tpl_report)
 nrfu.add_command(commands.md_report)

--- a/anta/cli/nrfu/commands.py
+++ b/anta/cli/nrfu/commands.py
@@ -13,7 +13,7 @@ import click
 
 from anta.cli.utils import exit_with_code
 
-from .utils import print_jinja, print_json, print_table, print_text, run_tests, save_markdown_report, save_to_csv
+from .utils import print_jinja, print_json, print_table, print_text, run_tests, save_markdown_report, save_to_csv, save_to_junit
 
 logger = logging.getLogger(__name__)
 
@@ -158,4 +158,26 @@ def md_report(ctx: click.Context, md_output: pathlib.Path, *, expand: bool) -> N
     """ANTA command to check network state with Markdown report."""
     run_context = run_tests(ctx)
     save_markdown_report(ctx, md_output=md_output, run_context=run_context, expand=expand)
+    exit_with_code(ctx)
+
+
+@click.command()
+@click.pass_context
+@click.option(
+    "--junit-output",
+    type=click.Path(
+        file_okay=True,
+        dir_okay=False,
+        exists=False,
+        writable=True,
+        path_type=pathlib.Path,
+    ),
+    show_envvar=True,
+    required=True,
+    help="Path to save report as a JUnit file",
+)
+def junit(ctx: click.Context, junit_output: pathlib.Path) -> None:
+    """ANTA command to check network state with JUnit report."""
+    run_tests(ctx)
+    save_to_junit(ctx, junit_file=junit_output)
     exit_with_code(ctx)

--- a/anta/cli/nrfu/utils.py
+++ b/anta/cli/nrfu/utils.py
@@ -20,6 +20,7 @@ from anta.cli.utils import ExitCode
 from anta.models import AntaTest
 from anta.reporter.csv_reporter import ReportCsv
 from anta.reporter.jinja_reporter import ReportJinja
+from anta.reporter.junit_reporter import JUnitReporter
 from anta.reporter.md_reporter import MDReportGenerator
 from anta.reporter.table_reporter import ReportTable
 
@@ -158,6 +159,16 @@ def save_to_csv(ctx: click.Context, csv_file: pathlib.Path) -> None:
         console.print(f"CSV report saved to {csv_file} ✅", style="cyan")
     except OSError:
         console.print(f"Failed to save CSV report to {csv_file} ❌", style="cyan")
+        ctx.exit(ExitCode.USAGE_ERROR)
+
+
+def save_to_junit(ctx: click.Context, junit_file: pathlib.Path) -> None:
+    """Save results to a JUnit file."""
+    try:
+        JUnitReporter.generate(results=_get_result_manager(ctx), output_path=junit_file)
+        console.print(f"JUnit report saved to {junit_file} ✅", style="cyan")
+    except OSError:
+        console.print(f"Failed to save JUnit report to {junit_file} ❌", style="cyan")
         ctx.exit(ExitCode.USAGE_ERROR)
 
 

--- a/anta/reporter/junit_reporter.py
+++ b/anta/reporter/junit_reporter.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2025-2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""JUnit Report management for ANTA."""
+
+from __future__ import annotations
+
+# pylint: disable = too-few-public-methods
+import datetime
+import hashlib
+import json
+import logging
+import xml.etree.ElementTree as ET
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from anta.logger import anta_log_exception
+from anta.result_manager.models import AntaTestStatus, TestResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from anta.result_manager import ResultManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TestSuite:
+    """Dataclass to track TestSuite information."""
+
+    element: ET.Element
+    name: str
+    hostname: str
+    timestamp: str
+    filename: str | None
+    suite_tests: int = 0
+    suite_failures: int = 0
+    suite_errors: int = 0
+    suite_skipped: int = 0
+    suite_time: float = 0.0
+
+
+class JUnitReporter:
+    """A reporter that generates JUnit XML output.
+
+    Note
+    ----
+      There are things to be added there as required:
+      * tracking assertions per test
+    """
+
+    @classmethod
+    def _get_testcase_name(cls, result: TestResult, duplicate_names: set[str]) -> str:
+        """Return the JUnit testcase name for an ANTA test result."""
+        testcase_name = result.test
+        if result.description:
+            testcase_name = f"{testcase_name} - {result.description}"
+
+        if testcase_name in duplicate_names:
+            return f"{testcase_name} [{cls._get_testcase_identity_hash(result)}]"
+
+        return testcase_name
+
+    @staticmethod
+    def _get_testcase_identity_hash(result: TestResult) -> str:
+        """Return a stable hash from existing result fields for JUnit testcase deduplication."""
+        identity_data = {
+            "name": result.name,
+            "test": result.test,
+            "description": result.description,
+            "categories": result.categories,
+            "custom_field": result.custom_field,
+            "atomic_results": [atomic.description for atomic in result.atomic_results],
+        }
+        identity_json = json.dumps(identity_data, sort_keys=True, separators=(",", ":"))
+        return hashlib.blake2s(identity_json.encode("utf-8"), digest_size=8).hexdigest()
+
+    @classmethod
+    def _add_test_to_testsuite(cls, result: TestResult, testsuite: TestSuite, duplicate_names: set[str]) -> None:
+        """Build testcase for a given TestResult and add it to the testsuite root element.
+
+        Not handling the UNSET teststatus because this is not present in JUnit specification
+
+        TODO: Add duration, file and line.
+        For file and line we could consider augmenting TestResult to keep track of the class used for the test,
+        instead of just the string of the name.
+
+        Parameters
+        ----------
+        result:
+            The TestResult.
+        testsuite:
+            The testsuite element to attach the test to.
+        duplicate_names:
+            Testcase names used by multiple results in this testsuite.
+        """
+        testcase = ET.SubElement(testsuite.element, "testcase")
+        testcase.set("name", cls._get_testcase_name(result, duplicate_names))
+        testcase.set("classname", result.name)
+
+        # Add properties
+        properties = ET.SubElement(testcase, "properties")
+        description = ET.SubElement(properties, "property")
+        description.set("name", "description")
+        description.text = result.description
+
+        # TestResult is missing start and end times so for now duration is 0.0 for all tests...
+        duration = 0.0
+        testcase.set("time", f"{duration:.3f}")
+        testsuite.suite_time += duration
+
+        # Add failure, error, skipped or success elements based on status
+        if result.result == AntaTestStatus.FAILURE:
+            failure = ET.SubElement(testcase, "failure")
+            failure.set("message", "Test Failed")
+            failure.set("type", "AssertionError")
+            failure.text = "\n".join(result.messages)
+            testsuite.suite_failures += 1
+
+        elif result.result == AntaTestStatus.ERROR:
+            error = ET.SubElement(testcase, "error")
+            error.set("message", "Test Error")
+            error.set("type", "RuntimeError")
+            error.text = "\n".join(result.messages)
+            testsuite.suite_errors += 1
+
+        elif result.result == AntaTestStatus.SKIPPED:
+            skipped = ET.SubElement(testcase, "skipped")
+            skipped.set("message", "Test Skipped")
+            skipped.text = "\n".join(result.messages)
+            testsuite.suite_skipped += 1
+
+        # AntaTestStatus.SUCCESS requires no extra element
+        # AntaTestStatus.UNSET is not considered by JUnit so skipping silently for now
+
+    @classmethod
+    def _build_testsuite(cls, device_name: str, results: list[TestResult], testsuites: ET.Element, catalog_path: Path | None = None) -> None:
+        """Build testsuite for a given device and add it to the testsuites root element.
+
+        Parameters
+        ----------
+        device_name:
+            The device name.
+        results:
+            The list of TestResult for this device.
+        testsuites:
+            The root element of the JUnit report to attach the testuite to.
+        catalog_path:
+            The path to the catalog where the test was defined.
+        """
+        testsuite = TestSuite(
+            element=ET.SubElement(testsuites, "testsuite"),
+            name=f"ANTA Tests on {device_name}",
+            hostname=device_name,
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+            filename=str(catalog_path) if catalog_path else None,
+            suite_tests=len(results),
+        )
+
+        testcase_names = [f"{result.test} - {result.description}" if result.description else result.test for result in results]
+        duplicate_names = {name for name, count in Counter(testcase_names).items() if count > 1}
+
+        # Iterate through results for this device to create <testcase> elements
+        for result in results:
+            JUnitReporter._add_test_to_testsuite(result, testsuite, duplicate_names)
+
+        # Set attributes for the current test suite
+        testsuite.element.set("name", testsuite.name)
+        testsuite.element.set("hostname", testsuite.hostname)
+        testsuite.element.set("timestamp", testsuite.timestamp)
+        testsuite.element.set("tests", str(testsuite.suite_tests))
+        testsuite.element.set("failures", str(testsuite.suite_failures))
+        testsuite.element.set("errors", str(testsuite.suite_errors))
+        testsuite.element.set("skipped", str(testsuite.suite_skipped))
+        testsuite.element.set("time", f"{testsuite.suite_time:.3f}")
+
+        if testsuite.filename is not None:
+            testsuite.element.set("filename", testsuite.filename)
+
+    @classmethod
+    def generate(cls, results: ResultManager, output_path: Path, catalog_path: Path | None = None) -> None:
+        """Generate the JUnit XML report and saves it to the output path.
+
+        Parameters
+        ----------
+        results:
+            The ResultManager containing the test results to create the report for.
+        output_path:
+            The Path where the report should be saved.
+        catalog_path:
+            The catalog where the test was defined.
+        """
+        # Group results by device (each device becomes a test suite)
+        results_by_device: dict[str, list[TestResult]] = {}
+        for result in results.get_results(sort_by=["categories", "test"]):
+            device_name = result.name
+            if device_name not in results_by_device:
+                results_by_device[device_name] = []
+            results_by_device[device_name].append(result)
+
+        # Create the root <testsuites> element
+        testsuites = ET.Element("testsuites")
+
+        # Iterate through devices to create <testsuite> elements
+        for device_name, device_results in results_by_device.items():
+            cls._build_testsuite(device_name, device_results, testsuites, catalog_path)
+
+        # Set attributes for the root testsuites element
+        testsuites.set("tests", str(results.get_total_results({AntaTestStatus.SUCCESS, AntaTestStatus.SKIPPED, AntaTestStatus.FAILURE, AntaTestStatus.ERROR})))
+        testsuites.set("failures", str(results.get_total_results({AntaTestStatus.FAILURE})))
+        testsuites.set("errors", str(results.get_total_results({AntaTestStatus.ERROR})))
+        testsuites.set("skipped", str(results.get_total_results({AntaTestStatus.SKIPPED})))
+
+        total_time = 0.0
+        testsuites.set("time", f"{total_time:.3f}")  # Total time for all suites
+
+        # Ensure the output directory exists
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write the XML to the file
+        try:
+            tree = ET.ElementTree(testsuites)
+            ET.indent(tree, space="  ", level=0)
+            tree.write(output_path, encoding="utf-8", xml_declaration=True)
+
+            logger.info("JUnit report generated successfully at: %s", output_path)
+
+        except Exception as exc:
+            message = f"Error while writing the JUNIT file '{output_path.resolve()}'."
+            anta_log_exception(exc, message, logger)
+            raise

--- a/docs/snippets/anta_nrfu_help.txt
+++ b/docs/snippets/anta_nrfu_help.txt
@@ -65,6 +65,7 @@ Options:
 Commands:
   csv         ANTA command to check network state with CSV report.
   json        ANTA command to check network state with JSON results.
+  junit       ANTA command to check network state with JUnit report.
   md-report   ANTA command to check network state with Markdown report.
   table       ANTA command to check network state with table results.
   text        ANTA command to check network state with text results.

--- a/tests/units/cli/nrfu/test_commands.py
+++ b/tests/units/cli/nrfu/test_commands.py
@@ -285,3 +285,23 @@ def test_anta_nrfu_table_sort(click_runner: CliRunner) -> None:
     # Check that device, test, description and status exist on the line
     # The regex ensures they appear in that specific order
     assert re.search(r"spine1.*VerifyInterfacesSpeed.*Verifies the speed, lanes, auto-negotiation.*failure", target_line)
+
+
+def test_anta_nrfu_md_junit(click_runner: CliRunner, tmp_path: Path) -> None:
+    """Test anta nrfu junit."""
+    junit_output = tmp_path / "junit.xml"
+    result = click_runner.invoke(anta, ["nrfu", "junit", "--junit-output", str(junit_output)])
+    assert result.exit_code == ExitCode.OK
+    assert "JUnit report saved to" in result.output
+    assert junit_output.exists()
+
+
+def test_anta_nrfu_junit_failure(click_runner: CliRunner, tmp_path: Path) -> None:
+    """Test anta nrfu junit failure for OS reason."""
+    junit_output = tmp_path / "junit.xml"
+    with patch("anta.reporter.junit_reporter.JUnitReporter.generate", side_effect=OSError()):
+        result = click_runner.invoke(anta, ["nrfu", "junit", "--junit-output", str(junit_output)])
+
+    assert result.exit_code == ExitCode.USAGE_ERROR
+    assert "Failed to save JUnit report to" in result.output
+    assert not junit_output.exists()

--- a/tests/units/reporter/test_junit_reporter.py
+++ b/tests/units/reporter/test_junit_reporter.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2023-2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Test anta.reporter.junit_reporter.py."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from anta.reporter.junit_reporter import JUnitReporter
+from anta.result_manager import ResultManager
+from anta.result_manager.models import AntaTestStatus, TestResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_junit_reporter_generate(tmp_path: Path, result_manager: ResultManager) -> None:
+    """Test the JUnitReporter.generate() class method."""
+    junit_filename = tmp_path / "test.xml"
+
+    JUnitReporter.generate(results=result_manager, output_path=junit_filename)
+    assert junit_filename.exists()
+
+    root = ET.parse(junit_filename).getroot()  # noqa: S314
+    assert root.tag == "testsuites"
+    assert root.get("tests") == str(result_manager.get_total_results({AntaTestStatus.SUCCESS, AntaTestStatus.SKIPPED, AntaTestStatus.FAILURE, AntaTestStatus.ERROR}))
+    assert root.get("failures") == str(result_manager.get_total_results({AntaTestStatus.FAILURE}))
+    assert root.get("errors") == str(result_manager.get_total_results({AntaTestStatus.ERROR}))
+    assert root.get("skipped") == str(result_manager.get_total_results({AntaTestStatus.SKIPPED}))
+
+    testsuites = root.findall("testsuite")
+    assert {testsuite.get("hostname") for testsuite in testsuites} == {result.name for result in result_manager.results}
+
+    testcases = root.findall("./testsuite/testcase")
+    assert len(testcases) == int(root.get("tests", "0"))
+    first_result = result_manager.get_results(sort_by=["categories", "test"])[0]
+    assert testcases[0].get("classname") == first_result.name
+    assert testcases[0].get("name", "").startswith(f"{first_result.test} - {first_result.description}")
+    assert testcases[0].find("./failure") is not None
+    assert testcases[0].find("./properties/property[@name='description']") is not None
+
+
+def test_junit_reporter_generate_failure(
+    tmp_path: Path,
+    result_manager: ResultManager,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the JUnitReporter.generate() class method."""
+    junit_filename = tmp_path / "test.xml"
+
+    with patch("xml.etree.ElementTree.ElementTree.write", side_effect=PermissionError(junit_filename)), pytest.raises(OSError, match=r"test\.xml"):
+        JUnitReporter.generate(results=result_manager, output_path=junit_filename)
+
+    assert len(caplog.record_tuples) == 1
+    assert "Error while writing the JUNIT file '" in caplog.text
+
+
+def test_junit_reporter_generate_deduplicates_duplicate_testcase_names(tmp_path: Path) -> None:
+    """Test that JUnit testcase names remain unique for duplicate ANTA test names."""
+    junit_filename = tmp_path / "test.xml"
+    result_manager = ResultManager()
+    result_manager.add(
+        TestResult(
+            name="leaf1",
+            test="VerifyReachability",
+            categories=["connectivity"],
+            description="Verifies reachability to BGP neighbors.",
+            result=AntaTestStatus.FAILURE,
+            messages=["Peer is not reachable"],
+        )
+    )
+    result_manager.results[0].add(description="Destination 192.0.2.1 in VRF default", status=AntaTestStatus.FAILURE)
+    result_manager.add(
+        TestResult(
+            name="leaf1",
+            test="VerifyReachability",
+            categories=["connectivity"],
+            description="Verifies reachability to BGP neighbors.",
+            result=AntaTestStatus.SUCCESS,
+        )
+    )
+    result_manager.results[1].add(description="Destination 192.0.2.2 in VRF default", status=AntaTestStatus.SUCCESS)
+
+    JUnitReporter.generate(results=result_manager, output_path=junit_filename)
+
+    testcases = ET.parse(junit_filename).findall("./testsuite/testcase")  # noqa: S314
+    testcase_names = [testcase.get("name") for testcase in testcases]
+    assert len(testcase_names) == len(set(testcase_names))
+    assert all(re.fullmatch(r"VerifyReachability - Verifies reachability to BGP neighbors\. \[[0-9a-f]{16}\]", name or "") for name in testcase_names)


### PR DESCRIPTION
## Summary

Adds native JUnit XML reporting for `anta nrfu` via a new `junit` command.

This is a reduced-scope version of the previous JUnit reporter work in #1237. The implementation keeps the change local to the reporter/CLI path and avoids changing the core ANTA result model. For repeated testcase names within the same device testsuite, the JUnit reporter appends a short stable hash derived from existing `TestResult` data so GitLab and other JUnit consumers do not collapse distinct test invocations.

Closes #789.
Supersedes #1237.

## Tests

```bash
PYENV_VERSION=3.11.9 uv run pytest tests/units/reporter/test_junit_reporter.py tests/units/cli/nrfu/test_commands.py -q
PYENV_VERSION=3.11.9 uv run pre-commit run --files anta/reporter/junit_reporter.py anta/cli/nrfu/__init__.py anta/cli/nrfu/commands.py anta/cli/nrfu/utils.py tests/units/reporter/test_junit_reporter.py tests/units/cli/nrfu/test_commands.py docs/snippets/anta_nrfu_help.txt
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `anta nrfu junit` command to run ANTA tests and save results as a JUnit XML report.
  - Reports include test outcomes grouped by device, including failures, errors, and skipped tests.
  - Duplicate test names are handled to ensure unique entries.

- **Documentation**
  - Updated `anta nrfu --help` to include the new JUnit reporting command.

- **Bug Fixes**
  - Added clear success and failure messages when saving JUnit reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->