### PR TITLE
ci: Exclude SA tests from benchmark

### DIFF
--- a/tests/units/anta_tests/advisories/test_sa_149.py
+++ b/tests/units/anta_tests/advisories/test_sa_149.py
@@ -89,7 +89,7 @@ def test_sa149_version_boundaries() -> None:
     )
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA149, "failure-both-features-on-physical-platform"): {
         "version": build_eos_version("4.36.1F"),
         "platform": build_eos_platform("DCS-7050CX3-32S"),

--- a/tests/units/anta_tests/advisories/test_sa_150.py
+++ b/tests/units/anta_tests/advisories/test_sa_150.py
@@ -133,7 +133,7 @@ def dot1x(*, controlled: bool) -> dict[str, object]:
     return {"systemAuthControl": True, "interfaces": {"Ethernet1": {"portControl": "controlled" if controlled else "forceAuth"}}}
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA150, "inconclusive-all-ural-issues"): {
         "version": build_eos_version("4.36.1F"),
         "platform": build_eos_platform(PHYSICAL_PLATFORM),

--- a/tests/units/anta_tests/advisories/test_sa_151.py
+++ b/tests/units/anta_tests/advisories/test_sa_151.py
@@ -51,7 +51,7 @@ EXPECTED_REMEDIATION = software_version_plan(
 expected = partial(build_expected_advisory_result, ADVISORY.vulnerabilities[0].id)
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA151, "affected-shared-acl"): {
         "version": build_eos_version("4.35.4M"),
         "platform": build_eos_platform("CCS-755-CH-F"),

--- a/tests/units/anta_tests/advisories/test_sa_152.py
+++ b/tests/units/anta_tests/advisories/test_sa_152.py
@@ -44,7 +44,7 @@ EXPECTED_REMEDIATION = software_version_plan(
 expected = partial(build_expected_advisory_result, ADVISORY.vulnerabilities[0].id)
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA152, "affected-default-password-ssh"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": [AAA_LOCAL, "", ""],

--- a/tests/units/anta_tests/advisories/test_sa_153.py
+++ b/tests/units/anta_tests/advisories/test_sa_153.py
@@ -103,7 +103,7 @@ def eos_data(trace: str) -> list[dict[str, Any] | str]:
     return [trace, trace, trace]
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA153, "failure-all-risky-traces-enabled"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": eos_data("trace ConfigAgent setting MgmtSecuritySslCertKey/034\ntrace Aaa setting */0-7"),

--- a/tests/units/anta_tests/advisories/test_sa_154.py
+++ b/tests/units/anta_tests/advisories/test_sa_154.py
@@ -44,7 +44,7 @@ def eos_data(*, admin_down: object = False, global_config: str = "", interface_c
     return [{"adminDown": admin_down}, global_config, interface_config]
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA154, "affected-authenticated-bfd"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": eos_data(global_config="router bfd\n   authentication mode md5 shared-secret profile test"),

--- a/tests/units/anta_tests/advisories/test_sa_155.py
+++ b/tests/units/anta_tests/advisories/test_sa_155.py
@@ -66,7 +66,7 @@ def test_sa155_version_boundaries() -> None:
     )
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA155, "failure-relay-option82"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": ["ip dhcp relay information option\ninterface Management1\n   ip address dhcp", RELAY_ACTIVE_OPTION82],

--- a/tests/units/anta_tests/advisories/test_sa_156.py
+++ b/tests/units/anta_tests/advisories/test_sa_156.py
@@ -194,7 +194,7 @@ def test_sa156_version_boundaries() -> None:
     # pylint: enable=duplicate-code
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA156, "failure-affected-release-even-with-setting"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [{"activeState": True}, "reply source-address validation", IP_LOCKING_INACTIVE, "DHCP relay is active", IP_LOCKING_INACTIVE],

--- a/tests/units/anta_tests/advisories/test_sa_157.py
+++ b/tests/units/anta_tests/advisories/test_sa_157.py
@@ -143,7 +143,7 @@ def expected_result(status: Status, issues: tuple[Issue, ...]) -> UnitTestResult
     # pylint: enable=duplicate-code
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA157, "failure-all-three-issues"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [VRRP_V2_IP_AH, VRRP_V2_IP_AH, ""],

--- a/tests/units/anta_tests/advisories/test_sa_158.py
+++ b/tests/units/anta_tests/advisories/test_sa_158.py
@@ -161,7 +161,7 @@ def expected_result(status: Status, issues: tuple[Issue, ...]) -> UnitTestResult
     }
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA158, "failure-both-issues"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [GNPSI_VULNERABLE, GNPSI_VULNERABLE, TRACE_ENABLED, GNPSI_VULNERABLE],

--- a/tests/units/anta_tests/advisories/test_sa_159.py
+++ b/tests/units/anta_tests/advisories/test_sa_159.py
@@ -57,7 +57,7 @@ def test_sa159_version_boundaries() -> None:
     )
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA159, "failure-affected-version"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [],

--- a/tests/units/anta_tests/advisories/test_sa_160.py
+++ b/tests/units/anta_tests/advisories/test_sa_160.py
@@ -233,7 +233,7 @@ def expected_result(status: Status, issues: tuple[Issue, ...]) -> UnitTestResult
     # pylint: enable=duplicate-code
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA160, "failure-all-three-issues"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [ISIS_BROADCAST, ISIS_CONFIGURED, ISIS_GRACEFUL_RESTART],

--- a/tests/units/anta_tests/advisories/test_sa_161.py
+++ b/tests/units/anta_tests/advisories/test_sa_161.py
@@ -78,7 +78,7 @@ EXPOSED_MLAG = {
     "detail": {"dualPrimaryDetectionDelay": 5, "dualPrimaryAction": "errdisableAllInterfaces"},
 }
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA161, "failure-configured"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [{**EXPOSED_MLAG, "state": "active", "peerLinkStatus": "up", "dualPrimaryDetectionState": "configured"}],

--- a/tests/units/anta_tests/advisories/test_sa_162.py
+++ b/tests/units/anta_tests/advisories/test_sa_162.py
@@ -46,7 +46,7 @@ def gnsi_eos_data(output: dict[str, Any]) -> list[dict[str, Any] | str]:
     return [output, output]
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA162, "failure-certz-enabled"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": gnsi_eos_data({"transports": {"default": {"enabled": True}}, "certzEnabled": True}),

--- a/tests/units/anta_tests/advisories/test_sa_163.py
+++ b/tests/units/anta_tests/advisories/test_sa_163.py
@@ -76,7 +76,7 @@ def transport(*, enabled: bool = True, authorization: bool = True, profile: str 
     return {"enabled": enabled, "authorization": authorization, "sslProfile": profile}
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA163, "affected-exposed-transport"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": [{"transports": {"default": transport()}}, TRUSTED_PROFILE, ""],

--- a/tests/units/anta_tests/advisories/test_sa_164.py
+++ b/tests/units/anta_tests/advisories/test_sa_164.py
@@ -41,7 +41,7 @@ OVERLAPPING_POLICY = '{"rules": [{"user": "alice", "path": {"elem": [{"name": "i
 DISJOINT_POLICY = '{"rules": [{"user": "alice", "path": {"elem": [{"name": "interfaces"}]}}, {"group": "operators", "path": {"elem": [{"name": "system"}]}}]}'
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA164, "affected-overlapping-policy"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": [{"transports": {"default": {"enabled": True}}}, {"pathzEnabled": True}, OVERLAPPING_POLICY],

--- a/tests/units/anta_tests/advisories/test_sa_165.py
+++ b/tests/units/anta_tests/advisories/test_sa_165.py
@@ -69,7 +69,7 @@ def test_sa165_version_boundaries() -> None:
     )
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA165, "failure-credentialz-enabled"): {
         "version": build_eos_version("4.36.0.1F"),
         "eos_data": [{"credentialzEnabled": True}],

--- a/tests/units/anta_tests/advisories/test_sa_166.py
+++ b/tests/units/anta_tests/advisories/test_sa_166.py
@@ -69,7 +69,7 @@ def test_sa166_version_boundaries() -> None:
     )
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA166, "failure-gnmi-enabled"): {
         "version": build_eos_version("4.36.0.1F"),
         "eos_data": [{"enabled": True}],

--- a/tests/units/anta_tests/advisories/test_sa_167.py
+++ b/tests/units/anta_tests/advisories/test_sa_167.py
@@ -46,7 +46,7 @@ def gnsi_eos_data(output: dict[str, Any]) -> list[dict[str, Any] | str]:
     return [output, output]
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA167, "affected-authz-exposed"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": gnsi_eos_data({"transports": {"default": {"enabled": True}}, "authzEnabled": True}),

--- a/tests/units/anta_tests/advisories/test_sa_168.py
+++ b/tests/units/anta_tests/advisories/test_sa_168.py
@@ -89,7 +89,7 @@ def test_sa168_version_boundaries() -> None:
     )
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA168, "failure-gnmi-enabled"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [{"enabled": True}, {"enabled": False}, {"enabled": False}],

