### PR TITLE
ci: simplify code testing workflow

### DIFF
--- a/.github/workflows/code-testing.yml
+++ b/.github/workflows/code-testing.yml
@@ -1,5 +1,5 @@
 ---
-name: Linting and Testing ANTA
+name: Testing ANTA
 on:
   push:
     branches:
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
-      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -24,85 +23,13 @@ jobs:
         with:
           filters: |
             code:
-              - 'anta/*'
               - 'anta/**'
-              - 'tests/*'
               - 'tests/**'
               # detect dependency changes
               - 'pyproject.toml'
-            core:
-              - 'anta/*'
-              - 'anta/reporter/*'
-              - 'anta/result_manager/*'
-              - 'anta/tools/*'
-            cli:
-              - 'anta/cli/*'
-              - 'anta/cli/**'
-            tests:
-              - 'anta/tests/*'
-              - 'anta/tests/**'
-            docs:
-              - '.github/workflows/pull-request-management.yml'
-              - 'tools/zensical_extensions/**'
-              - 'mkdocs.yml'
-              - 'docs/*'
-              - 'docs/**'
-              - 'README.md'
-  check-requirements:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    needs: file-changes
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: install requirements
-        run: |
-          pip install .
-      - name: install dev requirements
-        run: pip install --group dev
-  lint-python:
-    name: Check the code style
-    runs-on: ubuntu-latest
-    needs: file-changes
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: pip install tox
-      - name: "Run tox linting environment"
-        run: tox run -e lint
-  type-python:
-    name: Check typing
-    runs-on: ubuntu-latest
-    needs: file-changes
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: pip install tox
-      - name: "Run tox typing environment"
-        run: tox run -e type
   test-python:
     name: Pytest across all supported python versions
     runs-on: ubuntu-latest
-    needs: [lint-python, type-python]
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -129,7 +56,7 @@ jobs:
   test-python-windows:
     name: Pytest on 3.12 for windows
     runs-on: windows-2022
-    needs: [lint-python, type-python]
+    needs: [file-changes]
     if: needs.file-changes.outputs.code == 'true'
     env:
       # Required to prevent asyncssh to fail.
@@ -149,7 +76,6 @@ jobs:
   test-documentation:
     name: Build offline documentation for testing
     runs-on: ubuntu-latest
-    needs: [test-python]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -160,22 +86,12 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install dependencies
-        run: |
-          # Keep generated CLI snippets stable with Click's optional subcommand rendering.
-          pip install -e ".[cli]" "click~=8.4.2" --group doc -e tools/zensical_extensions
-      - name: "Check generated CLI doc snippets"
-        run: |
-          python docs/scripts/generate_doc_snippets.py
-          if [ -n "$(git status --porcelain -- docs/snippets)" ]; then
-            git status --short -- docs/snippets
-            git diff -- docs/snippets
-            exit 1
-          fi
+        run: pip install -e ".[cli]" --group doc -e tools/zensical_extensions
       - name: "Build Zensical documentation offline"
         run: zensical build --strict
   benchmarks:
     name: Benchmark ANTA for Python 3.12
-    needs: [test-python]
+    needs: [file-changes, test-python]
     if: needs.file-changes.outputs.code == 'true' && github.repository == 'aristanetworks/anta'
     permissions:
       contents: read

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -401,7 +401,7 @@ git diff --exit-code -- docs/snippets
 test -z "$(git status --porcelain -- docs/snippets)"
 ```
 
-The `doc-snippets` pre-commit hook runs the generator for CLI changes, and CI runs the same freshness check before building the documentation.
+The `doc-snippets` pre-commit hook runs the generator for CLI changes, and the autofix workflow commits any updated snippets to the pull request.
 
 ### Curated class diagram
 


### PR DESCRIPTION
## Description

Simplify the main code-testing workflow by relying on `autofix.ci` for checks it already runs and by removing unnecessary job dependencies.

- Remove the standalone lint and typing jobs because the autofix pre-commit pass already runs Ruff, Pylint, and Pyright.
- Remove the requirements matrix because the tox pytest matrix installs ANTA and the development dependencies on every supported Python version.
- Remove the generated CLI snippet check from the documentation job because the autofix workflow already runs the `doc-snippets` hook and commits updates.
- Start pytest and the strict documentation build immediately instead of waiting for unrelated checks.
- Keep CodSpeed behind successful pytest and the code-path filter so documentation-only pull requests skip benchmarks.
- Remove unused path-filter outputs and document that autofix maintains generated CLI snippets.

Validation:

- `pre-commit run --all-files`
- `uv run --group doc --with-editable tools/zensical_extensions zensical build --strict`
- `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [x] I have made corresponding changes to the documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance to clarify that the autofix workflow commits refreshed CLI snippets to pull requests.

- **Chores**
  - Streamlined automated testing workflows across supported Python versions and Windows.
  - Simplified documentation build dependencies and workflow conditions.
  - Updated the workflow name to “Testing ANTA.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->