### PR TITLE
refactor: Use the same warning preview message for all SAs

### DIFF
--- a/anta/tests/advisories/sa_149.py
+++ b/anta/tests/advisories/sa_149.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import Dot1xDynamicAuthorizationFact, RadiusProxyDynamicAuthorizationFact
@@ -125,7 +125,7 @@ def _assess_sa149(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA149(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0149.
 

--- a/anta/tests/advisories/sa_150.py
+++ b/anta/tests/advisories/sa_150.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import Dot1xControlledAuthenticatorFact
@@ -222,7 +222,7 @@ def _assess_cve_75945(version: Fact[EOSVersion], platform: Fact[PlatformIdentity
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA150(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0150.
 

--- a/anta/tests/advisories/sa_151.py
+++ b/anta/tests/advisories/sa_151.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.acl import SharedSviIngressAclFact
 from anta._advisory.facts.eos import EosVersionFact
@@ -89,7 +89,7 @@ def _assess_sa151(version: Fact[EOSVersion], platform: Fact[PlatformIdentity], a
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA151(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0151.
 

--- a/anta/tests/advisories/sa_152.py
+++ b/anta/tests/advisories/sa_152.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.aaa import LoginAuthenticationFact
 from anta._advisory.facts.eos import EosVersionFact
@@ -79,7 +79,7 @@ def _assess_sa152(version: Fact[EOSVersion], login_authentication: Fact[FeatureV
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA152(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0152.
 

--- a/anta/tests/advisories/sa_153.py
+++ b/anta/tests/advisories/sa_153.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -118,7 +118,7 @@ def _assess_tacacs_key(
     return _assess_sa153_issue(TACACS_KEY_ID, version, risky_trace)
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA153(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0153.
 

--- a/anta/tests/advisories/sa_154.py
+++ b/anta/tests/advisories/sa_154.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -75,7 +75,7 @@ def _assess_sa154(version: Fact[EOSVersion], bfd: Fact[FeatureValue]) -> Vulnera
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA154(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0154.
 

--- a/anta/tests/advisories/sa_155.py
+++ b/anta/tests/advisories/sa_155.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -67,7 +67,7 @@ def _assess_sa155(version: Fact[EOSVersion], option82: Fact[FeatureValue]) -> Vu
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA155(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0155.
 

--- a/anta/tests/advisories/sa_156.py
+++ b/anta/tests/advisories/sa_156.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import AffectedStatus, VersionRule, evaluate_version
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, MitigationState, MitigationValue, UnavailableFact
@@ -183,7 +183,7 @@ def _assess_sa156(  # noqa: C901, PLR0911  # pylint: disable=too-many-return-sta
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA156(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0156.
 

--- a/anta/tests/advisories/sa_157.py
+++ b/anta/tests/advisories/sa_157.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import AffectedStatus, VersionRule, evaluate_version
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -178,7 +178,7 @@ def _assess_logging(version: Fact[EOSVersion], vrrp: Fact[FeatureValue]) -> Vuln
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA157(_AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0157.
 

--- a/anta/tests/advisories/sa_158.py
+++ b/anta/tests/advisories/sa_158.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import (
@@ -146,7 +146,7 @@ def _assess_logging_issue(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA158(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0158.
 

--- a/anta/tests/advisories/sa_159.py
+++ b/anta/tests/advisories/sa_159.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.findings.assessment import assess_eos_scope
@@ -66,7 +66,7 @@ def _assess_sa159(version: Fact[EOSVersion]) -> VulnerabilityResult:
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA159(_AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0159.
 

--- a/anta/tests/advisories/sa_160.py
+++ b/anta/tests/advisories/sa_160.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -127,7 +127,7 @@ def _assess_broadcast_issue(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA160(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0160.
 

--- a/anta/tests/advisories/sa_161.py
+++ b/anta/tests/advisories/sa_161.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -75,7 +75,7 @@ def _assess_sa161(version: Fact[EOSVersion], local_mlag: Fact[FeatureValue]) -> 
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA161(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0161.
 

--- a/anta/tests/advisories/sa_162.py
+++ b/anta/tests/advisories/sa_162.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnsiCertzFact, GnsiTransportFact
@@ -107,7 +107,7 @@ def _assess_sa162(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA162(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0162.
 

--- a/anta/tests/advisories/sa_163.py
+++ b/anta/tests/advisories/sa_163.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.aaa import LevelZeroCommandAuthorizationFact
 from anta._advisory.facts.eos import EosVersionFact
@@ -97,7 +97,7 @@ def _assess_sa163(version: Fact[EOSVersion], exposure: Fact[FeatureValue], mitig
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA163(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0163.
 

--- a/anta/tests/advisories/sa_164.py
+++ b/anta/tests/advisories/sa_164.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnmiTransportFact, GnsiPathzFact, GnsiPathzPolicyOverlapFact
@@ -97,7 +97,7 @@ def _assess_sa164(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA164(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0164.
 

--- a/anta/tests/advisories/sa_165.py
+++ b/anta/tests/advisories/sa_165.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnsiCredentialzFact
@@ -72,7 +72,7 @@ def _assess_sa165(version: Fact[EOSVersion], credentialz: Fact[FeatureValue]) ->
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA165(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0165.
 

--- a/anta/tests/advisories/sa_166.py
+++ b/anta/tests/advisories/sa_166.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnmiTransportFact
@@ -73,7 +73,7 @@ def _assess_sa166(version: Fact[EOSVersion], gnmi: Fact[FeatureValue]) -> Vulner
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA166(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0166.
 

--- a/anta/tests/advisories/sa_167.py
+++ b/anta/tests/advisories/sa_167.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnsiAuthzFact, GnsiTransportFact
@@ -91,7 +91,7 @@ def _assess_sa167(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA167(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0167.
 

--- a/anta/tests/advisories/sa_168.py
+++ b/anta/tests/advisories/sa_168.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnmiTransportFact, NetconfTransportFact, RestconfTransportFact
@@ -82,7 +82,7 @@ def _assess_sa168(version: Fact[EOSVersion], services: tuple[Fact[FeatureValue],
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA168(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0168.
 

--- a/anta/tests/advisories/sa_169.py
+++ b/anta/tests/advisories/sa_169.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnsiAuthzFact, GnsiMultipleTransportsFact, GnsiTransportFact
@@ -104,7 +104,7 @@ def _assess_sa169(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA169(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0169.
 

--- a/anta/tests/advisories/sa_170.py
+++ b/anta/tests/advisories/sa_170.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnmiAuthorizationFact
@@ -69,7 +69,7 @@ def _assess_sa170(version: Fact[EOSVersion], authorization: Fact[FeatureValue]) 
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA170(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0170.
 

--- a/anta/tests/advisories/sa_171.py
+++ b/anta/tests/advisories/sa_171.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import (
@@ -200,7 +200,7 @@ def _assess_inactive_broadcast_issue(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA171(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0171.
 

--- a/anta/tests/advisories/sa_172.py
+++ b/anta/tests/advisories/sa_172.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, MitigationState, MitigationValue, UnavailableFact
@@ -97,7 +97,7 @@ def _assess_sa172(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA172(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0172.
 

--- a/anta/tests/advisories/sa_173.py
+++ b/anta/tests/advisories/sa_173.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, MitigationState, MitigationValue, UnavailableFact
@@ -109,7 +109,7 @@ def _assess_sa173(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA173(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0173.
 

--- a/anta/tests/advisories/sa_174.py
+++ b/anta/tests/advisories/sa_174.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import GnsiAcctzFact, GnsiAuthzFact
@@ -141,7 +141,7 @@ def _assess_sa174(  # noqa: PLR0911
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA174(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0174.
 

--- a/anta/tests/advisories/sa_175.py
+++ b/anta/tests/advisories/sa_175.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import AvailableFact, Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -74,7 +74,7 @@ def _assess_sa175(version: Fact[EOSVersion], sparse_mode: Fact[FeatureValue]) ->
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA175(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0175.
 

--- a/anta/tests/advisories/sa_176.py
+++ b/anta/tests/advisories/sa_176.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar, cast
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import (
@@ -123,7 +123,7 @@ def _assess_sa176(
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA176(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0176.
 

--- a/anta/tests/advisories/sa_177.py
+++ b/anta/tests/advisories/sa_177.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.models import Fact, FactDefinition, FeatureState, FeatureValue, UnavailableFact
@@ -135,7 +135,7 @@ def _assess_sa177(  # noqa: PLR0911
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA177(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0177.
 

--- a/anta/tests/advisories/sa_178.py
+++ b/anta/tests/advisories/sa_178.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any, ClassVar
 
-from anta._advisory.base import _AntaAdvisoryTest
+from anta._advisory.base import _PREVIEW_WARNING, _AntaAdvisoryTest
 from anta._advisory.eos_versions import VersionRule
 from anta._advisory.facts.eos import EosVersionFact
 from anta._advisory.facts.management import SnmpV3AuthenticationFact, SnmpV3CredentialSyntaxFact
@@ -114,7 +114,7 @@ def _assess_sa178(  # pylint: disable=too-many-return-statements
     )
 
 
-@preview_test_class
+@preview_test_class(warning_message=_PREVIEW_WARNING)
 class SA178(OptionalCommandsMixin, _AntaAdvisoryTest):
     """Verify whether the device is impacted by Security Advisory 0178.
 

--- a/tests/units/anta_tests/advisories/test_metadata.py
+++ b/tests/units/anta_tests/advisories/test_metadata.py
@@ -25,9 +25,6 @@ if TYPE_CHECKING:
     from anta.device import AntaDevice
 
 
-ADVISORY_TEST_CLASSES = (SA117, SA140, SA142, SA146, SA147)
-
-
 def test_published_advisory_metadata() -> None:
     """Verify stable identifiers, URLs, descriptions, and vulnerability metadata."""
     cases = (
@@ -128,10 +125,10 @@ def test_published_advisories_emit_one_shared_preview_warning(caplog: pytest.Log
     """Verify advisory tests emit one shared preview warning."""
     caplog.set_level(logging.WARNING)
 
-    for test_class in ADVISORY_TEST_CLASSES:
+    for test_class in _ADVISORY_TESTS:
         test_class(device)
 
-    assert caplog.messages.count("Security Advisory tests are in preview") == 1
+    assert caplog.messages == ["Security Advisory tests are in preview"]
 
 
 def test_sa148_advance_notice_severities() -> None:


### PR DESCRIPTION
## Description

title

Fixes # (issue id)

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized preview-warning messages across advisory tests.
  * Strengthened validation to require exactly one expected warning.
  * Consolidated advisory test coverage using the shared advisory test collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->