### PR TITLE
doc: extend snippet generation tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ If you plan to use ANTA only as a CLI tool you can use `pipx` to install it.
 ```bash
 # Install ANTA CLI with pipx
 $ pipx install anta[cli]
+```
 
-# Run ANTA CLI
+Run the ANTA CLI:
+
+```bash
 $ anta --help
 Usage: anta [OPTIONS] COMMAND [ARGS]...
 
@@ -69,7 +72,7 @@ Commands:
   exec   Commands to execute various scripts on EOS devices.
   get    Commands to get information from or generate inventories.
   nrfu   Run ANTA tests on selected inventory devices.
-  psirt  Run ANTA tests for Arista security advisories.
+  psirt  [PREVIEW] Run ANTA tests for Arista security advisories.
 ```
 
 You can also still choose to install it directly with `pip`:

--- a/docs/scripts/generate_doc_snippets.py
+++ b/docs/scripts/generate_doc_snippets.py
@@ -2,15 +2,18 @@
 # Copyright (c) 2024-2026 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
-"""Generates SVG for documentation purposes."""
+"""Generate stable CLI help snippets and synchronize README help text."""
 
+import re
 import sys
 from pathlib import Path
 
-# TODO: svg in  another PR
 from generate_snippet import main as generate_snippet
 
