### PR TITLE
doc: refresh security advisory examples

### DIFF
--- a/docs/imgs/anta_psirt_mdreport_mdoutput_psirtmd.svg
+++ b/docs/imgs/anta_psirt_mdreport_mdoutput_psirtmd.svg
@@ -1,0 +1,111 @@
+<svg class="rich-terminal" viewBox="0 0 1482 342.79999999999995" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3787747527-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3787747527-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3787747527-r1 { fill: #68a0b3 }
+.terminal-3787747527-r2 { fill: #98a84b }
+.terminal-3787747527-r3 { fill: #c5c8c6 }
+.terminal-3787747527-r4 { fill: #4e707b }
+.terminal-3787747527-r5 { fill: #608ab1 }
+.terminal-3787747527-r6 { fill: #d0b344 }
+.terminal-3787747527-r7 { fill: #868887 }
+.terminal-3787747527-r8 { fill: #68a0b3;font-weight: bold }
+.terminal-3787747527-r9 { fill: #98729f }
+.terminal-3787747527-r10 { fill: #729c1f }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3787747527-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="291.79999999999995" />
+    </clipPath>
+    <clipPath id="terminal-3787747527-line-0">
+    <rect x="0" y="1.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-1">
+    <rect x="0" y="25.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-2">
+    <rect x="0" y="50.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-3">
+    <rect x="0" y="74.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-4">
+    <rect x="0" y="99.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-5">
+    <rect x="0" y="123.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-6">
+    <rect x="0" y="147.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-7">
+    <rect x="0" y="172.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-8">
+    <rect x="0" y="196.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-9">
+    <rect x="0" y="221.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3787747527-line-10">
+    <rect x="0" y="245.5" width="1464" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="340.8" rx="8"/><text class="terminal-3787747527-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">anta&#160;psirt&#160;md-report&#160;--md-output&#160;psirt.md</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3787747527-clip-terminal)">
+
+    <g class="terminal-3787747527-matrix">
+    <text class="terminal-3787747527-r1" x="0" y="20" textLength="24.4" clip-path="url(#terminal-3787747527-line-0)">╭─</text><text class="terminal-3787747527-r1" x="24.4" y="20" textLength="256.2" clip-path="url(#terminal-3787747527-line-0)">─────────────────────</text><text class="terminal-3787747527-r2" x="292.8" y="20" textLength="97.6" clip-path="url(#terminal-3787747527-line-0)">Settings</text><text class="terminal-3787747527-r1" x="402.6" y="20" textLength="256.2" clip-path="url(#terminal-3787747527-line-0)">─────────────────────</text><text class="terminal-3787747527-r1" x="658.8" y="20" textLength="24.4" clip-path="url(#terminal-3787747527-line-0)">─╮</text><text class="terminal-3787747527-r3" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-3787747527-line-0)">
+</text><text class="terminal-3787747527-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-3787747527-line-1)">│</text><text class="terminal-3787747527-r1" x="24.4" y="44.4" textLength="634.4" clip-path="url(#terminal-3787747527-line-1)">-&#160;ANTA&#160;Inventory&#160;contains&#160;8&#160;devices&#160;(AsyncEOSDevice)</text><text class="terminal-3787747527-r1" x="671" y="44.4" textLength="12.2" clip-path="url(#terminal-3787747527-line-1)">│</text><text class="terminal-3787747527-r3" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-3787747527-line-1)">
+</text><text class="terminal-3787747527-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-3787747527-line-2)">│</text><text class="terminal-3787747527-r1" x="24.4" y="68.8" textLength="402.6" clip-path="url(#terminal-3787747527-line-2)">-&#160;Tests&#160;catalog&#160;contains&#160;35&#160;tests</text><text class="terminal-3787747527-r1" x="671" y="68.8" textLength="12.2" clip-path="url(#terminal-3787747527-line-2)">│</text><text class="terminal-3787747527-r3" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-3787747527-line-2)">
+</text><text class="terminal-3787747527-r1" x="0" y="93.2" textLength="683.2" clip-path="url(#terminal-3787747527-line-3)">╰──────────────────────────────────────────────────────╯</text><text class="terminal-3787747527-r3" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-3787747527-line-3)">
+</text><text class="terminal-3787747527-r3" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-3787747527-line-4)">
+</text><text class="terminal-3787747527-r4" x="0" y="142" textLength="231.8" clip-path="url(#terminal-3787747527-line-5)">[09/11/26&#160;10:46:38]</text><text class="terminal-3787747527-r5" x="244" y="142" textLength="97.6" clip-path="url(#terminal-3787747527-line-5)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r3" x="353.8" y="142" textLength="219.6" clip-path="url(#terminal-3787747527-line-5)">ANTA&#160;run&#160;starting&#160;</text><text class="terminal-3787747527-r6" x="573.4" y="142" textLength="36.6" clip-path="url(#terminal-3787747527-line-5)">...</text><text class="terminal-3787747527-r7" x="1293.2" y="142" textLength="122" clip-path="url(#terminal-3787747527-line-5)">_runner.py</text><text class="terminal-3787747527-r7" x="1415.2" y="142" textLength="12.2" clip-path="url(#terminal-3787747527-line-5)">:</text><text class="terminal-3787747527-r7" x="1427.4" y="142" textLength="36.6" clip-path="url(#terminal-3787747527-line-5)">261</text><text class="terminal-3787747527-r3" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-3787747527-line-5)">
+</text><text class="terminal-3787747527-r4" x="0" y="166.4" textLength="231.8" clip-path="url(#terminal-3787747527-line-6)">[09/11/26&#160;10:46:39]</text><text class="terminal-3787747527-r6" x="244" y="166.4" textLength="97.6" clip-path="url(#terminal-3787747527-line-6)">WARNING&#160;</text><text class="terminal-3787747527-r3" x="353.8" y="166.4" textLength="902.8" clip-path="url(#terminal-3787747527-line-6)">Security&#160;Advisory&#160;tests&#160;are&#160;in&#160;preview&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r7" x="1268.8" y="166.4" textLength="158.6" clip-path="url(#terminal-3787747527-line-6)">decorators.py</text><text class="terminal-3787747527-r7" x="1427.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3787747527-line-6)">:</text><text class="terminal-3787747527-r7" x="1439.6" y="166.4" textLength="24.4" clip-path="url(#terminal-3787747527-line-6)">24</text><text class="terminal-3787747527-r3" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-3787747527-line-6)">
+</text><text class="terminal-3787747527-r5" x="244" y="190.8" textLength="97.6" clip-path="url(#terminal-3787747527-line-7)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r3" x="353.8" y="190.8" textLength="329.4" clip-path="url(#terminal-3787747527-line-7)">Initial&#160;inventory&#160;contains&#160;</text><text class="terminal-3787747527-r8" x="683.2" y="190.8" textLength="12.2" clip-path="url(#terminal-3787747527-line-7)">8</text><text class="terminal-3787747527-r3" x="695.4" y="190.8" textLength="585.6" clip-path="url(#terminal-3787747527-line-7)">&#160;devices&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r7" x="1293.2" y="190.8" textLength="122" clip-path="url(#terminal-3787747527-line-7)">_runner.py</text><text class="terminal-3787747527-r7" x="1415.2" y="190.8" textLength="12.2" clip-path="url(#terminal-3787747527-line-7)">:</text><text class="terminal-3787747527-r7" x="1427.4" y="190.8" textLength="36.6" clip-path="url(#terminal-3787747527-line-7)">452</text><text class="terminal-3787747527-r3" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-3787747527-line-7)">
+</text><text class="terminal-3787747527-r5" x="244" y="215.2" textLength="97.6" clip-path="url(#terminal-3787747527-line-8)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r8" x="353.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3787747527-line-8)">8</text><text class="terminal-3787747527-r3" x="366" y="215.2" textLength="915" clip-path="url(#terminal-3787747527-line-8)">&#160;devices&#160;selected&#160;for&#160;testing&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r7" x="1293.2" y="215.2" textLength="122" clip-path="url(#terminal-3787747527-line-8)">_runner.py</text><text class="terminal-3787747527-r7" x="1415.2" y="215.2" textLength="12.2" clip-path="url(#terminal-3787747527-line-8)">:</text><text class="terminal-3787747527-r7" x="1427.4" y="215.2" textLength="36.6" clip-path="url(#terminal-3787747527-line-8)">462</text><text class="terminal-3787747527-r3" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-3787747527-line-8)">
+</text><text class="terminal-3787747527-r5" x="244" y="239.6" textLength="97.6" clip-path="url(#terminal-3787747527-line-9)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r8" x="353.8" y="239.6" textLength="36.6" clip-path="url(#terminal-3787747527-line-9)">280</text><text class="terminal-3787747527-r3" x="390.4" y="239.6" textLength="890.6" clip-path="url(#terminal-3787747527-line-9)">&#160;total&#160;tests&#160;scheduled&#160;across&#160;all&#160;selected&#160;devices&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3787747527-r7" x="1293.2" y="239.6" textLength="122" clip-path="url(#terminal-3787747527-line-9)">_runner.py</text><text class="terminal-3787747527-r7" x="1415.2" y="239.6" textLength="12.2" clip-path="url(#terminal-3787747527-line-9)">:</text><text class="terminal-3787747527-r7" x="1427.4" y="239.6" textLength="36.6" clip-path="url(#terminal-3787747527-line-9)">463</text><text class="terminal-3787747527-r3" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-3787747527-line-9)">
+</text><text class="terminal-3787747527-r3" x="24.4" y="264" textLength="12.2" clip-path="url(#terminal-3787747527-line-10)">•</text><text class="terminal-3787747527-r3" x="48.8" y="264" textLength="207.4" clip-path="url(#terminal-3787747527-line-10)">Running&#160;Tests&#160;...</text><text class="terminal-3787747527-r9" x="256.2" y="264" textLength="48.8" clip-path="url(#terminal-3787747527-line-10)">100%</text><text class="terminal-3787747527-r10" x="317.2" y="264" textLength="805.2" clip-path="url(#terminal-3787747527-line-10)">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</text><text class="terminal-3787747527-r2" x="1134.6" y="264" textLength="85.4" clip-path="url(#terminal-3787747527-line-10)">280/280</text><text class="terminal-3787747527-r3" x="1232.2" y="264" textLength="12.2" clip-path="url(#terminal-3787747527-line-10)">•</text><text class="terminal-3787747527-r6" x="1256.6" y="264" textLength="85.4" clip-path="url(#terminal-3787747527-line-10)">0:00:31</text><text class="terminal-3787747527-r3" x="1354.2" y="264" textLength="12.2" clip-path="url(#terminal-3787747527-line-10)">•</text><text class="terminal-3787747527-r1" x="1378.6" y="264" textLength="85.4" clip-path="url(#terminal-3787747527-line-10)">0:00:00</text><text class="terminal-3787747527-r3" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-3787747527-line-10)">
+</text><text class="terminal-3787747527-r1" x="0" y="288.4" textLength="646.6" clip-path="url(#terminal-3787747527-line-11)">Security&#160;advisory&#160;Markdown&#160;report&#160;saved&#160;to&#160;psirt.md&#160;✅</text><text class="terminal-3787747527-r3" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-3787747527-line-11)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/imgs/anta_psirt_test_SA117_mdreport_mdoutput_sa117md.svg
+++ b/docs/imgs/anta_psirt_test_SA117_mdreport_mdoutput_sa117md.svg
@@ -1,0 +1,111 @@
+<svg class="rich-terminal" viewBox="0 0 1482 342.79999999999995" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2919332270-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2919332270-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2919332270-r1 { fill: #68a0b3 }
+.terminal-2919332270-r2 { fill: #98a84b }
+.terminal-2919332270-r3 { fill: #c5c8c6 }
+.terminal-2919332270-r4 { fill: #4e707b }
+.terminal-2919332270-r5 { fill: #608ab1 }
+.terminal-2919332270-r6 { fill: #d0b344 }
+.terminal-2919332270-r7 { fill: #868887 }
+.terminal-2919332270-r8 { fill: #68a0b3;font-weight: bold }
+.terminal-2919332270-r9 { fill: #98729f }
+.terminal-2919332270-r10 { fill: #729c1f }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2919332270-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="291.79999999999995" />
+    </clipPath>
+    <clipPath id="terminal-2919332270-line-0">
+    <rect x="0" y="1.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-1">
+    <rect x="0" y="25.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-2">
+    <rect x="0" y="50.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-3">
+    <rect x="0" y="74.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-4">
+    <rect x="0" y="99.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-5">
+    <rect x="0" y="123.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-6">
+    <rect x="0" y="147.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-7">
+    <rect x="0" y="172.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-8">
+    <rect x="0" y="196.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-9">
+    <rect x="0" y="221.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2919332270-line-10">
+    <rect x="0" y="245.5" width="1464" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="340.8" rx="8"/><text class="terminal-2919332270-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">anta&#160;psirt&#160;--test&#160;SA117&#160;md-report&#160;--md-output&#160;sa117.md</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2919332270-clip-terminal)">
+
+    <g class="terminal-2919332270-matrix">
+    <text class="terminal-2919332270-r1" x="0" y="20" textLength="24.4" clip-path="url(#terminal-2919332270-line-0)">╭─</text><text class="terminal-2919332270-r1" x="24.4" y="20" textLength="256.2" clip-path="url(#terminal-2919332270-line-0)">─────────────────────</text><text class="terminal-2919332270-r2" x="292.8" y="20" textLength="97.6" clip-path="url(#terminal-2919332270-line-0)">Settings</text><text class="terminal-2919332270-r1" x="402.6" y="20" textLength="256.2" clip-path="url(#terminal-2919332270-line-0)">─────────────────────</text><text class="terminal-2919332270-r1" x="658.8" y="20" textLength="24.4" clip-path="url(#terminal-2919332270-line-0)">─╮</text><text class="terminal-2919332270-r3" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-2919332270-line-0)">
+</text><text class="terminal-2919332270-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-2919332270-line-1)">│</text><text class="terminal-2919332270-r1" x="24.4" y="44.4" textLength="634.4" clip-path="url(#terminal-2919332270-line-1)">-&#160;ANTA&#160;Inventory&#160;contains&#160;8&#160;devices&#160;(AsyncEOSDevice)</text><text class="terminal-2919332270-r1" x="671" y="44.4" textLength="12.2" clip-path="url(#terminal-2919332270-line-1)">│</text><text class="terminal-2919332270-r3" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-2919332270-line-1)">
+</text><text class="terminal-2919332270-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-2919332270-line-2)">│</text><text class="terminal-2919332270-r1" x="24.4" y="68.8" textLength="402.6" clip-path="url(#terminal-2919332270-line-2)">-&#160;Tests&#160;catalog&#160;contains&#160;35&#160;tests</text><text class="terminal-2919332270-r1" x="671" y="68.8" textLength="12.2" clip-path="url(#terminal-2919332270-line-2)">│</text><text class="terminal-2919332270-r3" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-2919332270-line-2)">
+</text><text class="terminal-2919332270-r1" x="0" y="93.2" textLength="683.2" clip-path="url(#terminal-2919332270-line-3)">╰──────────────────────────────────────────────────────╯</text><text class="terminal-2919332270-r3" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-2919332270-line-3)">
+</text><text class="terminal-2919332270-r3" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-2919332270-line-4)">
+</text><text class="terminal-2919332270-r4" x="0" y="142" textLength="231.8" clip-path="url(#terminal-2919332270-line-5)">[09/11/26&#160;10:46:16]</text><text class="terminal-2919332270-r5" x="244" y="142" textLength="97.6" clip-path="url(#terminal-2919332270-line-5)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r3" x="353.8" y="142" textLength="219.6" clip-path="url(#terminal-2919332270-line-5)">ANTA&#160;run&#160;starting&#160;</text><text class="terminal-2919332270-r6" x="573.4" y="142" textLength="36.6" clip-path="url(#terminal-2919332270-line-5)">...</text><text class="terminal-2919332270-r7" x="1293.2" y="142" textLength="122" clip-path="url(#terminal-2919332270-line-5)">_runner.py</text><text class="terminal-2919332270-r7" x="1415.2" y="142" textLength="12.2" clip-path="url(#terminal-2919332270-line-5)">:</text><text class="terminal-2919332270-r7" x="1427.4" y="142" textLength="36.6" clip-path="url(#terminal-2919332270-line-5)">261</text><text class="terminal-2919332270-r3" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-2919332270-line-5)">
+</text><text class="terminal-2919332270-r4" x="0" y="166.4" textLength="231.8" clip-path="url(#terminal-2919332270-line-6)">[09/11/26&#160;10:46:17]</text><text class="terminal-2919332270-r6" x="244" y="166.4" textLength="97.6" clip-path="url(#terminal-2919332270-line-6)">WARNING&#160;</text><text class="terminal-2919332270-r3" x="353.8" y="166.4" textLength="902.8" clip-path="url(#terminal-2919332270-line-6)">Security&#160;Advisory&#160;tests&#160;are&#160;in&#160;preview&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r7" x="1268.8" y="166.4" textLength="158.6" clip-path="url(#terminal-2919332270-line-6)">decorators.py</text><text class="terminal-2919332270-r7" x="1427.4" y="166.4" textLength="12.2" clip-path="url(#terminal-2919332270-line-6)">:</text><text class="terminal-2919332270-r7" x="1439.6" y="166.4" textLength="24.4" clip-path="url(#terminal-2919332270-line-6)">24</text><text class="terminal-2919332270-r3" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-2919332270-line-6)">
+</text><text class="terminal-2919332270-r5" x="244" y="190.8" textLength="97.6" clip-path="url(#terminal-2919332270-line-7)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r3" x="353.8" y="190.8" textLength="329.4" clip-path="url(#terminal-2919332270-line-7)">Initial&#160;inventory&#160;contains&#160;</text><text class="terminal-2919332270-r8" x="683.2" y="190.8" textLength="12.2" clip-path="url(#terminal-2919332270-line-7)">8</text><text class="terminal-2919332270-r3" x="695.4" y="190.8" textLength="585.6" clip-path="url(#terminal-2919332270-line-7)">&#160;devices&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r7" x="1293.2" y="190.8" textLength="122" clip-path="url(#terminal-2919332270-line-7)">_runner.py</text><text class="terminal-2919332270-r7" x="1415.2" y="190.8" textLength="12.2" clip-path="url(#terminal-2919332270-line-7)">:</text><text class="terminal-2919332270-r7" x="1427.4" y="190.8" textLength="36.6" clip-path="url(#terminal-2919332270-line-7)">452</text><text class="terminal-2919332270-r3" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-2919332270-line-7)">
+</text><text class="terminal-2919332270-r5" x="244" y="215.2" textLength="97.6" clip-path="url(#terminal-2919332270-line-8)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r8" x="353.8" y="215.2" textLength="12.2" clip-path="url(#terminal-2919332270-line-8)">8</text><text class="terminal-2919332270-r3" x="366" y="215.2" textLength="915" clip-path="url(#terminal-2919332270-line-8)">&#160;devices&#160;selected&#160;for&#160;testing&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r7" x="1293.2" y="215.2" textLength="122" clip-path="url(#terminal-2919332270-line-8)">_runner.py</text><text class="terminal-2919332270-r7" x="1415.2" y="215.2" textLength="12.2" clip-path="url(#terminal-2919332270-line-8)">:</text><text class="terminal-2919332270-r7" x="1427.4" y="215.2" textLength="36.6" clip-path="url(#terminal-2919332270-line-8)">462</text><text class="terminal-2919332270-r3" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-2919332270-line-8)">
+</text><text class="terminal-2919332270-r5" x="244" y="239.6" textLength="97.6" clip-path="url(#terminal-2919332270-line-9)">INFO&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r8" x="353.8" y="239.6" textLength="12.2" clip-path="url(#terminal-2919332270-line-9)">8</text><text class="terminal-2919332270-r3" x="366" y="239.6" textLength="915" clip-path="url(#terminal-2919332270-line-9)">&#160;total&#160;tests&#160;scheduled&#160;across&#160;all&#160;selected&#160;devices&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-2919332270-r7" x="1293.2" y="239.6" textLength="122" clip-path="url(#terminal-2919332270-line-9)">_runner.py</text><text class="terminal-2919332270-r7" x="1415.2" y="239.6" textLength="12.2" clip-path="url(#terminal-2919332270-line-9)">:</text><text class="terminal-2919332270-r7" x="1427.4" y="239.6" textLength="36.6" clip-path="url(#terminal-2919332270-line-9)">463</text><text class="terminal-2919332270-r3" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-2919332270-line-9)">
+</text><text class="terminal-2919332270-r3" x="24.4" y="264" textLength="12.2" clip-path="url(#terminal-2919332270-line-10)">•</text><text class="terminal-2919332270-r3" x="48.8" y="264" textLength="207.4" clip-path="url(#terminal-2919332270-line-10)">Running&#160;Tests&#160;...</text><text class="terminal-2919332270-r9" x="256.2" y="264" textLength="48.8" clip-path="url(#terminal-2919332270-line-10)">100%</text><text class="terminal-2919332270-r10" x="317.2" y="264" textLength="854" clip-path="url(#terminal-2919332270-line-10)">━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</text><text class="terminal-2919332270-r2" x="1183.4" y="264" textLength="36.6" clip-path="url(#terminal-2919332270-line-10)">8/8</text><text class="terminal-2919332270-r3" x="1232.2" y="264" textLength="12.2" clip-path="url(#terminal-2919332270-line-10)">•</text><text class="terminal-2919332270-r6" x="1256.6" y="264" textLength="85.4" clip-path="url(#terminal-2919332270-line-10)">0:00:00</text><text class="terminal-2919332270-r3" x="1354.2" y="264" textLength="12.2" clip-path="url(#terminal-2919332270-line-10)">•</text><text class="terminal-2919332270-r1" x="1378.6" y="264" textLength="85.4" clip-path="url(#terminal-2919332270-line-10)">0:00:00</text><text class="terminal-2919332270-r3" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-2919332270-line-10)">
+</text><text class="terminal-2919332270-r1" x="0" y="288.4" textLength="646.6" clip-path="url(#terminal-2919332270-line-11)">Security&#160;advisory&#160;Markdown&#160;report&#160;saved&#160;to&#160;sa117.md&#160;✅</text><text class="terminal-2919332270-r3" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-2919332270-line-11)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/scripts/generate_snippet.py
+++ b/docs/scripts/generate_snippet.py
@@ -116,13 +116,14 @@ def finalize_console_output(max_lines: int | None, omitted_results: int) -> None
         console.print(f"\n[dim]{format_omitted_results(omitted_results)}[/]")
 
 
-def custom_progress_bar() -> Progress:
+def custom_progress_bar(spinner_name: str = "anta") -> Progress:
     """Set the console of progress_bar to main anta console.
 
     Caveat: this capture all steps of the progress bar..
     Disabling refresh to only capture beginning and end
     """
-    progress = anta_progress_bar()
+    # The Pylint pre-commit environment resolves this helper from the latest release, which still has the legacy zero-argument signature.
+    progress = anta_progress_bar(spinner_name)  # pylint: disable=too-many-function-args
     progress.live.auto_refresh = False
     progress.live.console = console
     return progress

--- a/docs/security-advisory/lab.md
+++ b/docs/security-advisory/lab.md
@@ -24,7 +24,7 @@ setting up a local environment.
 The lab includes four cEOS-lab devices running EOS 4.33.0F and an ANTA
 release with `anta psirt` command support.
 
-![ANTA PSIRT lab topology](../imgs/anta-psirt.png){ loading=lazy width="713" }
+![ANTA PSIRT lab topology](../imgs/anta-psirt.png){ class="img_center" loading=lazy width="713" }
 
 The lab may cover only a limited number of security advisories available in the installed ANTA release and enabled by the lab configuration.
 The ANTA release installed in the lab may change over time without a notice. Please verify the lab before running a demo.
@@ -32,9 +32,9 @@ The ANTA release installed in the lab may change over time without a notice. Ple
 ## Launch the lab
 
 To get started, sign in at [labs.arista.com](https://labs.arista.com/) and
-confirm that you can access the service. Then launch the lab:
+confirm that you can access the service. Then launch the lab.
 
-[Start the ANTA PSIRT lab](https://labs.arista.com/launch?lab_type=anta-psirt&origin=tech-lib){ .md-button .md-button--primary target="_blank" rel="noopener" }
+[Start the ANTA PSIRT lab](https://labs.arista.com/launch?lab_type=anta-psirt&origin=tech-lib){ .md-button .md-button--primary .button_center target="_blank" rel="noopener" }
 
 Once the lab is ready, follow the walkthrough provided in the lab environment.
 

--- a/docs/security-advisory/tests-overview.md
+++ b/docs/security-advisory/tests-overview.md
@@ -22,6 +22,8 @@ page.
     To view the implementation details and inputs for each available test, see
     [Security Advisory Tests](tests.md).
 
+<div class="table_center"></div>
+
 | Security advisory | Last updated | Supported in ANTA version | Comment |
 | --- | --- | --- | --- |
 | Security Advisory 0182 | | N/A | VeloCloud; not covered by ANTA |

--- a/docs/security-advisory/usage.md
+++ b/docs/security-advisory/usage.md
@@ -31,21 +31,30 @@ behavior, and exit handling with [`anta nrfu`](../cli/nrfu.md).
 --8<-- "anta_psirt_help.txt"
 ```
 
-Provide an inventory and credentials as for NRFU and select a report format:
+Provide an inventory and credentials as for NRFU, either with command-line
+options or the shared ANTA environment variables. Then select a report format:
 
 ```bash
-anta psirt --inventory inventory.yml --username admin --prompt md-report --md-output sa-report.md
+anta psirt md-report --md-output psirt.md
 ```
+
+![anta psirt Markdown report](../imgs/anta_psirt_mdreport_mdoutput_psirtmd.svg){ class="img_center" loading=lazy width="1600" }
 
 By default, the command runs every test registered in the built-in
 `anta.tests.advisories` catalog.
+
+All security advisory tests share the same preview warning. ANTA logs
+`Security Advisory tests are in preview` once during a command invocation,
+regardless of how many advisory tests or devices are selected.
 
 Use `--test` to filter the built-in catalog and run only selected security
 advisories. Provide the advisory test class name:
 
 ```bash
-anta psirt --inventory inventory.yml --test SA117 md-report --md-output sa117-report.md
+anta psirt --test SA117 md-report --md-output sa117.md
 ```
+
+![anta psirt SA117 Markdown report](../imgs/anta_psirt_test_SA117_mdreport_mdoutput_sa117md.svg){ class="img_center" loading=lazy width="1600" }
 
 Repeat `--test` to assess multiple selected advisories.
 

--- a/docs/stylesheets/extra.zensical.css
+++ b/docs/stylesheets/extra.zensical.css
@@ -459,6 +459,16 @@
     margin-right: auto;
     border-radius: 1%;
   }
+  .md-typeset .md-button.button_center {
+    display: block;
+    width: fit-content;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .md-typeset .table_center + table {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 /* mkdocstrings css from official repo to indent sub-elements nicely */

--- a/tests/docs/test_generate_snippet.py
+++ b/tests/docs/test_generate_snippet.py
@@ -11,10 +11,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 from rich.console import Console
+from rich.progress import Progress
 
 from anta.result_manager import ResultManager
 from anta.result_manager.models import TestResult as AntaTestResult
 from docs.scripts.generate_snippet import (
+    custom_progress_bar,
     finalize_console_output,
     format_omitted_results,
     limit_result_manager,
@@ -95,3 +97,19 @@ def test_finalize_console_output(monkeypatch: pytest.MonkeyPatch) -> None:
     finalize_console_output(max_lines=2, omitted_results=2)
 
     assert test_console.export_text(clear=True) == "first\n\n... 1 line omitted ...\n\nthird\n\n... 2 results omitted ...\n"
+
+
+def test_custom_progress_bar_forwards_spinner_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify the capture progress bar preserves the command-specific spinner."""
+    progress = Progress()
+    requested_spinners = []
+
+    def progress_factory(spinner_name: str) -> Progress:
+        requested_spinners.append(spinner_name)
+        return progress
+
+    monkeypatch.setattr("docs.scripts.generate_snippet.anta_progress_bar", progress_factory)
+
+    assert custom_progress_bar("security") is progress
+    assert requested_spinners == ["security"]
+    assert progress.live.auto_refresh is False


### PR DESCRIPTION
## Description

Refresh the ANTA PSIRT documentation with current generic and SA117 lab-backed command captures. Document the single preview warning, preserve the PSIRT-specific progress spinner in generated snapshots, and center the security-advisory lab controls and tests-overview table.

The generated Markdown report side effects are intentionally excluded; only the terminal output SVGs are committed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have run targeted pre-commit checks for code linting and typing
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`tox -e testenv`) — full tox was not run; 11 targeted snippet-generator tests and the strict Zensical build pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved alignment for images, launch buttons, and support tables on security advisory pages.
  - Updated usage examples with shared environment variables and report-specific Markdown output.
  - Added default and filtered report screenshots, preview warning guidance, and an SA117 filtering example.
  - Added responsive styling for centered buttons and tables.

- **Enhancements**
  - Progress bar examples can optionally specify a spinner name while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->