### PR TITLE
fix(anta): Adding more unsupported commands

### DIFF
--- a/anta/constants.py
+++ b/anta/constants.py
@@ -88,6 +88,8 @@ UNSUPPORTED_PLATFORM_ERRORS = [
     "Incomplete command (at token 1: 'ptp')",
     "Invalid input (at token 1: 'directflow')",
     "Invalid input (at token 3: 'gnpsi')",
+    "Invalid input (at token 3: 'gnsi')",
+    "Invalid input (at token 3: 'segment-routing')",
 ]
 """Error messages indicating platform or hardware unsupported commands. Includes both general hardware
 platform errors and specific ASIC family limitations.


### PR DESCRIPTION
## Description

<!-- PR description !-->

Fixes # (issue id)

## Checklist

<!-- Delete not relevant items !-->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unsupported `gnsi` and `segment-routing` commands by recognizing their platform error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->