### PR TITLE
fix(anta): apply connectivity timeout to session login

### DIFF
--- a/asynceapi/_auth.py
+++ b/asynceapi/_auth.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from ._constants import EAPI_CONNECTIVITY_TIMEOUT
 from .errors import EapiAsyncOnlyError, EapiAuthenticationError
 
 LOGGER = logging.getLogger(__name__)
@@ -72,8 +73,12 @@ class EapiSessionAuth(httpx.Auth):
             async with self._lock:
                 if not self.logged_in:
                     LOGGER.debug("Performing login for %s...", self._host)
-                    # Send login request
-                    login_request = httpx.Request("POST", self._login_url, json={"username": self._username, "password": self._password})
+                    login_request = httpx.Request(
+                        "POST",
+                        self._login_url,
+                        json={"username": self._username, "password": self._password},
+                        extensions={"timeout": httpx.Timeout(EAPI_CONNECTIVITY_TIMEOUT).as_dict()},
+                    )
                     login_response = yield login_request
 
                     # Validate response

--- a/asynceapi/_constants.py
+++ b/asynceapi/_constants.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 from enum import Enum
 
+EAPI_CONNECTIVITY_TIMEOUT = 5
+"""Seconds to wait while establishing connectivity during refresh and session login."""
+
 
 class EapiCommandFormat(str, Enum):
     """Enum for the eAPI command format.

--- a/asynceapi/device.py
+++ b/asynceapi/device.py
@@ -25,7 +25,7 @@ from ._auth import EapiSessionAuth
 # -----------------------------------------------------------------------------
 # Private Imports
 # -----------------------------------------------------------------------------
-from ._constants import EapiCommandFormat
+from ._constants import EAPI_CONNECTIVITY_TIMEOUT, EapiCommandFormat
 from .aio_portcheck import port_check_url
 from .config_session import SessionConfig
 from .errors import EapiCommandError
@@ -180,7 +180,7 @@ class Device(httpx.AsyncClient):
             True when the device eAPI HTTP endpoint is accessible (2xx status code),
             otherwise an HTTPStatusError exception is raised.
         """
-        response = await self.head(self.EAPI_COMMAND_API_URL, timeout=5)
+        response = await self.head(self.EAPI_COMMAND_API_URL, timeout=EAPI_CONNECTIVITY_TIMEOUT)
         response.raise_for_status()
         return True
 

--- a/tests/units/asynceapi/test__auth.py
+++ b/tests/units/asynceapi/test__auth.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 
 from asynceapi._auth import EapiSessionAuth, _cookie_fingerprint
+from asynceapi._constants import EAPI_CONNECTIVITY_TIMEOUT
 from asynceapi.errors import EapiAsyncOnlyError, EapiAuthenticationError
 
 _HOST = "192.0.2.1"
@@ -81,6 +82,7 @@ async def test_auth_flow_login_success(session_auth: EapiSessionAuth) -> None:
 
     login_req = await anext(gen)
     assert login_req.url.path == "/login"
+    assert login_req.extensions["timeout"] == httpx.Timeout(EAPI_CONNECTIVITY_TIMEOUT).as_dict()
 
     login_response = httpx.Response(200, headers={"Set-Cookie": f"Session={_SESSION_COOKIE}; Path=/"}, request=login_req)
     cmd_req = await gen.asend(login_response)


### PR DESCRIPTION
## Description

When `--use-session-auth` is enabled, the initial `POST /login` request in `EapiSessionAuth` did not set a connect timeout. On unreachable inventory hosts, inventory refresh could block for ~2 minutes (OS TCP retry window) instead of failing fast like basic-auth refresh via `check_api_endpoint()`.

This change applies the same 5-second connectivity timeout to session login and centralizes the value as `EAPI_CONNECTIVITY_TIMEOUT`.

Fixes # (issue id)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run pre-commit for code linting and typing (`pre-commit run`)
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tox -e testenv`)