-sys.path.insert(0, str(Path(__file__).parents[2]))
+REPOSITORY_ROOT = Path(__file__).parents[2]
+README_HELP_PATTERN = re.compile(r"(?P<intro>^Run the ANTA CLI:\n\n)```bash\n.*?^```", flags=re.DOTALL | re.MULTILINE)
+
+sys.path.insert(0, str(REPOSITORY_ROOT))
 
 COMMANDS = [
     "anta --help",
@@ -39,6 +42,26 @@ COMMANDS = [
     "anta debug run-template --help",
 ]
 
-for command in COMMANDS:
-    # TODO: svg in  another PR
-    generate_snippet(command.split(" "), output="txt")
+
+def sync_readme_help(readme: Path, help_snippet: Path) -> None:
+    """Synchronize the standalone README help block with its generated text snippet."""
+    readme_content = readme.read_text(encoding="utf-8")
+    help_content = help_snippet.read_text(encoding="utf-8").rstrip()
+    replacement = rf"\g<intro>```bash\n{help_content}\n```"
+    updated_content, replacement_count = README_HELP_PATTERN.subn(replacement, readme_content)
+    if replacement_count != 1:
+        msg = f"Expected exactly one help block after 'Run the ANTA CLI:' in {readme}, found {replacement_count}"
+        raise ValueError(msg)
+    readme.write_text(updated_content, encoding="utf-8")
+
+
+def main() -> None:
+    """Generate CLI help snippets and update their standalone README copy."""
+    for command in COMMANDS:
+        generate_snippet(command.split(" "), output="txt")
+
+    sync_readme_help(REPOSITORY_ROOT / "README.md", REPOSITORY_ROOT / "docs/snippets/anta_help.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/generate_snippet.py
+++ b/docs/scripts/generate_snippet.py
@@ -109,6 +109,13 @@ def limit_console_lines(max_lines: int | None) -> None:
     console.print(Text.from_ansi(output_lines[-1]))
 
 
+def finalize_console_output(max_lines: int | None, omitted_results: int) -> None:
+    """Apply line truncation, then append result-omission metadata."""
+    limit_console_lines(max_lines)
+    if omitted_results:
+        console.print(f"\n[dim]{format_omitted_results(omitted_results)}[/]")
+
+
 def custom_progress_bar() -> Progress:
     """Set the console of progress_bar to main anta console.
 
@@ -180,13 +187,10 @@ def main(args: list[str], output: Literal["svg", "txt"] = "svg", max_results: in
             console.print(f"$ {' '.join(sys.argv)}")
         function()
 
-    if omitted_results:
-        console.print(f"\n[dim]{format_omitted_results(omitted_results)}[/]")
-
     if "--help" in args:
         console.print(escape(f.getvalue()))
 
-    limit_console_lines(max_lines)
+    finalize_console_output(max_lines, omitted_results)
 
     filename = f"{'_'.join(x.replace('/', '_').replace('-', '').replace('.', '') for x in args)}.{output}"
     filename = output_dir / filename

--- a/docs/scripts/generate_snippet.py
+++ b/docs/scripts/generate_snippet.py
@@ -6,11 +6,12 @@
 
 usage:
 
-python generate_snippet.py anta ...
+python generate_snippet.py [--format {svg,txt}] [--max-results MAX_RESULTS] [--max-lines MAX_LINES] anta ...
 """
 # This script contains print statements
 # ruff: noqa: T201
 
+import argparse
 import io
 import logging
 import os
@@ -23,14 +24,18 @@ from importlib.metadata import entry_points
 from typing import Literal
 from unittest.mock import patch
 
+import click
 from rich.logging import RichHandler
 from rich.markup import escape
 from rich.progress import Progress
+from rich.text import Text
 
 sys.path.insert(0, str(pathlib.Path(__file__).parents[2]))
 
 from anta.cli.console import console
+from anta.cli.nrfu import commands as nrfu_commands
 from anta.cli.nrfu.utils import anta_progress_bar
+from anta.result_manager import ResultManager
 
 root = logging.getLogger()
 
@@ -38,6 +43,70 @@ r = RichHandler(console=console)
 root.addHandler(r)
 
 SNAPSHOT_OUTPUT_PATTERN = re.compile(r"anta_snapshot_\d{4}-\d{2}-\d{2}_\d{2}_\d{2}_\d{2}")
+
+
+def positive_integer(value: str) -> int:
+    """Parse a strictly positive integer."""
+    parsed_value = int(value)
+    if parsed_value <= 0:
+        msg = "must be greater than zero"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed_value
+
+
+def parse_args(args: list[str] | None = None) -> tuple[list[str], Literal["svg", "txt"], int | None, int | None]:
+    """Parse the snippet generator command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", choices=("svg", "txt"), default="svg", dest="output_format", help="Output format (default: svg).")
+    parser.add_argument("--max-results", type=positive_integer, help="Maximum number of ANTA results to include in rendered reports.")
+    parser.add_argument("--max-lines", type=positive_integer, help="Maximum number of terminal output lines to include.")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="ANTA command and arguments to capture.")
+    parsed_args = parser.parse_args(args)
+    if not parsed_args.command:
+        parser.error("an ANTA command is required")
+    return parsed_args.command, parsed_args.output_format, parsed_args.max_results, parsed_args.max_lines
+
+
+def limit_result_manager(manager: ResultManager, max_results: int | None) -> tuple[ResultManager, int]:
+    """Return a result manager limited to the requested number of results."""
+    if max_results is None or len(manager) <= max_results:
+        return manager, 0
+
+    limited_manager = ResultManager()
+    limited_manager.results = manager.results[:max_results]
+    return limited_manager, len(manager) - max_results
+
+
+def format_omitted_results(count: int) -> str:
+    """Format the message shown when results are omitted."""
+    result_label = "result" if count == 1 else "results"
+    return f"... {count} {result_label} omitted ..."
+
+
+def normalize_svg_whitespace(svg_path: pathlib.Path) -> None:
+    """Remove trailing horizontal whitespace emitted by Rich without changing SVG rendering."""
+    content = svg_path.read_text(encoding="utf-8")
+    svg_path.write_text(re.sub(r"[ \t]+$", "", content, flags=re.MULTILINE), encoding="utf-8")
+
+
+def limit_console_lines(max_lines: int | None) -> None:
+    """Limit recorded console output while preserving ANSI styles and the final status line."""
+    if max_lines is None:
+        return
+
+    rendered_output = console.export_text(clear=True, styles=True)
+    output_lines = rendered_output.splitlines()
+    if len(output_lines) <= max_lines:
+        console.print(Text.from_ansi(rendered_output), end="")
+        return
+
+    head_count = max(max_lines - 1, 0)
+    omitted_lines = len(output_lines) - head_count - 1
+    line_label = "line" if omitted_lines == 1 else "lines"
+    if head_count:
+        console.print(Text.from_ansi("\n".join(output_lines[:head_count])))
+    console.print(f"\n[dim]... {omitted_lines} {line_label} omitted ...[/]\n")
+    console.print(Text.from_ansi(output_lines[-1]))
 
 
 def custom_progress_bar() -> Progress:
@@ -52,7 +121,7 @@ def custom_progress_bar() -> Progress:
     return progress
 
 
-def main(args: list[str], output: Literal["svg", "txt"] = "svg") -> None:
+def main(args: list[str], output: Literal["svg", "txt"] = "svg", max_results: int | None = None, max_lines: int | None = None) -> None:
     """Execute the script."""
     # Sane rich size
     os.environ["COLUMNS"] = "120"
@@ -84,19 +153,40 @@ def main(args: list[str], output: Literal["svg", "txt"] = "svg") -> None:
     module = import_module(module_path)
     function = getattr(module, function_name)
 
+    omitted_results = 0
+    original_run_tests = nrfu_commands.run_tests
+
+    def run_tests_and_limit_results(ctx: click.Context) -> object:
+        """Run the tests and apply the snippet limit before rendering."""
+        nonlocal omitted_results
+        run_context = original_run_tests(ctx)
+        limited_manager, omitted_results = limit_result_manager(ctx.obj["result_manager"], max_results)
+        ctx.obj["result_manager"] = limited_manager
+        return run_context
+
     pipe = io.StringIO()
     console.record = True
     console.file = pipe
     # Redirect stdout of the program towards another StringIO to capture help
     # that is not part or anta rich console
     # redirect potential progress bar output to console by patching
-    with redirect_stdout(io.StringIO()) as f, patch("anta.cli.nrfu.utils.anta_progress_bar", custom_progress_bar), suppress(SystemExit):
+    with (
+        redirect_stdout(io.StringIO()) as f,
+        patch("anta.cli.nrfu.utils.anta_progress_bar", custom_progress_bar),
+        patch("anta.cli.nrfu.commands.run_tests", run_tests_and_limit_results),
+        suppress(SystemExit),
+    ):
         if output == "txt":
             console.print(f"$ {' '.join(sys.argv)}")
         function()
 
+    if omitted_results:
+        console.print(f"\n[dim]{format_omitted_results(omitted_results)}[/]")
+
     if "--help" in args:
         console.print(escape(f.getvalue()))
+
+    limit_console_lines(max_lines)
 
     filename = f"{'_'.join(x.replace('/', '_').replace('-', '').replace('.', '') for x in args)}.{output}"
     filename = output_dir / filename
@@ -107,9 +197,11 @@ def main(args: list[str], output: Literal["svg", "txt"] = "svg") -> None:
         # TODO: Not using this to avoid newline console.save_text(str(filename))
     elif output == "svg":
         console.save_svg(str(filename), title=" ".join(args))
+        normalize_svg_whitespace(filename)
 
     print(f"File saved at {filename}")
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:], "svg")
+    command, output_format, parsed_max_results, parsed_max_lines = parse_args()
+    main(command, output_format, parsed_max_results, parsed_max_lines)

--- a/tests/docs/test_doc_output_examples.py
+++ b/tests/docs/test_doc_output_examples.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Tests for reproducible documentation output examples."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+README_HELP_PATTERN = re.compile(r"^Run the ANTA CLI:\n\n(?P<help>```bash\n.*?^```)", flags=re.DOTALL | re.MULTILINE)
+
+
+def test_readme_help_matches_generated_snippet() -> None:
+    """Verify the standalone README help block matches generated CLI help."""
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+    generated_help = (REPOSITORY_ROOT / "docs/snippets/anta_help.txt").read_text(encoding="utf-8").rstrip()
+    match = README_HELP_PATTERN.search(readme)
+
+    assert match is not None
+    assert match.group("help") == f"```bash\n{generated_help}\n```"

--- a/tests/docs/test_generate_snippet.py
+++ b/tests/docs/test_generate_snippet.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+"""Tests for the documentation snippet generator."""
+
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+import pytest
+
+from anta.cli.console import console
+from anta.result_manager import ResultManager
+from anta.result_manager.models import TestResult as AntaTestResult
+from docs.scripts.generate_snippet import (
+    format_omitted_results,
+    limit_console_lines,
+    limit_result_manager,
+    normalize_svg_whitespace,
+    parse_args,
+    positive_integer,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_format", "expected_max_results", "expected_max_lines"),
+    [
+        (["anta", "--help"], "svg", None, None),
+        (["--format", "txt", "--max-results", "10", "--max-lines", "20", "anta", "--help"], "txt", 10, 20),
+    ],
+)
+def test_parse_args(args: list[str], expected_format: str, expected_max_results: int | None, expected_max_lines: int | None) -> None:
+    """Verify the default and explicit output formats."""
+    command, output_format, max_results, max_lines = parse_args(args)
+
+    assert command == ["anta", "--help"]
+    assert output_format == expected_format
+    assert max_results == expected_max_results
+    assert max_lines == expected_max_lines
+
+
+def test_parse_args_requires_command() -> None:
+    """Verify an ANTA command is required."""
+    with pytest.raises(SystemExit):
+        parse_args(["--format", "svg"])
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_positive_integer_rejects_non_positive_values(value: str) -> None:
+    """Verify the result limit must be greater than zero."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        positive_integer(value)
+
+
+def test_limit_result_manager() -> None:
+    """Verify result managers are truncated without mutating the original."""
+    result_count = 3
+    manager = ResultManager()
+    manager.results = [AntaTestResult(name=f"device-{index}", test="VerifyTest", categories=[], description="Test") for index in range(result_count)]
+
+    limited_manager, omitted_results = limit_result_manager(manager, 2)
+
+    assert [result.name for result in limited_manager.results] == ["device-0", "device-1"]
+    assert omitted_results == 1
+    assert len(manager) == result_count
+
+
+@pytest.mark.parametrize(("count", "expected"), [(1, "... 1 result omitted ..."), (2, "... 2 results omitted ...")])
+def test_format_omitted_results(count: int, expected: str) -> None:
+    """Verify the omission message handles singular and plural results."""
+    assert format_omitted_results(count) == expected
+
+
+def test_normalize_svg_whitespace(tmp_path: Path) -> None:
+    """Verify SVG normalization removes trailing whitespace and preserves line endings."""
+    svg_path = tmp_path / "capture.svg"
+    svg_path.write_text("<svg>  \n  <text>output</text>\t\n</svg>\n", encoding="utf-8")
+
+    normalize_svg_whitespace(svg_path)
+
+    assert svg_path.read_text(encoding="utf-8") == "<svg>\n  <text>output</text>\n</svg>\n"
+
+
+def test_limit_console_lines() -> None:
+    """Verify truncation preserves the beginning and final terminal status line."""
+    console.record = True
+    console.export_text(clear=True)
+    console.print("first\nsecond\nthird")
+
+    limit_console_lines(2)
+
+    assert console.export_text(clear=True) == "first\n\n... 1 line omitted ...\n\nthird\n"

--- a/tests/docs/test_generate_snippet.py
+++ b/tests/docs/test_generate_snippet.py
@@ -6,16 +6,17 @@
 from __future__ import annotations
 
 import argparse
+import io
 from typing import TYPE_CHECKING
 
 import pytest
+from rich.console import Console
 
-from anta.cli.console import console
 from anta.result_manager import ResultManager
 from anta.result_manager.models import TestResult as AntaTestResult
 from docs.scripts.generate_snippet import (
+    finalize_console_output,
     format_omitted_results,
-    limit_console_lines,
     limit_result_manager,
     normalize_svg_whitespace,
     parse_args,
@@ -85,12 +86,12 @@ def test_normalize_svg_whitespace(tmp_path: Path) -> None:
     assert svg_path.read_text(encoding="utf-8") == "<svg>\n  <text>output</text>\n</svg>\n"
 
 
-def test_limit_console_lines() -> None:
-    """Verify truncation preserves the beginning and final terminal status line."""
-    console.record = True
-    console.export_text(clear=True)
-    console.print("first\nsecond\nthird")
+def test_finalize_console_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify truncation preserves the final status line before result-omission metadata."""
+    test_console = Console(file=io.StringIO(), record=True)
+    monkeypatch.setattr("docs.scripts.generate_snippet.console", test_console)
+    test_console.print("first\nsecond\nthird")
 
-    limit_console_lines(2)
+    finalize_console_output(max_lines=2, omitted_results=2)
 
-    assert console.export_text(clear=True) == "first\n\n... 1 line omitted ...\n\nthird\n"
+    assert test_console.export_text(clear=True) == "first\n\n... 1 line omitted ...\n\nthird\n\n... 2 results omitted ...\n"


### PR DESCRIPTION
## Summary

- add SVG/text output selection and result/line limits to the documentation snippet generator
- normalize generated SVG trailing whitespace and preserve final status lines when truncating output
- keep the visible README CLI help block synchronized without HTML markers
- add focused tests for generator behavior and README freshness

## Validation

- uv run --extra cli --group test pytest tests/docs/test_generate_snippet.py tests/docs/test_doc_output_examples.py -q
- pre-commit run --all-files
- uv run --group doc --with-editable tools/zensical_extensions zensical build --strict --clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pipx installation guidance with explicit CLI execution instructions.
  * Marked the `psirt` command as preview.
  * README CLI help is now synchronized with generated help output.

* **New Features**
  * Documentation snippet generation supports SVG or text output, result limits, and console-line limits.
  * Generated snippets now report omitted results and normalize SVG whitespace.

* **Tests**
  * Added coverage for snippet options, validation, truncation, formatting, and README help synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->