--- a/tests/units/anta_tests/advisories/test_sa_169.py
+++ b/tests/units/anta_tests/advisories/test_sa_169.py
@@ -49,7 +49,7 @@ def gnsi_eos_data(output: dict[str, Any]) -> list[dict[str, Any] | str]:
     return [output, output, output]
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA169, "inconclusive-prerequisites-active"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": gnsi_eos_data(gnsi(enabled_transports=1, authz=True)),

--- a/tests/units/anta_tests/advisories/test_sa_170.py
+++ b/tests/units/anta_tests/advisories/test_sa_170.py
@@ -69,7 +69,7 @@ def test_sa170_version_boundaries() -> None:
     )
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA170, "failure-authorized-gnmi"): {
         "version": build_eos_version("4.36.0.1F"),
         "eos_data": [{"enabled": True, "authorization": True}],

--- a/tests/units/anta_tests/advisories/test_sa_171.py
+++ b/tests/units/anta_tests/advisories/test_sa_171.py
@@ -289,7 +289,7 @@ def expected_result(status: Status, issues: tuple[Issue, Issue]) -> UnitTestResu
     # pylint: enable=duplicate-code
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA171, "failure-both-issues"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": eos_data(BROADCAST_INTERFACE, "", BROADCAST_PROCESS_CONFIG, SEGMENT_ROUTING_EXPOSED),

--- a/tests/units/anta_tests/advisories/test_sa_172.py
+++ b/tests/units/anta_tests/advisories/test_sa_172.py
@@ -102,7 +102,7 @@ def test_sa172_version_boundaries() -> None:
     # pylint: enable=duplicate-code
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA172, "failure-current-ospfv3"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [CURRENT_OSPFV3, EMPTY_OSPFV3, UNAUTHENTICATED_CONFIG],

--- a/tests/units/anta_tests/advisories/test_sa_173.py
+++ b/tests/units/anta_tests/advisories/test_sa_173.py
@@ -82,7 +82,7 @@ def expected_result(status: ProductionStatus, message: str, remediation: Remedia
     return build_expected_advisory_result(ADVISORY.vulnerabilities[0].id, status, message, remediation)
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA173, "failure-configured-without-authentication"): {
         "version": build_eos_version("4.35.4M"),
         "eos_data": eos_data(CURRENT_OSPFV3, EMPTY_OSPFV3, UNAUTHENTICATED_CONFIG),

--- a/tests/units/anta_tests/advisories/test_sa_174.py
+++ b/tests/units/anta_tests/advisories/test_sa_174.py
@@ -61,7 +61,7 @@ def eos_data(p4_output: dict[str, Any], ssl_output: dict[str, Any], gnsi_output:
     return [p4_output, p4_output, ssl_output, p4_output, gnsi_output, gnsi_output]
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA174, "affected-without-mtls"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": eos_data(p4(profile=""), {}, {}),

--- a/tests/units/anta_tests/advisories/test_sa_175.py
+++ b/tests/units/anta_tests/advisories/test_sa_175.py
@@ -38,7 +38,7 @@ EXPECTED_4_32_REMEDIATION = software_version_plan(EXPECTED_FIXED_RELEASES, curre
 expected_result = partial(build_expected_advisory_result, ADVISORY.vulnerabilities[0].id)
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA175, "failure-canonical-ipv4-sparse-mode"): {
         "version": build_eos_version("4.35.5M"),
         "eos_data": ["pim ipv4 sparse-mode"],

--- a/tests/units/anta_tests/advisories/test_sa_176.py
+++ b/tests/units/anta_tests/advisories/test_sa_176.py
@@ -50,7 +50,7 @@ def modules(model: str) -> dict[str, object]:
     return {"modules": {"Switchcard1": {"modelName": model}}}
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA176, "failure-7050x4-loose-ipv4-urpf"): {
         "version": build_eos_version("4.35.4M"),
         "platform": build_eos_platform("DCS-7050CX4-40D"),

--- a/tests/units/anta_tests/advisories/test_sa_177.py
+++ b/tests/units/anta_tests/advisories/test_sa_177.py
@@ -48,7 +48,7 @@ MLAG_CONFIGURED = {
 MLAG_NOT_CONFIGURED: dict[str, object] = {}
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA177, "affected-pim-and-active-mlag"): {
         "version": build_eos_version("4.35.5M"),
         "platform": build_eos_platform("cEOSLab"),

--- a/tests/units/anta_tests/advisories/test_sa_178.py
+++ b/tests/units/anta_tests/advisories/test_sa_178.py
@@ -60,7 +60,7 @@ EXPECTED_CONVERT_REMEDIATION = RemediationPlan(EXPECTED_CONVERT_ACTION)
 expected_result = partial(build_expected_advisory_result, ADVISORY.vulnerabilities[0].id)
 
 
-DATA: AntaUnitTestData = {
+_DATA: AntaUnitTestData = {
     (SA178, "success-affected-version-with-encrypted-syntax"): {
         "version": build_eos_version("4.36.1F"),
         "eos_data": [SNMP_AUTH_ENABLED, ENCRYPTED_USER],


### PR DESCRIPTION
## Description

<!-- PR description !-->
Exclude SA tests from benchmark

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized advisory test data identifiers by marking them as module-private.
  - No changes to test behavior, assertions, or expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->